### PR TITLE
fix(herdr): keep subagent tabs in current workspace

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pi-herdr-subagents",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pi-herdr-subagents",
-      "version": "0.1.2",
+      "version": "0.1.3",
       "license": "MIT",
       "devDependencies": {
         "@earendil-works/pi-coding-agent": "^0.80.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-herdr-subagents",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Interactive subagents for pi running in herdr",
   "keywords": [
     "pi-package"

--- a/pi-extension/subagents/herdr.ts
+++ b/pi-extension/subagents/herdr.ts
@@ -114,18 +114,26 @@ function getHerdrCurrentPaneInfo(): {
   return { pane_id: paneId, tab_id: tabId, workspace_id: workspaceId };
 }
 
-export function createHerdrSurface(name: string): string {
-  // Create a new tab per subagent so parallel spawns each get a full tab
-  // instead of ever-narrower splits of the parent pane.
-  const output = herdrExec([
+function buildTabCreateArgs(name: string, cwd: string, workspaceId: string): string[] {
+  return [
     "tab",
     "create",
+    "--workspace",
+    workspaceId,
     "--label",
     name,
     "--cwd",
-    process.cwd(),
+    cwd,
     "--no-focus",
-  ]);
+  ];
+}
+
+export function createHerdrSurface(name: string): string {
+  // Create a new tab per subagent so parallel spawns each get a full tab
+  // instead of ever-narrower splits of the parent pane. Target the current
+  // workspace explicitly because Herdr's implicit default may be another space.
+  const { workspace_id: workspaceId } = getHerdrCurrentPaneInfo();
+  const output = herdrExec(buildTabCreateArgs(name, process.cwd(), workspaceId));
   const paneId = extractHerdrRootPaneId(output, "tab create");
   try {
     herdrExec(["pane", "rename", paneId, name]);
@@ -260,6 +268,7 @@ export function renameHerdrWorkspace(title: string): void {
 }
 
 export const __herdrTest__ = {
+  buildTabCreateArgs,
   parseHerdrJson,
   extractHerdrPaneId,
   extractHerdrRootPaneId,

--- a/test/test.ts
+++ b/test/test.ts
@@ -2752,6 +2752,22 @@ describe("herdr.ts", () => {
     });
   });
 
+  describe("herdr command construction", () => {
+    it("targets the current workspace when creating a subagent tab", () => {
+      assert.deepEqual(__herdrTest__.buildTabCreateArgs("reviewer", "/repo", "workspace-2"), [
+        "tab",
+        "create",
+        "--workspace",
+        "workspace-2",
+        "--label",
+        "reviewer",
+        "--cwd",
+        "/repo",
+        "--no-focus",
+      ]);
+    });
+  });
+
   describe("herdr response parsing", () => {
     it("extracts pane id from a pane split response", () => {
       const output = JSON.stringify({


### PR DESCRIPTION
## Summary

- explicitly target the parent Herdr workspace when creating subagent tabs
- add regression coverage for workspace-aware tab creation
- bump the package version to 0.1.3

## Testing

- `npm test`
- `npm run lint`