### PR TITLE
ci(release): automate package version releases

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,26 +1,68 @@
-name: Publish to npm
+name: Release
 
 on:
   push:
-    tags:
-      - "v*"
+    branches:
+      - main
+    paths:
+      - package.json
+  workflow_dispatch:
 
 permissions:
-  contents: read
+  contents: write
   id-token: write
 
 concurrency:
-  group: npm-publish-${{ github.ref }}
+  group: pi-herdr-subagents-release
   cancel-in-progress: false
 
 jobs:
-  publish:
-    name: Test and publish
+  detect:
+    name: Detect version bump
+    runs-on: ubuntu-latest
+    outputs:
+      release: ${{ steps.version.outputs.release }}
+      version: ${{ steps.version.outputs.version }}
+      tag: ${{ steps.version.outputs.tag }}
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Detect package version bump
+        id: version
+        shell: bash
+        env:
+          BEFORE_SHA: ${{ github.event.before }}
+        run: |
+          version="$(node --input-type=module -e "import pkg from './package.json' with { type: 'json' }; process.stdout.write(pkg.version)")"
+          release=true
+
+          if [[ "${GITHUB_EVENT_NAME}" == "push" ]]; then
+            previous_version="$(git show "${BEFORE_SHA}:package.json" | node --input-type=module -e "let input=''; process.stdin.on('data', chunk => input += chunk); process.stdin.on('end', () => process.stdout.write(JSON.parse(input).version));")"
+            if [[ "$version" == "$previous_version" ]]; then
+              release=false
+              echo "package.json changed without a version bump; no release is needed."
+            fi
+          fi
+
+          echo "release=$release" >> "$GITHUB_OUTPUT"
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+          echo "tag=v$version" >> "$GITHUB_OUTPUT"
+
+  release:
+    name: Tag, publish, and create GitHub release
+    needs: detect
+    if: needs.detect.outputs.release == 'true'
     runs-on: ubuntu-latest
 
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Set up Node.js
         uses: actions/setup-node@v4
@@ -29,27 +71,76 @@ jobs:
           registry-url: https://registry.npmjs.org
           cache: npm
 
+      - name: Verify package version is unpublished
+        id: npm
+        shell: bash
+        env:
+          VERSION: ${{ needs.detect.outputs.version }}
+        run: |
+          if npm view "pi-herdr-subagents@${VERSION}" version >/dev/null 2>&1; then
+            echo "published=true" >> "$GITHUB_OUTPUT"
+            echo "pi-herdr-subagents@${VERSION} is already published; npm publish will be skipped."
+          else
+            echo "published=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Install dependencies
         run: npm ci
+
+      - name: Run lint
+        run: npm run lint
 
       - name: Run tests
         run: npm test
 
-      - name: Verify tag matches package version
-        shell: bash
-        run: |
-          package_version="$(node --input-type=module -e "import pkg from './package.json' with { type: 'json' }; process.stdout.write(pkg.version)")"
-          tag_version="${GITHUB_REF_NAME#v}"
-
-          if [[ "$package_version" != "$tag_version" ]]; then
-            echo "Tag version ($tag_version) does not match package.json ($package_version)."
-            exit 1
-          fi
-
       - name: Verify package contents
         run: npm pack --dry-run
 
-      - name: Publish package
+      - name: Create and push tag
+        shell: bash
+        env:
+          TAG: ${{ needs.detect.outputs.tag }}
+        run: |
+          if git rev-parse "$TAG" >/dev/null 2>&1; then
+            tagged_sha="$(git rev-list -n 1 "$TAG")"
+            if [[ "$tagged_sha" != "$GITHUB_SHA" ]]; then
+              echo "$TAG already points to $tagged_sha instead of $GITHUB_SHA."
+              exit 1
+            fi
+            echo "$TAG already exists on this commit."
+          else
+            git config user.name "github-actions[bot]"
+            git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+            git tag -a "$TAG" -m "Release $TAG"
+            git push origin "$TAG"
+          fi
+
+      - name: Publish package to npm
+        if: steps.npm.outputs.published != 'true'
         run: npm publish --access public --provenance
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Create GitHub release
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ needs.detect.outputs.tag }}
+          VERSION: ${{ needs.detect.outputs.version }}
+        run: |
+          if gh release view "$TAG" >/dev/null 2>&1; then
+            echo "GitHub release $TAG already exists."
+          else
+            gh release create "$TAG" \
+              --verify-tag \
+              --title "$TAG" \
+              --generate-notes \
+              --notes "Published package: [pi-herdr-subagents@${VERSION}](https://www.npmjs.com/package/pi-herdr-subagents/v/${VERSION})"
+          fi
+
+      - name: Release summary
+        env:
+          TAG: ${{ needs.detect.outputs.tag }}
+          VERSION: ${{ needs.detect.outputs.version }}
+        run: |
+          echo "Released [$TAG](https://github.com/${GITHUB_REPOSITORY}/releases/tag/${TAG}) and [pi-herdr-subagents@${VERSION}](https://www.npmjs.com/package/pi-herdr-subagents/v/${VERSION})." >> "$GITHUB_STEP_SUMMARY"

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ pi install npm:pi-herdr-subagents
 
 This project does not install or load `HazAT/pi-interactive-subagents` automatically.
 
-For maintainers publishing a release to npm, see [RELEASING.md](RELEASING.md).
+Changing the `package.json` version on `main` automatically creates a matching Git tag and GitHub Release, generates release notes, and publishes the package to npm. For authentication, versioning, verification, and troubleshooting, see [RELEASING.md](RELEASING.md).
 
 Start herdr, then run pi inside it:
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,6 +1,8 @@
 # Release guide
 
