### PR TITLE
feat(subagents): preserve parent names and configure models

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,15 +90,15 @@ Subagent tabs and panes are created without stealing keyboard focus. Launch comm
 
 ### Bundled Agents
 
-| Agent             | Default runtime | Role                                                                                     |
-| ----------------- | --------------- | ---------------------------------------------------------------------------------------- |
-| **planner**       | Inherit parent  | Brainstorming — clarifies requirements, explores approaches, writes plans, creates todos |
-| **scout**         | Inherit parent  | Fast codebase reconnaissance — maps files, patterns, conventions                         |
-| **worker**        | Inherit parent  | Implements tasks from todos — writes code, runs tests, makes polished commits            |
-| **reviewer**      | Inherit parent  | Reviews code for bugs, security issues, correctness                                      |
-| **visual-tester** | Inherit parent  | Visual QA via Chrome CDP — screenshots, responsive testing, interaction testing          |
+| Agent             | Default runtime       | Role                                                                                     |
+| ----------------- | --------------------- | ---------------------------------------------------------------------------------------- |
+| **planner**       | Config, then parent   | Brainstorming — clarifies requirements, explores approaches, writes plans, creates todos |
+| **scout**         | Config, then parent   | Fast codebase reconnaissance — maps files, patterns, conventions                         |
+| **worker**        | Config, then parent   | Implements tasks from todos — writes code, runs tests, makes polished commits            |
+| **reviewer**      | Config, then parent   | Reviews code for bugs, security issues, correctness                                      |
+| **visual-tester** | Config, then parent   | Visual QA via Chrome CDP — screenshots, responsive testing, interaction testing          |
 
-Bundled agents inherit the parent model and thinking level. The orchestrating agent can override either field for a specific task using an exact authenticated model ID and a supported Pi thinking level. Prefer changing thinking before changing models.
+Bundled agents use model defaults from `config.json` when configured; otherwise they inherit the parent model. Thinking defaults still come from agent frontmatter or the parent level. The orchestrating agent can override either field for a specific task using an exact authenticated model ID and a supported Pi thinking level. Prefer changing thinking before changing models.
 
 Agent discovery follows priority: **project-local** (`.pi/agents/`) > **global** (`~/.pi/agent/agents/`) > **package-bundled**. Override any bundled agent by placing your own version in the higher-priority location.
 
@@ -170,10 +170,20 @@ cp config.json.example config.json
     "enabled": true
   },
   "models": {
-    "default": "anthropic/claude-sonnet-4-6",
+    "agents": {}
+  }
+}
+```
+
+The copyable example is model-neutral, so it works without requiring credentials for a specific provider. To configure models, replace the empty section with exact IDs from your authenticated model catalog:
+
+```json
+{
+  "models": {
+    "default": "your-provider/your-default-model",
     "agents": {
-      "scout": "openai/gpt-5-mini",
-      "reviewer": "anthropic/claude-sonnet-4-6"
+      "scout": "your-provider/your-fast-model",
+      "reviewer": "your-provider/your-review-model"
     }
   }
 }
