### PR TITLE
Improve named subagent routing and runtime-default guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,9 +98,9 @@ Subagent tabs and panes are created without stealing keyboard focus. Launch comm
 | **reviewer**      | Config, then parent   | Reviews code for bugs, security issues, correctness                                      |
 | **visual-tester** | Config, then parent   | Visual QA via Chrome CDP — screenshots, responsive testing, interaction testing          |
 
-Bundled agents use model defaults from `config.json` when configured; otherwise they inherit the parent model. Thinking defaults still come from agent frontmatter or the parent level. The orchestrating agent can override either field for a specific task using an exact authenticated model ID and a supported Pi thinking level. Prefer changing thinking before changing models.
+Bundled agents use model defaults from `config.json` when configured; otherwise they inherit the parent model. Thinking defaults still come from agent frontmatter or the parent level. For a named agent, callers should omit `model` and `thinking` so those configured defaults apply. Passing either field explicitly is a one-off override and takes precedence over agent frontmatter.
 
-Agent discovery follows priority: **project-local** (`.pi/agents/`) > **global** (`~/.pi/agent/agents/`) > **package-bundled**. Override any bundled agent by placing your own version in the higher-priority location.
+Agent discovery follows priority: **project-local** (`.pi/agents/`) > **global** (`~/.pi/agent/agents/`) > **package-bundled**. Override any bundled agent by placing your own version in the higher-priority location. The discovered names, descriptions, and runtime defaults are included in the subagent tool guidance so the orchestrator can select by role instead of treating one agent as a generic default.
 
 ---
 
