### PR TITLE
fix: wait for agent settling before auto-exit

### DIFF
--- a/pi-extension/subagents/subagent-done.ts
+++ b/pi-extension/subagents/subagent-done.ts
@@ -150,6 +150,7 @@ export default function (pi: ExtensionAPI) {
 
   let userTookOver = false;
   let agentStarted = false;
+  let latestAgentMessages: any[] | undefined;
 
   // Show widget + status bar on session start
   pi.on("session_start", (_event, ctx) => {
@@ -178,22 +179,28 @@ export default function (pi: ExtensionAPI) {
     recorder.agentStart();
   });
 
-  pi.on("agent_end", (event, ctx) => {
-    const messages = (event as any).messages as any[] | undefined;
-    const shouldExit = autoExit && shouldAutoExitOnAgentEnd(userTookOver, messages);
+  pi.on("agent_end", (event) => {
+    // agent_end is not terminal: Pi may compact and automatically retry after
+    // this event. Keep the latest result, but do not publish completion or
+    // shut down until agent_settled confirms no continuation will run.
+    latestAgentMessages = (event as any).messages as any[] | undefined;
+    recorder.agentEndWaiting();
+  });
+
+  pi.on("agent_settled", (_event, ctx) => {
+    const shouldExit = autoExit
+      && shouldAutoExitOnAgentEnd(userTookOver, latestAgentMessages);
 
     if (shouldExit) {
       // Surface stopReason: "error" turns (auto-retry exhausted, provider
       // overload, etc.) to the parent via the .exit sidecar so the watcher
       // can report a clear failure with the underlying error message.
-      // Without this the parent would only see exit code 0 and a stale
-      // assistant message, mistaking the crash for a successful completion.
       const sessionFile = process.env.PI_SUBAGENT_SESSION;
       if (sessionFile) {
         try {
           writeFileSync(
             `${sessionFile}.exit`,
-            JSON.stringify(buildCompletionSidecar(messages)),
+            JSON.stringify(buildCompletionSidecar(latestAgentMessages)),
           );
         } catch {
           // Best effort — the watcher can still detect the terminal sentinel
@@ -206,10 +213,9 @@ export default function (pi: ExtensionAPI) {
       return;
     }
 
-    recorder.agentEndWaiting();
     if (autoExit) {
       // Reset any recorded manual input marker. Auto-exit is decided by whether
-      // the latest agent turn completed normally, not by who initiated it.
+      // the latest settled agent run completed normally, not by who initiated it.
       userTookOver = false;
     }
   });

--- a/test/test.ts
+++ b/test/test.ts
@@ -48,7 +48,7 @@ import {
   getSubagentActivityFile,
   readSubagentActivityFile,
 } from "../pi-extension/subagents/activity.ts";
-import {
+import subagentDoneExtension, {
   shouldMarkUserTookOver,
   shouldAutoExitOnAgentEnd,
   findLatestAssistantError,
@@ -1386,6 +1386,62 @@ describe("subagent-done.ts", () => {
       // failure detail; staying open would just strand the worker.
       const messages = [{ role: "assistant", stopReason: "error", errorMessage: "529 overloaded" }];
       assert.equal(shouldAutoExitOnAgentEnd(false, messages), true);
+    });
+  });
+
+  describe("auto-exit lifecycle", () => {
+    it("waits for agent_settled and uses the latest agent result", () => {
+      withTempDir((dir) => {
+        const previousAutoExit = process.env.PI_SUBAGENT_AUTO_EXIT;
+        const previousSession = process.env.PI_SUBAGENT_SESSION;
+        const sessionFile = join(dir, "child.jsonl");
+        process.env.PI_SUBAGENT_AUTO_EXIT = "1";
+        process.env.PI_SUBAGENT_SESSION = sessionFile;
+
+        try {
+          const { api, eventHandlers } = createMockExtensionApi();
+          subagentDoneExtension(api);
+          const agentEnd = eventHandlers.get("agent_end")![0];
+          const agentSettled = eventHandlers.get("agent_settled")![0];
+          let shutdowns = 0;
+          const ctx = { shutdown: () => { shutdowns += 1; } };
+
+          agentEnd({ messages: [{ role: "assistant", stopReason: "stop" }] }, ctx);
+          assert.equal(shutdowns, 0, "agent_end must not shut down before Pi settles");
+          assert.equal(existsSync(`${sessionFile}.exit`), false);
+
+          agentEnd({ messages: [{ role: "assistant", stopReason: "error", errorMessage: "latest failure" }] }, ctx);
+          agentSettled({ type: "agent_settled" }, ctx);
+
+          assert.equal(shutdowns, 1);
+          assert.deepEqual(JSON.parse(readFileSync(`${sessionFile}.exit`, "utf8")), {
+            type: "error",
+            errorMessage: "latest failure",
+            stopReason: "error",
+          });
+        } finally {
+          restoreEnvVar("PI_SUBAGENT_AUTO_EXIT", previousAutoExit);
+          restoreEnvVar("PI_SUBAGENT_SESSION", previousSession);
+        }
+      });
+    });
+
+    it("preserves an aborted worker after agent_settled", () => {
+      const previousAutoExit = process.env.PI_SUBAGENT_AUTO_EXIT;
+      process.env.PI_SUBAGENT_AUTO_EXIT = "1";
+      try {
+        const { api, eventHandlers } = createMockExtensionApi();
+        subagentDoneExtension(api);
+        let shutdowns = 0;
+        const ctx = { shutdown: () => { shutdowns += 1; } };
+        eventHandlers.get("agent_end")![0]({
+          messages: [{ role: "assistant", stopReason: "aborted" }],
+        }, ctx);
+        eventHandlers.get("agent_settled")![0]({ type: "agent_settled" }, ctx);
+        assert.equal(shutdowns, 0);
+      } finally {
+        restoreEnvVar("PI_SUBAGENT_AUTO_EXIT", previousAutoExit);
+      }
     });
   });
 


### PR DESCRIPTION
## Summary
- defer delegated worker auto-exit and completion sidecar publication from `agent_end` to `agent_settled`
- retain the latest `agent_end` messages so settled completion reports the final retry/compaction result
- preserve aborted-worker behavior and existing completion sidecar semantics

## Root cause
`agent_end` can be followed by automatic compaction/retry. Shutting down there destroys the worker before Pi completes that continuation and can publish a stale result. `agent_settled` is the terminal lifecycle event that guarantees no retry, compaction, or queued continuation remains.

## Tests
- `npm test` (173 passed)
- `npm run lint`
