### PR TITLE
fix(subagents): pass Claude CLI bare model IDs

### DIFF
--- a/pi-extension/subagents/index.ts
+++ b/pi-extension/subagents/index.ts
@@ -29,6 +29,7 @@ import {
 import { waitForCompletion } from "./completion.ts";
 import {
   buildAuthenticatedModelCatalog,
+  modelForCli,
   resolveRuntimePlan,
   wrapPiModelRegistry,
   THINKING_LEVELS,
@@ -1121,7 +1122,6 @@ async function launchSubagent(
     { provider: ctx.model.provider, modelId: ctx.model.id, thinking: parentThinking },
     wrapPiModelRegistry(ctx.modelRegistry),
   );
-  const effectiveModel = runtimePlan.model;
   const effectiveTools = params.tools ?? agentDefs?.tools;
   const effectiveSkills = params.skills ?? agentDefs?.skills;
   const effectiveThinking = runtimePlan.thinking;
@@ -1200,6 +1200,7 @@ async function launchSubagent(
     : `${roleBlock}\n\n${modeHint}\n\n${params.task}\n\n${summaryInstruction}`;
   // ── Claude Code CLI path ──
   if (agentDefs?.cli === "claude") {
+    const effectiveModel = modelForCli("claude", runtimePlan);
     const sentinelFile = `/tmp/pi-claude-${id}-done`;
     const pluginDir = join(SUBAGENTS_DIR, "plugin");
 
@@ -1272,6 +1273,7 @@ async function launchSubagent(
   // ── Pi CLI path ──
 
   // Build pi command
+  const effectiveModel = modelForCli("pi", runtimePlan);
   const parts: string[] = ["pi"];
   parts.push("--session", shellQuote(subagentSessionFile));
 

--- a/pi-extension/subagents/runtime-routing.ts
+++ b/pi-extension/subagents/runtime-routing.ts
@@ -76,6 +76,13 @@ export interface ResolvedRuntimePlan {
   runtimeMismatch?: string;
 }
 
+export function modelForCli(
+  cli: "claude" | "pi",
+  runtimePlan: Pick<ResolvedRuntimePlan, "model" | "modelId">,
+): string {
+  return cli === "claude" ? runtimePlan.modelId : runtimePlan.model;
+}
+
 export class RuntimeResolutionError extends Error {
   constructor(message: string) {
     super(message);

--- a/test/runtime-routing.test.ts
+++ b/test/runtime-routing.test.ts
@@ -3,6 +3,7 @@ import { describe, it } from "node:test";
 import {
   RuntimeResolutionError,
   buildAuthenticatedModelCatalog,
+  modelForCli,
   resolveRuntimePlan,
   wrapPiModelRegistry,
   type ParentRuntime,
@@ -171,6 +172,24 @@ describe("runtime routing", () => {
       to: "off",
       reason: "non-reasoning",
     });
+  });
+});
+
+describe("CLI model routing", () => {
+  for (const modelId of ["fable", "opus", "sonnet"]) {
+    it(`passes the ${modelId} alias to Claude CLI without its provider`, () => {
+      assert.equal(
+        modelForCli("claude", { model: `anthropic/${modelId}`, modelId }),
+        modelId,
+      );
+    });
+  }
+
+  it("retains the provider-qualified model for Pi CLI", () => {
+    assert.equal(
+      modelForCli("pi", { model: "anthropic/claude-sonnet-4-5", modelId: "claude-sonnet-4-5" }),
+      "anthropic/claude-sonnet-4-5",
+    );
   });
 });
 


### PR DESCRIPTION
## Summary
- add a pure `modelForCli` resolver for CLI-specific model syntax
- pass only the model ID to Claude Code while retaining `provider/model` for Pi
- cover fable, opus, sonnet, and Pi model routing

## Reproduction
A configured Claude-backed subagent resolves its runtime through Pi as `anthropic/opus` (or `anthropic/fable` / `anthropic/sonnet`). The previous Claude command builder passed that provider-qualified reference to `claude --model`, but Claude CLI expects its model ID/alias alone. This change sends `opus` to Claude CLI while keeping provider-qualified references intact for Pi CLI.

## Verification
- `PI_CODING_AGENT_DIR=$(mktemp -d) npm test`
- `PI_CODING_AGENT_DIR=$(mktemp -d) npm run lint`