@@ -220,8 +220,8 @@ subagent({ name: "Designer", agent: "game-designer", cwd: "agents/game-designer"
 | `agent`                | string  | —              | Load defaults from agent definition                                                               |
 | `fork`                 | boolean | `false`        | Force the full-context fork mode for this spawn, overriding any agent `session-mode` frontmatter  |
 | `interactive`          | boolean | derived        | Mark this spawn as interactive (don't wake the parent on stall/recovery). Defaults to the agent's `interactive` frontmatter, otherwise the inverse of `auto-exit`. |
-| `model`                | string  | configured or parent | Exact authenticated `provider/model-id`; resolution is tool argument → agent frontmatter → per-agent config → global config → parent |
-| `thinking`             | string  | parent level   | Pi thinking level (`off` through `max`); omit to inherit the parent                                |
+| `model`                | string  | agent, configured, or parent | Exact authenticated `provider/model-id`; resolution is tool argument → agent frontmatter → per-agent config → global config → parent |
+| `thinking`             | string  | agent or parent | Pi thinking level (`off` through `max`); resolution is tool argument → agent frontmatter → parent |
 | `systemPrompt`         | string  | —              | Append to system prompt                                                                           |
 | `skills`               | string  | —              | Comma-separated skill names                                                                       |
 | `tools`                | string  | —              | Comma-separated tool names                                                                        |
@@ -315,7 +315,7 @@ This always forks the current session into a subagent with full conversation con
 
 ## Custom Agents
 
-Place a `.md` file in `.pi/agents/` (project) or `~/.pi/agent/agents/` (global):
+Place a `.md` file in `.pi/agents/` (project) or `~/.pi/agent/agents/` (global). Keep the filename and frontmatter `name` aligned (for example, `researcher.md` must declare `name: researcher`) so discovery and direct invocation agree:
 
 ```markdown
 ---

--- a/pi-extension/subagents/index.ts
+++ b/pi-extension/subagents/index.ts
@@ -98,12 +98,18 @@ const RUNTIME_KEY = Symbol.for("pi-subagents/runtime");
   }
 }
 
-function buildSubagentRoutingGuidelines(catalog?: string): string[] {
+function buildSubagentRoutingGuidelines(
+  modelCatalog?: string,
+  agentCatalog?: string,
+): string[] {
   return [
-    "For subagent model and thinking selection, inherit the parent runtime by omitting both fields unless the task warrants an override.",
-    "For subagent tasks, prefer changing thinking before changing models: minimal/low for bounded mechanical work, medium for ordinary implementation or review, and high+ for architecture, concurrency, security, or hard diagnosis.",
+    "Choose the named agent whose description most closely matches the task; do not use one agent as a generic default.",
+    "Omit model and thinking when invoking a named agent so its configured defaults apply. Passing either field is an explicit one-off override and takes precedence over agent frontmatter.",
+    "For a bare spawn, omit model and thinking to inherit the parent runtime.",
+    "When an intentional runtime override is necessary, prefer changing thinking before changing models: minimal/low for bounded mechanical work, medium for ordinary implementation or review, and high+ for architecture, concurrency, security, or hard diagnosis.",
     "When overriding a subagent model, use an exact authenticated provider/model-id from the live catalog below. Do not invent aliases or fuzzy names.",
-    catalog ?? "Authenticated subagent model catalog becomes available after session start.",
+    agentCatalog ?? "Available named subagent catalog becomes available after session start.",
+    modelCatalog ?? "Authenticated subagent model catalog becomes available after session start.",
   ];
 }
 
@@ -113,7 +119,7 @@ const ThinkingLevelSchema = Type.Union(
   THINKING_LEVELS.map((level) => Type.Literal(level)),
   {
     description:
-      "Pi thinking level. Omit to inherit the parent level. Prefer changing thinking before changing models: minimal/low for bounded mechanical work, medium for ordinary implementation or review, high+ for architecture, concurrency, security, or hard diagnosis.",
+      "Pi thinking level. Omit to use a named agent's thinking default, then the parent level. Passing a value explicitly overrides agent frontmatter for this spawn.",
   },
 );
 
@@ -123,7 +129,7 @@ const SubagentParams = Type.Object({
   agent: Type.Optional(
     Type.String({
       description:
-        "Agent name to load defaults from (e.g. 'worker', 'scout', 'reviewer'). Reads ~/.pi/agent/agents/<name>.md for model, tools, skills.",
+        "Agent name to load defaults from the available named subagent catalog. Agent frontmatter can provide model, thinking, tools, skills, and role instructions.",
     }),
   ),
   systemPrompt: Type.Optional(
@@ -132,7 +138,7 @@ const SubagentParams = Type.Object({
   model: Type.Optional(
     Type.String({
       description:
-        "Exact authenticated provider/model-id. Omit to inherit the parent model. Select another model only when task capability, speed, cost, modality, or context requirements warrant it.",
+        "Exact authenticated provider/model-id. Omit to use a named agent's model default, then the configured or parent model. Passing a value explicitly overrides agent frontmatter for this spawn.",
     }),
   ),
   thinking: Type.Optional(ThinkingLevelSchema),
@@ -314,6 +320,34 @@ function discoverAgentDefinitions(): ListedAgentDefinition[] {
   }
 
   return [...agents.values()];
+}
+
+function buildAvailableAgentCatalog(
+  agents: ListedAgentDefinition[],
+  limit = 24,
+): string {
+  const sorted = [...agents].sort((a, b) => a.name.localeCompare(b.name));
+  const visible = sorted.slice(0, limit);
+  const lines = [
+    "Available named subagents (choose by role; omit model/thinking to use agent defaults):",
+  ];
+
+  for (const agent of visible) {
+    const defaults = [
+      agent.model ? `model ${agent.model}` : undefined,
+      agent.thinking ? `thinking ${agent.thinking}` : undefined,
+    ].filter(Boolean);
+    const runtime = defaults.length > 0 ? `; defaults: ${defaults.join(", ")}` : "";
+    const description = agent.description ? ` — ${agent.description}` : "";
+    lines.push(`- ${agent.name} [${agent.source}${runtime}]${description}`);
+  }
+
+  if (visible.length === 0) lines.push("- none discovered; use a bare spawn");
+  if (sorted.length > visible.length) {
+    lines.push(`- … ${sorted.length - visible.length} more named subagents omitted`);
+  }
+
+  return lines.join("\n");
 }
 
 function resolveSubagentPaths(
@@ -562,6 +596,7 @@ interface SubagentRuntime {
   pi?: ExtensionAPI;
   latestCtx?: ExtensionContext;
   modelCatalog?: string;
+  agentCatalog?: string;
 }
 
 function createSubagentRuntime(): SubagentRuntime {
@@ -1601,7 +1636,13 @@ export default function subagentsExtension(pi: ExtensionAPI) {
   pi.on("session_start", (_event, ctx) => {
     runtime.latestCtx = ctx;
     runtime.modelCatalog = buildAuthenticatedModelCatalog(wrapPiModelRegistry(ctx.modelRegistry));
-    const refreshedGuidelines = buildSubagentRoutingGuidelines(runtime.modelCatalog);
+    runtime.agentCatalog = buildAvailableAgentCatalog(
+      discoverAgentDefinitions().filter((agent) => !agent.disableModelInvocation),
+    );
+    const refreshedGuidelines = buildSubagentRoutingGuidelines(
+      runtime.modelCatalog,
+      runtime.agentCatalog,
+    );
     subagentRoutingGuidelines.splice(0, subagentRoutingGuidelines.length, ...refreshedGuidelines);
     if (runningSubagents.size > 0) {
       startWidgetRefresh();

--- a/pi-extension/subagents/runtime-routing.ts
+++ b/pi-extension/subagents/runtime-routing.ts
@@ -307,7 +307,7 @@ export function buildAuthenticatedModelCatalog(
     lines.push(`- … ${models.length - visibleModels.length} more authenticated models omitted`);
   }
   lines.push(
-    "Default: inherit the parent model and thinking. Override thinking first; override model only when task capability, speed, cost, modality, or context warrants it.",
+    "Named agents keep their configured runtime when model and thinking overrides are omitted; bare spawns inherit the parent runtime. Pass overrides only when intentional.",
   );
   return lines.join("\n");
 }

--- a/test/runtime-routing.test.ts
+++ b/test/runtime-routing.test.ts
@@ -187,7 +187,10 @@ describe("authenticated model catalog", () => {
     assert.match(catalog, /200k context/);
     assert.match(catalog, /other\/plain/);
     assert.match(catalog, /non-reasoning/);
-    assert.match(catalog, /Default: inherit the parent model and thinking/);
+    assert.match(
+      catalog,
+      /Named agents keep their configured runtime when model and thinking overrides are omitted/,
+    );
   });
 
   it("caps large catalogs and reports omitted models", () => {

--- a/test/test.ts
+++ b/test/test.ts
@@ -1122,26 +1122,28 @@ describe("subagent discovery", () => {
     );
   });
 
-  it("bundled agents inherit the parent runtime and preserve interaction modes", () => {
-    const expectedInteraction = {
-      scout: false,
-      worker: false,
-      reviewer: false,
-      planner: true,
-      "visual-tester": false,
-    } as const;
+  it("bundled agents inherit the parent runtime and preserve interaction modes", async () => {
+    await withIsolatedAgentEnv(() => {
+      const expectedInteraction = {
+        scout: false,
+        worker: false,
+        reviewer: false,
+        planner: true,
+        "visual-tester": false,
+      } as const;
 
-    for (const [name, interactive] of Object.entries(expectedInteraction)) {
-      const defs = testApi.loadAgentDefaults(name);
-      assert.ok(defs, `expected bundled agent ${name} to be discoverable`);
-      assert.equal(defs.model, undefined, `${name} should inherit the parent model`);
-      assert.equal(defs.thinking, undefined, `${name} should inherit the parent thinking level`);
-      assert.equal(
-        testApi.resolveEffectiveInteractive({ name, task: "" }, defs),
-        interactive,
-        `${name} should preserve its interaction mode`,
-      );
-    }
+      for (const [name, interactive] of Object.entries(expectedInteraction)) {
+        const defs = testApi.loadAgentDefaults(name);
+        assert.ok(defs, `expected bundled agent ${name} to be discoverable`);
+        assert.equal(defs.model, undefined, `${name} should inherit the parent model`);
+        assert.equal(defs.thinking, undefined, `${name} should inherit the parent thinking level`);
+        assert.equal(
+          testApi.resolveEffectiveInteractive({ name, task: "" }, defs),
+          interactive,
+          `${name} should preserve its interaction mode`,
+        );
+      }
+    });
   });
 
   it("ignores invalid session-mode values", async () => {
@@ -1871,6 +1873,57 @@ describe("commands", () => {
 });
 
 describe("tool registration", () => {
+  it("advertises named agents and tells callers to preserve their runtime defaults", async () => {
+    await withIsolatedAgentEnv(async ({ globalAgentsDir }) => {
+      writeAgentFile(
+        globalAgentsDir,
+        "researcher",
+        [
+          "name: researcher",
+          "description: Researches external topics using authoritative sources",
+          "model: fake/research",
+          "thinking: max",
+        ].join("\n"),
+      );
+
+      const { api, registeredTools, eventHandlers } = createMockExtensionApi();
+      (subagentsModule as any).default(api);
+
+      const subagent = registeredTools.find((tool) => tool.name === "subagent");
+      assert.ok(subagent);
+      const sessionStart = eventHandlers.get("session_start")?.[0];
+      assert.ok(sessionStart);
+      sessionStart({}, {
+        hasUI: false,
+        modelRegistry: {
+          find: (provider: string, id: string) => ({ provider, id, reasoning: true }),
+          getAvailable: () => [{
+            provider: "fake",
+            id: "parent",
+            reasoning: true,
+            input: ["text"],
+            contextWindow: 128_000,
+            maxTokens: 16_000,
+            cost: { input: 1, output: 2, cacheRead: 0, cacheWrite: 0 },
+          }],
+          hasConfiguredAuth: () => true,
+        },
+      });
+
+      const guidance = subagent.promptGuidelines.join("\n");
+      assert.match(guidance, /Available named subagents/);
+      assert.match(
+        guidance,
+        /researcher.*Researches external topics using authoritative sources/,
+      );
+      assert.match(guidance, /omit.*model.*thinking.*named agent.*defaults/i);
+      assert.match(
+        subagent.parameters.properties.thinking.description,
+        /named agent's thinking default/i,
+      );
+    });
+  });
+
   it("refreshes subagent routing guidance from the live authenticated model registry", () => {
     const { api, registeredTools, eventHandlers } = createMockExtensionApi();
     (subagentsModule as any).default(api);


### PR DESCRIPTION
## Summary

This PR improves how the parent agent selects and configures named subagents.

- Add discovered subagents, role descriptions, and runtime defaults to the `subagent` tool guidance.
- Tell callers to select the named agent that best matches the task.
- Tell callers to omit `model` and `thinking` so named-agent defaults apply.
- Keep explicit `model` and `thinking` values as one-time overrides.
- Clarify that bare spawns inherit the parent runtime.
- Update the documentation and parameter descriptions.
- Isolate bundled-agent tests from global user agent definitions.

## Motivation

Named-agent frontmatter was already applied when the caller omitted runtime arguments. However, the tool guidance did not show the available agent roles and encouraged the caller to select a thinking level.

As a result, the parent agent could:

1. Select a general `scout` for a task better suited to another agent.
2. Pass `thinking: high`, which overrides an agent's configured `thinking: max`.

This change makes the available roles and defaults visible to the parent agent. It does not change runtime precedence: explicit tool arguments still override agent frontmatter.