-GitHub Actions publishes this package to npm when you push a tag named `vX.Y.Z`. The tag version must match the version in `package.json`.
+GitHub Actions publishes this package when the version in `package.json` changes on `main`. The release workflow validates the package, creates a matching `vX.Y.Z` tag, publishes to npm with provenance, and creates a GitHub Release with generated notes and a link to the npm package.
+
+The published version must be unique on npm.
 
 ## Prerequisites
 
@@ -14,6 +16,7 @@ Run the checks before starting:
 
 ```bash
 npm ci
+npm run lint
 npm test
 npm pack --dry-run
 ```
@@ -30,7 +33,7 @@ npm pack --dry-run
 
 Never store the token in the repository, `package.json`, or a committed `.npmrc` file.
 
-If the package does not exist on npm yet and the workflow cannot create it with the token, publish the first version locally with `npm login` and `npm publish --access public`. Keep the tag-driven workflow for later releases.
+If the package does not exist on npm yet and the workflow cannot create it with the token, publish the first version locally with `npm login` and `npm publish --access public`. Keep the version-driven workflow for later releases.
 
 ## Publish a release
 
@@ -40,33 +43,18 @@ Choose the semantic version increment:
 - `minor`: compatible features, such as `0.1.0` to `0.2.0`
 - `major`: breaking changes, such as `0.1.0` to `1.0.0`
 
-Create the version commit and tag:
-
-```bash
-npm version patch --sign-git-tag-version
-```
-
-Replace `patch` with `minor` or `major` when appropriate. If you do not sign Git tags, use:
+Create the version commit without a local tag:
 
 ```bash
 npm version patch --no-git-tag-version
-```
-
-In that case, create the tag separately after committing the version change:
-
-```bash
 git add package.json package-lock.json
-git commit -m "chore: release vX.Y.Z"
-git tag vX.Y.Z
+git commit -m "chore: release v$(node -p \"require('./package.json').version\")"
+git push origin main
 ```
 
-Push the release commit and tag:
+Replace `patch` with `minor` or `major` when appropriate. The push triggers the **Release** workflow, which installs dependencies, runs lint and tests, previews package contents, creates and pushes the version tag, publishes to npm with provenance, and creates the GitHub Release.
 
-```bash
-git push origin main --follow-tags
-```
-
-Watch the **Publish to npm** workflow on the repository's **Actions** page. The workflow installs dependencies, runs tests, checks the tag against `package.json`, previews the package contents, and publishes to npm with provenance.
+You can rerun a failed or incomplete release from **Actions → Release → Run workflow**. The workflow safely skips an npm version, tag, or GitHub Release that already exists, while verifying that an existing tag points to the release commit.
 
 ## Verify the release
 
@@ -86,9 +74,9 @@ The package should appear at <https://pi.dev/packages/pi-herdr-subagents> after 
 
 ## Troubleshooting
 
-### Tag and package versions differ
+### Tag points to another commit
 
-The workflow stops when, for example, tag `v0.1.1` points to a commit whose `package.json` still contains `0.1.0`. Create a new matching version and tag. Do not reuse a published npm version.
+The workflow stops if the matching version tag already points to a different commit. Do not move or reuse release tags. Increment the package version and push a new release commit instead.
 
 ### npm rejects authentication
 
@@ -96,7 +84,7 @@ Confirm that the GitHub secret is named exactly `NPM_TOKEN`, the token has write
 
 ### npm reports that the version already exists
 
-npm versions are immutable. Increment the package version, create a new tag, and run the release again.
+npm versions are immutable. Increment the package version and push a new release commit.
 
 ### The package is absent from pi.dev
 

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "type": "module",
   "scripts": {
     "lint": "oxlint pi-extension test",
-    "test": "node --test test/test.ts test/runtime-routing.test.ts",
+    "test": "node --test test/test.ts test/runtime-routing.test.ts test/release-workflow.test.ts",
     "test:integration": "node --test --test-concurrency=1 test/integration/*.test.ts"
   },
   "peerDependencies": {

--- a/test/release-workflow.test.ts
+++ b/test/release-workflow.test.ts
@@ -1,0 +1,17 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+
+test("release workflow reacts to package version changes and creates all release artifacts", async () => {
+  const workflow = await readFile(".github/workflows/publish.yml", "utf8");
+
+  assert.match(workflow, /branches:\n\s+- main/);
+  assert.match(workflow, /paths:\n\s+- package\.json/);
+  assert.match(workflow, /npm run lint/);
+  assert.match(workflow, /npm test/);
+  assert.match(workflow, /git tag -a "\$TAG"/);
+  assert.match(workflow, /npm publish --access public --provenance/);
+  assert.match(workflow, /gh release create "\$TAG"/);
+  assert.match(workflow, /--generate-notes/);
+  assert.match(workflow, /npmjs\.com\/package\/pi-herdr-subagents\/v\/\$\{VERSION\}/);
+});


### PR DESCRIPTION
## Summary

- trigger releases when the `package.json` version changes on `main`
- validate, tag, publish to npm with provenance, and create a GitHub Release with generated notes
- link each GitHub Release to the exact `pi-herdr-subagents` npm version
- document and test the version-driven release process

## Validation

- `npm run lint`
- `npm test` — 165 tests passed
- `npm pack --dry-run`
- `npx --yes yaml-lint .github/workflows/publish.yml`
- `git diff --check`