@@ -210,7 +220,7 @@ subagent({ name: "Designer", agent: "game-designer", cwd: "agents/game-designer"
 | `agent`                | string  | —              | Load defaults from agent definition                                                               |
 | `fork`                 | boolean | `false`        | Force the full-context fork mode for this spawn, overriding any agent `session-mode` frontmatter  |
 | `interactive`          | boolean | derived        | Mark this spawn as interactive (don't wake the parent on stall/recovery). Defaults to the agent's `interactive` frontmatter, otherwise the inverse of `auto-exit`. |
-| `model`                | string  | parent model   | Exact authenticated `provider/model-id`; omit to inherit the parent                               |
+| `model`                | string  | configured or parent | Exact authenticated `provider/model-id`; resolution is tool argument → agent frontmatter → per-agent config → global config → parent |
 | `thinking`             | string  | parent level   | Pi thinking level (`off` through `max`); omit to inherit the parent                                |
 | `systemPrompt`         | string  | —              | Append to system prompt                                                                           |
 | `skills`               | string  | —              | Comma-separated skill names                                                                       |

--- a/README.md
+++ b/README.md
@@ -297,12 +297,7 @@ Phase 4: Execute          → Scout + sequential workers implement todos
 Phase 5: Review           → Reviewer subagent checks all changes
 ```
 
-Tab/window titles update to show current phase:
-
-```
-🔍 Investigating: dark mode → 💬 Planning: dark mode
-→ 🔨 Executing: 1/3 → 🔎 Reviewing → ✅ Done
-```
+The parent workspace and tab names stay unchanged. Subagents are created in newly named tabs or panes for each phase.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -168,9 +168,18 @@ cp config.json.example config.json
 {
   "status": {
     "enabled": true
+  },
+  "models": {
+    "default": "anthropic/claude-sonnet-4-6",
+    "agents": {
+      "scout": "openai/gpt-5-mini",
+      "reviewer": "anthropic/claude-sonnet-4-6"
+    }
   }
 }
 ```
+
+`models.default` sets the model for subagents that do not specify a model. `models.agents` sets per-agent defaults, keyed by the agent name passed to `subagent({ agent: ... })`. Explicit `model` tool arguments take precedence, followed by agent frontmatter, per-agent config, the global default, and finally the parent model. Model values must be exact authenticated `provider/model-id` references.
 
 `config.json` is gitignored so local overrides don't get committed.
 
@@ -179,7 +188,7 @@ cp config.json.example config.json
 ## Spawning Subagents
 
 ```typescript
-// Named agent with defaults from agent definition
+// Named agent with defaults from agent definition or config.json
 subagent({ name: "Scout", agent: "scout", task: "Analyze the codebase..." });
 
 // Force a full-context fork for this spawn

--- a/config.json.example
+++ b/config.json.example
@@ -3,10 +3,6 @@
     "enabled": true
   },
   "models": {
-    "default": "anthropic/claude-sonnet-4-6",
-    "agents": {
-      "scout": "openai/gpt-5-mini",
-      "reviewer": "anthropic/claude-sonnet-4-6"
-    }
+    "agents": {}
   }
 }

--- a/config.json.example
+++ b/config.json.example
@@ -1,5 +1,12 @@
 {
   "status": {
     "enabled": true
+  },
+  "models": {
+    "default": "anthropic/claude-sonnet-4-6",
+    "agents": {
+      "scout": "openai/gpt-5-mini",
+      "reviewer": "anthropic/claude-sonnet-4-6"
+    }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pi-herdr-subagents",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pi-herdr-subagents",
-      "version": "0.1.4",
+      "version": "0.1.5",
       "license": "MIT",
       "devDependencies": {
         "@earendil-works/pi-ai": "^0.80.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-herdr-subagents",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "Interactive subagents for pi running in herdr",
   "keywords": [
     "pi-package"

--- a/pi-extension/subagents/index.ts
+++ b/pi-extension/subagents/index.ts
@@ -36,7 +36,7 @@ import {
   type ResolvedRuntimePlan,
   type ThinkingLevel,
 } from "./runtime-routing.ts";
-import { loadModelConfig } from "./model-config.ts";
+import { loadModelConfig, resolveModelDefault } from "./model-config.ts";
 
 import {
   findLastAssistantMessage,
@@ -1113,13 +1113,10 @@ async function launchSubagent(
 
   const agentDefs = params.agent ? loadAgentDefaults(params.agent) : null;
   if (!ctx.model) throw new Error("Subagent launch requires a resolved parent model");
-  const configuredModel = params.agent
-    ? modelConfig.agents[params.agent] ?? modelConfig.default
-    : modelConfig.default;
   const runtimePlan = resolveRuntimePlan(
     { model: params.model, thinking: params.thinking },
     {
-      model: agentDefs?.model ?? configuredModel,
+      model: resolveModelDefault(params.agent, agentDefs?.model, modelConfig),
       thinking: agentDefs?.thinking,
     },
     { provider: ctx.model.provider, modelId: ctx.model.id, thinking: parentThinking },
@@ -2464,7 +2461,7 @@ export default function subagentsExtension(pi: ExtensionAPI) {
         return;
       }
 
-      // Rename workspace and tab to show this is a planning session
+      // Rename the tab to show this is a planning session
       if (isTerminalAvailable()) {
         try {
           const label = task.length > 40 ? task.slice(0, 40) + "..." : task;
@@ -2484,4 +2481,3 @@ export default function subagentsExtension(pi: ExtensionAPI) {
     },
   });
 }
-// test

--- a/pi-extension/subagents/index.ts
+++ b/pi-extension/subagents/index.ts
@@ -22,7 +22,6 @@ import {
   closePane,
   interruptPane,
   shellQuote,
-  renameCurrentTab,
   readPane,
   readPaneAsync,
   inspectPane,
@@ -2459,16 +2458,6 @@ export default function subagentsExtension(pi: ExtensionAPI) {
       if (!task) {
         ctx.ui.notify("Usage: /plan <what to build>", "warning");
         return;
-      }
-
-      // Rename the tab to show this is a planning session
-      if (isTerminalAvailable()) {
-        try {
-          const label = task.length > 40 ? task.slice(0, 40) + "..." : task;
-          renameCurrentTab(`🎯 Plan: ${label}`);
-        } catch {
-          // non-critical -- do not block the plan
-        }
       }
 
       // Load the plan skill from the subagents extension directory

--- a/pi-extension/subagents/index.ts
+++ b/pi-extension/subagents/index.ts
@@ -23,7 +23,6 @@ import {
   interruptPane,
   shellQuote,
   renameCurrentTab,
-  renameCurrentWorkspace,
   readPane,
   readPaneAsync,
   inspectPane,
@@ -37,6 +36,7 @@ import {
   type ResolvedRuntimePlan,
   type ThinkingLevel,
 } from "./runtime-routing.ts";
+import { loadModelConfig } from "./model-config.ts";
 
 import {
   findLastAssistantMessage,
@@ -468,6 +468,7 @@ function getArtifactDir(sessionDir: string, sessionId: string): string {
 }
 
 const statusConfig = loadStatusConfig();
+const modelConfig = loadModelConfig();
 
 function resolveResultPresentation(
   result: Pick<
@@ -1112,9 +1113,15 @@ async function launchSubagent(
 
   const agentDefs = params.agent ? loadAgentDefaults(params.agent) : null;
   if (!ctx.model) throw new Error("Subagent launch requires a resolved parent model");
+  const configuredModel = params.agent
+    ? modelConfig.agents[params.agent] ?? modelConfig.default
+    : modelConfig.default;
   const runtimePlan = resolveRuntimePlan(
     { model: params.model, thinking: params.thinking },
-    { model: agentDefs?.model, thinking: agentDefs?.thinking },
+    {
+      model: agentDefs?.model ?? configuredModel,
+      thinking: agentDefs?.thinking,
+    },
     { provider: ctx.model.provider, modelId: ctx.model.id, thinking: parentThinking },
     wrapPiModelRegistry(ctx.modelRegistry),
   );
@@ -2461,7 +2468,6 @@ export default function subagentsExtension(pi: ExtensionAPI) {
       if (isTerminalAvailable()) {
         try {
           const label = task.length > 40 ? task.slice(0, 40) + "..." : task;
-          renameCurrentWorkspace(`🎯 ${label}`);
           renameCurrentTab(`🎯 Plan: ${label}`);
         } catch {
           // non-critical -- do not block the plan

--- a/pi-extension/subagents/model-config.ts
+++ b/pi-extension/subagents/model-config.ts
@@ -1,6 +1,5 @@
 import { readFileSync } from "node:fs";
-import { join } from "node:path";
-import { dirname } from "node:path";
+import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
 const PACKAGE_ROOT = join(dirname(fileURLToPath(import.meta.url)), "../..");
@@ -51,11 +50,28 @@ export function parseModelConfig(rawConfig: unknown, source = "config.json"): Mo
       if (typeof model !== "string" || model.trim() === "") {
         invalidModelConfig(source, `models.agents.${agent} must be a non-empty string`);
       }
-      agents[agent] = model.trim();
+      Object.defineProperty(agents, agent, {
+        value: model.trim(),
+        enumerable: true,
+        writable: true,
+        configurable: true,
+      });
     }
   }
 
   return { default: defaultModel, agents };
+}
+
+export function resolveModelDefault(
+  agentName: string | undefined,
+  agentModel: string | undefined,
+  config: ModelConfig,
+): string | undefined {
+  if (agentModel) return agentModel;
+  if (agentName && Object.hasOwn(config.agents, agentName)) {
+    return config.agents[agentName];
+  }
+  return config.default;
 }
 
 export function loadModelConfig(configPath = DEFAULT_MODEL_CONFIG_PATH): ModelConfig {

--- a/pi-extension/subagents/model-config.ts
+++ b/pi-extension/subagents/model-config.ts
@@ -1,0 +1,79 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const PACKAGE_ROOT = join(dirname(fileURLToPath(import.meta.url)), "../..");
+const DEFAULT_MODEL_CONFIG_PATH = join(PACKAGE_ROOT, "config.json");
+
+export interface ModelConfig {
+  default?: string;
+  agents: Record<string, string>;
+}
+
+function invalidModelConfig(source: string, message: string): never {
+  throw new Error(`Invalid subagent model config in ${source}: ${message}`);
+}
+
+export function parseModelConfig(rawConfig: unknown, source = "config.json"): ModelConfig {
+  if (rawConfig == null || typeof rawConfig !== "object" || Array.isArray(rawConfig)) {
+    invalidModelConfig(source, "root must be an object");
+  }
+
+  const config = rawConfig as Record<string, unknown>;
+  const models = config.models;
+  if (models == null) return { agents: {} };
+  if (typeof models !== "object" || Array.isArray(models)) {
+    invalidModelConfig(source, "models must be an object");
+  }
+
+  const value = models as Record<string, unknown>;
+  const allowedKeys = new Set(["default", "agents"]);
+  const unsupportedKeys = Object.keys(value).filter((key) => !allowedKeys.has(key));
+  if (unsupportedKeys.length > 0) {
+    invalidModelConfig(source, `models has unsupported key(s): ${unsupportedKeys.join(", ")}`);
+  }
+
+  let defaultModel: string | undefined;
+  if (value.default != null) {
+    if (typeof value.default !== "string" || value.default.trim() === "") {
+      invalidModelConfig(source, "models.default must be a non-empty string");
+    }
+    defaultModel = value.default.trim();
+  }
+
+  const agents: Record<string, string> = {};
+  if (value.agents != null) {
+    if (typeof value.agents !== "object" || Array.isArray(value.agents)) {
+      invalidModelConfig(source, "models.agents must be an object");
+    }
+    for (const [agent, model] of Object.entries(value.agents as Record<string, unknown>)) {
+      if (typeof model !== "string" || model.trim() === "") {
+        invalidModelConfig(source, `models.agents.${agent} must be a non-empty string`);
+      }
+      agents[agent] = model.trim();
+    }
+  }
+
+  return { default: defaultModel, agents };
+}
+
+export function loadModelConfig(configPath = DEFAULT_MODEL_CONFIG_PATH): ModelConfig {
+  let raw: string;
+  try {
+    raw = readFileSync(configPath, "utf8");
+  } catch (error) {
+    const errno = error as NodeJS.ErrnoException;
+    if (errno.code === "ENOENT") return { agents: {} };
+    throw error;
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw) as unknown;
+  } catch (error) {
+    const detail = error instanceof Error ? error.message : String(error);
+    throw new Error(`Invalid JSON in subagent model config ${configPath}: ${detail}`);
+  }
+  return parseModelConfig(parsed, configPath);
+}

--- a/test/test.ts
+++ b/test/test.ts
@@ -25,7 +25,11 @@ import {
 } from "../pi-extension/subagents/session.ts";
 
 import { isHerdrAvailable, __herdrTest__ } from "../pi-extension/subagents/herdr.ts";
-import { loadModelConfig, parseModelConfig } from "../pi-extension/subagents/model-config.ts";
+import {
+  loadModelConfig,
+  parseModelConfig,
+  resolveModelDefault,
+} from "../pi-extension/subagents/model-config.ts";
 import {
   advanceStatusState,
   capStatusLines,
@@ -923,6 +927,37 @@ describe("model configuration", () => {
   it("loads no model overrides when config.json is absent", () => {
     const config = loadModelConfig(join(createTestDir(), "missing-config.json"));
     assert.deepEqual(config, { agents: {} });
+  });
+
+  it("resolves frontmatter, per-agent, global, and parent fallback precedence", () => {
+    const config = parseModelConfig({
+      models: {
+        default: "fake/global",
+        agents: { scout: "fake/scout" },
+      },
+    });
+
+    assert.equal(resolveModelDefault("scout", "fake/frontmatter", config), "fake/frontmatter");
+    assert.equal(resolveModelDefault("scout", undefined, config), "fake/scout");
+    assert.equal(resolveModelDefault("reviewer", undefined, config), "fake/global");
+    assert.equal(resolveModelDefault(undefined, undefined, { agents: {} }), undefined);
+  });
+
+  it("does not read inherited object properties as agent model defaults", () => {
+    const config = parseModelConfig({ models: { agents: {} } });
+    for (const agent of ["constructor", "toString", "__proto__"]) {
+      assert.equal(resolveModelDefault(agent, undefined, config), undefined);
+    }
+  });
+
+  it("supports reserved property names when explicitly configured", () => {
+    const config = parseModelConfig(
+      JSON.parse(
+        '{"models":{"agents":{"constructor":"fake/constructor","__proto__":"fake/proto"}}}',
+      ),
+    );
+    assert.equal(resolveModelDefault("constructor", undefined, config), "fake/constructor");
+    assert.equal(resolveModelDefault("__proto__", undefined, config), "fake/proto");
   });
 
   it("rejects invalid model configuration", () => {

--- a/test/test.ts
+++ b/test/test.ts
@@ -25,6 +25,7 @@ import {
 } from "../pi-extension/subagents/session.ts";
 
 import { isHerdrAvailable, __herdrTest__ } from "../pi-extension/subagents/herdr.ts";
+import { loadModelConfig, parseModelConfig } from "../pi-extension/subagents/model-config.ts";
 import {
   advanceStatusState,
   capStatusLines,
@@ -900,6 +901,33 @@ describe("status.ts", () => {
     assert.match(aggregate, /^Subagent status:/);
     assert.match(aggregate, /\+2 more running\./);
     assert.doesNotMatch(aggregate, /\/tmp|\.jsonl/);
+  });
+});
+
+describe("model configuration", () => {
+  it("parses global and per-agent model defaults", () => {
+    assert.deepEqual(
+      parseModelConfig({
+        models: {
+          default: " anthropic/claude-sonnet-4-6 ",
+          agents: { scout: " openai/gpt-5-mini " },
+        },
+      }),
+      {
+        default: "anthropic/claude-sonnet-4-6",
+        agents: { scout: "openai/gpt-5-mini" },
+      },
+    );
+  });
+
+  it("loads no model overrides when config.json is absent", () => {
+    const config = loadModelConfig(join(createTestDir(), "missing-config.json"));
+    assert.deepEqual(config, { agents: {} });
+  });
+
+  it("rejects invalid model configuration", () => {
+    assert.throws(() => parseModelConfig({ models: { default: "" } }), /non-empty string/);
+    assert.throws(() => parseModelConfig({ models: { agents: [] } }), /must be an object/);
   });
 });
 


### PR DESCRIPTION
## Summary
- preserve the parent workspace and current tab names while naming newly created subagent tabs and panes
- add configurable global and per-agent subagent model defaults through `config.json`
- validate configured models against the authenticated model registry
- make the tracked `config.json.example` safe to copy without provider credentials
- document model precedence and custom-agent configuration

## Verification
- `npm test` — 171 tests passed
- `npm run lint` — passed
- `git diff --check` — passed

## Release
- Bumped package version from `0.1.4` to `0.1.5`
