### PR TITLE
fix(herdr): address review findings

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ Agent discovery follows priority: **project-local** (`.pi/agents/`) > **global**
 
 ```
 1. Agent calls subagent()          → returns immediately ("started")
-2. Sub-agent runs in mux pane      → widget shows live status
+2. Sub-agent runs in herdr pane    → widget shows live status
 3. User keeps chatting             → main session fully interactive
 4. Sub-agent finishes              → result steered back as a normal completion/failure
 5. Main agent processes result     → continues with new context

--- a/pi-extension/subagents/herdr.ts
+++ b/pi-extension/subagents/herdr.ts
@@ -137,16 +137,15 @@ export function createHerdrSurface(name: string): string {
 
 export function createHerdrSurfaceSplit(
   name: string,
-  direction: "left" | "right" | "up" | "down",
+  direction: "right" | "down",
 ): string {
   const parentPaneId = getHerdrParentPaneId();
-  const dir = direction === "left" || direction === "right" ? "right" : "down";
   const output = herdrExec([
     "pane",
     "split",
     parentPaneId,
     "--direction",
-    dir,
+    direction,
     "--no-focus",
     "--cwd",
     process.cwd(),
@@ -161,9 +160,8 @@ export function createHerdrSurfaceSplit(
 }
 
 export function readHerdrScreen(surface: string, lines = 50): string {
-  // `visible` is the current viewport — reliable for freshly-created panes
-  // where `recent` scrollback may not be populated yet. Matches what tmux
-  // capture-pane and zellij dump-screen return.
+  // `visible` is reliable for freshly created panes where herdr's `recent`
+  // scrollback may not be populated yet.
   return herdrExec(["pane", "read", surface, "--source", "visible", "--lines", String(lines)]);
 }
 

--- a/pi-extension/subagents/index.ts
+++ b/pi-extension/subagents/index.ts
@@ -924,7 +924,7 @@ function startWidgetRefresh() {
 }
 
 /**
- * Launch a subagent: creates the multiplexer pane, builds the command, and
+ * Launch a subagent: creates the herdr pane, builds the command, and
  * sends it. Returns a RunningSubagent — does NOT poll.
  *
  * Call watchSubagent() on the returned object to observe completion.
@@ -1399,14 +1399,14 @@ export default function subagentsExtension(pi: ExtensionAPI) {
       name: "subagent",
       label: "Subagent",
       description:
-        "Spawn a sub-agent in a dedicated terminal multiplexer pane. " +
+        "Spawn a sub-agent in a dedicated terminal herdr pane. " +
         "This is a fire-and-forget async tool: the call returns immediately with only an acknowledgement. " +
         "When the sub-agent finishes, the harness AUTOMATICALLY delivers its result as a steer message that wakes you up and starts a new turn — you do not need to do anything to receive it. " +
         "DO NOT write polling loops, sleep/wait commands, tail/watch scripts, or repeatedly read session/log files to detect completion. DO NOT call subagents_list or any other tool to 'check' status. All of that is wasted work — the harness handles delivery for you. " +
         "DO NOT fabricate, assume, or summarize results after calling this tool. " +
         "After spawning, either end your turn immediately, or work on other independent tasks (including spawning more subagents in parallel). The harness will wake you with the result when it is ready.",
       promptSnippet:
-        "Spawn a sub-agent in a dedicated terminal multiplexer pane. " +
+        "Spawn a sub-agent in a dedicated terminal herdr pane. " +
         "This is a fire-and-forget async tool: the call returns immediately with only an acknowledgement. " +
         "When the sub-agent finishes, the harness AUTOMATICALLY delivers its result as a steer message that wakes you up and starts a new turn — you do not need to do anything to receive it. " +
         "DO NOT write polling loops, sleep/wait commands, tail/watch scripts, or repeatedly read session/log files to detect completion. DO NOT call subagents_list or any other tool to 'check' status. All of that is wasted work — the harness handles delivery for you. " +
@@ -1711,14 +1711,14 @@ export default function subagentsExtension(pi: ExtensionAPI) {
       name: "subagent_resume",
       label: "Resume Subagent",
       description:
-        "Resume a previous sub-agent session in a new multiplexer pane. " +
+        "Resume a previous sub-agent session in a new herdr pane. " +
         "This is a fire-and-forget async tool: the call returns immediately with only an acknowledgement. " +
         "When the resumed sub-agent finishes, the harness AUTOMATICALLY delivers its result as a steer message that wakes you up and starts a new turn — you do not need to do anything to receive it. " +
         "DO NOT write polling loops, sleep/wait commands, tail/watch scripts, or repeatedly read session/log files to detect completion. DO NOT poll for status. All of that is wasted work — the harness handles delivery for you. " +
         "DO NOT fabricate or assume results. After resuming, either end your turn or work on other independent tasks; the harness will wake you when the result is ready. " +
         "Use when a sub-agent was cancelled or needs follow-up work.",
       promptSnippet:
-        "Resume a previous sub-agent session in a new multiplexer pane. " +
+        "Resume a previous sub-agent session in a new herdr pane. " +
         "This is a fire-and-forget async tool: the call returns immediately with only an acknowledgement. " +
         "When the resumed sub-agent finishes, the harness AUTOMATICALLY delivers its result as a steer message that wakes you up and starts a new turn — you do not need to do anything to receive it. " +
         "DO NOT write polling loops, sleep/wait commands, tail/watch scripts, or repeatedly read session/log files to detect completion. DO NOT poll for status. All of that is wasted work — the harness handles delivery for you. " +

--- a/pi-extension/subagents/plan-skill.md
+++ b/pi-extension/subagents/plan-skill.md
@@ -111,7 +111,7 @@ During the session, the planner can spawn:
 - **`scout`** — when a design decision depends on existing code it hasn't read
 - **`researcher`** — when a decision depends on external facts (library tradeoffs, best practices, API behaviors)
 
-These are internal to the planning session. You'll see them in the multiplexer but don't need to intervene.
+These are internal to the planning session. You'll see them in herdr but don't need to intervene.
 
 ### Optional: extra scout after planning
 

--- a/pi-extension/subagents/terminal.ts
+++ b/pi-extension/subagents/terminal.ts
@@ -15,7 +15,7 @@ import {
 } from "./herdr.ts";
 
 export type PaneId = string;
-export type SplitDirection = "left" | "right" | "up" | "down";
+export type SplitDirection = "right" | "down";
 
 const SETUP_HINT = "Start pi inside herdr (`herdr`, then run `pi`).";
 

--- a/test/integration/harness.ts
+++ b/test/integration/harness.ts
@@ -4,7 +4,7 @@
  * Provides utilities to:
  * - Detect whether herdr is available
  * - Create isolated test environments with test agent definitions
- * - Start real pi sessions in mux surfaces
+ * - Start real pi sessions in herdr panes
  * - Poll for file creation and screen output
  * - Clean up surfaces and temp files after tests
  */
@@ -25,7 +25,6 @@ import { tmpdir } from "node:os";
 import {
   isTerminalAvailable,
   createSubagentPane,
-  splitCurrentPane,
   runInPane,
   runScriptInPane,
   readPane,
@@ -40,7 +39,6 @@ type MuxBackend = "herdr";
 // Re-export mux primitives for tests
 export {
   createSubagentPane,
-  splitCurrentPane,
   runInPane,
   runScriptInPane,
   readPane,
@@ -191,17 +189,6 @@ export function createTrackedSurface(env: TestEnv, name: string): string {
   return surface;
 }
 
-export function createTrackedSurfaceSplit(
-  env: TestEnv,
-  name: string,
-  direction: "left" | "right" | "up" | "down",
-  fromSurface?: string,
-): string {
-  const surface = splitCurrentPane(name, direction, fromSurface);
-  env.surfaces.push(surface);
-  return surface;
-}
-
 /**
  * Remove a surface from tracking (after manual close).
  */
@@ -212,7 +199,7 @@ export function untrackSurface(env: TestEnv, surface: string): void {
 // ── Pi session management ──
 
 /**
- * Start a pi session in a mux surface with the subagents extension loaded.
+ * Start a pi session in a herdr pane with the subagents extension loaded.
  * Returns immediately — the pi process runs asynchronously in the surface.
  *
  * The command ends with a sentinel so we can detect when pi exits:

--- a/test/integration/mux-surface.test.ts
+++ b/test/integration/mux-surface.test.ts
@@ -1,14 +1,11 @@
 /**
- * Integration tests for the multiplexer surface layer.
+ * Integration tests for herdr terminal operations.
  *
- * These tests exercise real mux operations: creating panes,
- * sending commands, reading screen output, and closing surfaces.
+ * These tests exercise real herdr operations: creating panes,
+ * sending commands, reading output, preserving focus, and closing panes.
  * No LLM calls — fast and free.
  *
- * Run inside a supported multiplexer:
- *   herdr  # then run: npm run test:integration
- *   tmux new 'npm run test:integration'
- *   zellij --session pi  # then run: npm run test:integration
+ * Run `npm run test:integration` from inside herdr.
  */
 import { describe, it, before, after } from "node:test";
 import assert from "node:assert/strict";
@@ -20,11 +17,7 @@ import {
   createTestEnv,
   cleanupTestEnv,
   createTrackedSurface,
-  createTrackedSurfaceSplit,
-  focusSurface,
   getFocusedSurface,
-  getSurfacePane,
-  waitForFocusedSurface,
   untrackSurface,
   runInPane,
   runScriptInPane,
@@ -44,12 +37,12 @@ const backends = getAvailableBackends();
 const FOCUS_TEST_SHELL_READY_DELAY_MS = Number(process.env.PI_SUBAGENT_SHELL_READY_DELAY_MS ?? "2500");
 
 if (backends.length === 0) {
-  console.log("⚠️  No mux backend available — skipping mux-surface integration tests");
+  console.log("⚠️  herdr is unavailable — skipping terminal integration tests");
   console.log("   Run inside herdr to enable these tests.");
 }
 
 for (const backend of backends) {
-  describe(`mux-surface [${backend}]`, { timeout: 60_000 }, () => {
+  describe(`herdr terminal [${backend}]`, { timeout: 60_000 }, () => {
     let prevMux: string | undefined;
     let env: TestEnv;
 
@@ -63,34 +56,17 @@ for (const backend of backends) {
       restoreBackend(prevMux);
     });
 
-    it("keeps focus on the active surface while creating and targeting subagent surfaces", async () => {
-      // herdr and wezterm don't expose absolute pane focusing via CLI —
-      // herdr only has directional focus, wezterm has no focus helpers at all.
-      // The --no-focus behavior these backends use for surface creation is
-      // already covered by the other mux-surface tests.
-      if (backend === "herdr" || backend === "wezterm") return;
-
-      const anchor = createTrackedSurfaceSplit(env, "focus-anchor", "right");
-      await sleep(1000);
-
-      focusSurface(backend, anchor);
-      await waitForFocusedSurface(backend, anchor, 10_000);
+    it("keeps focus on the current pane while creating and targeting subagent tabs", async () => {
+      const focusedPane = getFocusedSurface(backend);
+      assert.ok(focusedPane, "Expected herdr to report the currently focused pane");
 
       const childA = createTrackedSurface(env, "focus-child-a");
       await sleep(FOCUS_TEST_SHELL_READY_DELAY_MS);
-      assert.equal(getFocusedSurface(backend), anchor);
+      assert.equal(getFocusedSurface(backend), focusedPane);
 
       const childB = createTrackedSurface(env, "focus-child-b");
       await sleep(FOCUS_TEST_SHELL_READY_DELAY_MS);
-      assert.equal(getFocusedSurface(backend), anchor);
-
-      if (false) {
-        const paneA = getSurfacePane(backend, childA);
-        const paneB = getSurfacePane(backend, childB);
-        assert.ok(paneA, `Expected pane ref for ${childA}`);
-        assert.ok(paneB, `Expected pane ref for ${childB}`);
-        assert.equal(paneB, paneA);
-      }
+      assert.equal(getFocusedSurface(backend), focusedPane);
 
       const markerA = uniqueId();
       const markerB = uniqueId();
@@ -101,7 +77,7 @@ for (const backend of backends) {
         waitForScreen(childA, new RegExp(`FOCUS_A_${markerA}`), 20_000, 50),
         waitForScreen(childB, new RegExp(`FOCUS_B_${markerB}`), 20_000, 50),
       ]);
-      assert.equal(getFocusedSurface(backend), anchor);
+      assert.equal(getFocusedSurface(backend), focusedPane);
     });
 
     it("creates a surface, sends a command, reads output, and closes it", async () => {

--- a/test/integration/subagent-lifecycle.test.ts
+++ b/test/integration/subagent-lifecycle.test.ts
@@ -1,16 +1,13 @@
 /**
  * Integration tests for the full subagent lifecycle.
  *
- * These tests spawn REAL pi sessions with REAL LLM calls (haiku by default).
- * Each test creates a mux surface, runs pi with a task that uses the subagent
- * tool, and verifies the outcome via marker files and screen output.
+ * These tests spawn real pi sessions with real LLM calls.
+ * Each test creates a herdr pane, runs pi with a task that uses the subagent
+ * tool, and verifies the outcome through marker files and terminal output.
  *
- * Costs: ~$0.01-0.05 per test run (haiku).
- * Duration: ~30-90s per test.
+ * Duration: ~30-120s per test, depending on the selected model.
  *
- * Run inside a supported multiplexer:
- *   herdr  # then run: npm run test:integration
- *   tmux new 'npm run test:integration'
+ * Run `npm run test:integration` from inside herdr.
  *
  * Configuration:
  *   PI_TEST_MODEL     — model for all pi sessions (default: openrouter/free)
@@ -40,7 +37,7 @@ import {
 const backends = getAvailableBackends();
 
 if (backends.length === 0) {
-  console.log("⚠️  No mux backend available — skipping subagent lifecycle integration tests");
+  console.log("⚠️  herdr is unavailable — skipping subagent lifecycle integration tests");
   console.log("   Run inside herdr to enable these tests.");
 }
 

--- a/test/test.ts
+++ b/test/test.ts
@@ -1,6 +1,6 @@
 import { describe, it, before, after } from "node:test";
 import assert from "node:assert/strict";
-import { mkdtempSync, writeFileSync, readFileSync, mkdirSync, rmSync } from "node:fs";
+import { existsSync, mkdtempSync, writeFileSync, readFileSync, mkdirSync, rmSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { fileURLToPath } from "node:url";
@@ -42,7 +42,7 @@ import {
   shouldAutoExitOnAgentEnd,
   findLatestAssistantError,
 } from "../pi-extension/subagents/subagent-done.ts";
-import { interpretExitSidecar } from "../pi-extension/subagents/completion.ts";
+import { interpretExitSidecar, waitForCompletion } from "../pi-extension/subagents/completion.ts";
 
 // --- Helpers ---
 
@@ -1282,7 +1282,7 @@ describe("subagent-done.ts", () => {
   });
 });
 
-describe("completion.ts interpretExitSidecar", () => {
+describe("completion.ts", () => {
 
   it("decodes ping payloads", () => {
     assert.deepEqual(
@@ -1328,7 +1328,83 @@ describe("completion.ts interpretExitSidecar", () => {
     assert.deepEqual(interpretExitSidecar({}), { reason: "done", exitCode: 0 });
     assert.deepEqual(interpretExitSidecar(null), { reason: "done", exitCode: 0 });
   });
+
+  it("consumes a sidecar and removes it", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "completion-sidecar-"));
+    const sessionFile = join(dir, "session.jsonl");
+    const exitFile = `${sessionFile}.exit`;
+    writeFileSync(exitFile, JSON.stringify({ type: "ping", name: "Scout", message: "ready" }));
+    try {
+      const result = await waitForCompletion(new AbortController().signal, {
+        intervalMs: 1,
+        sessionFile,
+        readTerminalTail: async () => "",
+      });
+      assert.deepEqual(result, {
+        reason: "ping",
+        exitCode: 0,
+        ping: { name: "Scout", message: "ready" },
+      });
+      assert.equal(existsSync(exitFile), false);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("returns the terminal sentinel exit code", async () => {
+    const result = await waitForCompletion(new AbortController().signal, {
+      intervalMs: 1,
+      readTerminalTail: async () => "output\n__SUBAGENT_DONE_17__\n",
+    });
+    assert.deepEqual(result, { reason: "sentinel", exitCode: 17 });
+  });
+
+  it("returns when an external sentinel file appears", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "completion-sentinel-"));
+    const sentinelFile = join(dir, "done");
+    writeFileSync(sentinelFile, "complete");
+    try {
+      const result = await waitForCompletion(new AbortController().signal, {
+        intervalMs: 1,
+        sentinelFile,
+        readTerminalTail: async () => "",
+      });
+      assert.deepEqual(result, { reason: "sentinel", exitCode: 0 });
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("retries transient terminal read failures and reports ticks", async () => {
+    let reads = 0;
+    let ticks = 0;
+    const result = await waitForCompletion(new AbortController().signal, {
+      intervalMs: 1,
+      readTerminalTail: async () => {
+        reads += 1;
+        if (reads === 1) throw new Error("pane temporarily unavailable");
+        return "__SUBAGENT_DONE_0__";
+      },
+      onTick: () => {
+        ticks += 1;
+      },
+    });
+    assert.deepEqual(result, { reason: "sentinel", exitCode: 0 });
+    assert.equal(reads, 2);
+    assert.equal(ticks, 1);
+  });
+
+  it("rejects promptly when aborted", async () => {
+    const controller = new AbortController();
+    const completion = waitForCompletion(controller.signal, {
+      intervalMs: 10_000,
+      readTerminalTail: async () => "",
+    });
+    controller.abort();
+    await assert.rejects(completion, /Aborted while waiting for subagent to finish/);
+  });
 });
+
 describe("commands", () => {
   it("/iterate always emits a full-context fork tool call", () => {
     const { api, registeredCommands, sentUserMessages } = createMockExtensionApi();


### PR DESCRIPTION
## Summary

- replace the no-op herdr focus test with a real focus-preservation assertion
- narrow pane split directions to the values herdr actually supports
- remove the ignored source-pane argument from the integration harness
- add direct completion polling coverage for sidecars, sentinels, transient failures, and aborts
- remove stale multi-backend terminology from documentation and tests

## Verification

- `npm test` — 110 tests passed
- `PI_TEST_MODEL=\"deepseek/deepseek-v4-flash\" npm run test:integration` — 15 tests passed
- `npm audit` — 0 vulnerabilities
- `git diff --check`