### PR TITLE
fix(subagents): resolve named agents by catalog identity, not filename

### DIFF
--- a/pi-extension/subagents/index.ts
+++ b/pi-extension/subagents/index.ts
@@ -35,7 +35,7 @@ import {
   type ResolvedRuntimePlan,
   type ThinkingLevel,
 } from "./runtime-routing.ts";
-import { loadModelConfig, resolveModelDefault } from "./model-config.ts";
+import { loadModelConfig, resolveModelDefault, type ModelConfig } from "./model-config.ts";
 
 import {
   findLastAssistantMessage,
@@ -310,12 +310,17 @@ function discoverAgentDefinitions(): ListedAgentDefinition[] {
   for (const { path: dir, source } of dirs) {
     if (!existsSync(dir)) continue;
     for (const file of readdirSync(dir).filter((entry) => entry.endsWith(".md"))) {
-      const parsed = parseAgentDefinition(
-        readFileSync(join(dir, file), "utf8"),
-        file.replace(/\.md$/, ""),
-      );
-      if (!parsed) continue;
-      agents.set(parsed.name, { ...parsed, source });
+      try {
+        const parsed = parseAgentDefinition(
+          readFileSync(join(dir, file), "utf8"),
+          file.replace(/\.md$/, ""),
+        );
+        if (!parsed) continue;
+        agents.set(parsed.name, { ...parsed, source });
+      } catch {
+        // Skip unreadable or racy entries rather than aborting discovery
+        // for every other agent definition.
+      }
     }
   }
 
@@ -325,6 +330,7 @@ function discoverAgentDefinitions(): ListedAgentDefinition[] {
 function buildAvailableAgentCatalog(
   agents: ListedAgentDefinition[],
   limit = 24,
+  config: ModelConfig = modelConfig,
 ): string {
   const sorted = [...agents].sort((a, b) => a.name.localeCompare(b.name));
   const visible = sorted.slice(0, limit);
@@ -333,8 +339,9 @@ function buildAvailableAgentCatalog(
   ];
 
   for (const agent of visible) {
+    const effectiveModel = resolveModelDefault(agent.name, agent.model, config);
     const defaults = [
-      agent.model ? `model ${agent.model}` : undefined,
+      effectiveModel ? `model ${effectiveModel}` : undefined,
       agent.thinking ? `thinking ${agent.thinking}` : undefined,
     ].filter(Boolean);
     const runtime = defaults.length > 0 ? `; defaults: ${defaults.join(", ")}` : "";
@@ -442,20 +449,11 @@ function resolveEffectiveInteractive(
 }
 
 function loadAgentDefaults(agentName: string): AgentDefaults | null {
-  const configDir = getAgentConfigDir();
-  const paths = [
-    join(process.cwd(), ".pi", "agents", `${agentName}.md`),
-    join(configDir, "agents", `${agentName}.md`),
-    join(getBundledAgentsDir(), `${agentName}.md`),
-  ];
-
-  for (const p of paths) {
-    if (!existsSync(p)) continue;
-    const parsed = parseAgentDefinition(readFileSync(p, "utf8"), agentName);
-    if (parsed) return parsed;
-  }
-
-  return null;
+  // Resolve through the same name-keyed map discoverAgentDefinitions() builds
+  // for the tool-guidance catalog, so a name advertised there always resolves
+  // to the same definition here — even when an agent's frontmatter `name`
+  // differs from its filename.
+  return discoverAgentDefinitions().find((agent) => agent.name === agentName) ?? null;
 }
 
 function formatElapsed(seconds: number): string {
@@ -1094,6 +1092,7 @@ export const __test__ = {
   renderSubagentWidgetLines,
   loadAgentDefaults,
   discoverAgentDefinitions,
+  buildAvailableAgentCatalog,
   resolveEffectiveSessionMode,
   resolveLaunchBehavior,
   resolveEffectiveAutoExit,

--- a/test/test.ts
+++ b/test/test.ts
@@ -1354,6 +1354,84 @@ describe("subagent discovery", () => {
       assert.equal(loaded.disableModelInvocation, true);
     });
   });
+
+  it("resolves loadAgentDefaults by the frontmatter name the catalog advertises, not the filename", async () => {
+    await withIsolatedAgentEnv(async ({ projectAgentsDir }) => {
+      writeAgentFile(
+        projectAgentsDir,
+        "renamed-file-test-agent",
+        [
+          "name: aliased-test-agent",
+          "description: Frontmatter name differs from filename",
+          "model: anthropic/test-aliased",
+        ].join("\n"),
+        "You are the aliased agent.",
+      );
+
+      const { api, registeredTools } = createMockExtensionApi();
+      (subagentsModule as any).default(api);
+
+      const tool = registeredTools.find((tool) => tool.name === "subagents_list");
+      const result = await tool.execute();
+      const agents = result.details?.agents ?? [];
+      assert.ok(
+        agents.some((agent: any) => agent.name === "aliased-test-agent"),
+        "catalog should advertise the frontmatter name",
+      );
+
+      const loadedByFrontmatterName = testApi.loadAgentDefaults("aliased-test-agent");
+      assert.ok(
+        loadedByFrontmatterName,
+        "loadAgentDefaults must resolve the same name the catalog advertises",
+      );
+      assert.equal(loadedByFrontmatterName.model, "anthropic/test-aliased");
+
+      const loadedByFilename = testApi.loadAgentDefaults("renamed-file-test-agent");
+      assert.equal(
+        loadedByFilename,
+        null,
+        "the filename alone should not resolve once frontmatter overrides the name",
+      );
+    });
+  });
+
+  it("discoverAgentDefinitions skips an unreadable entry instead of aborting discovery", async () => {
+    await withIsolatedAgentEnv(async ({ projectAgentsDir }) => {
+      writeAgentFile(
+        projectAgentsDir,
+        "readable-sibling-test-agent",
+        ["name: readable-sibling-test-agent", "description: Should still be discovered"].join("\n"),
+      );
+      // A directory ending in .md passes the file filter but throws EISDIR on
+      // read — previously this aborted discoverAgentDefinitions() entirely.
+      mkdirSync(join(projectAgentsDir, "broken-entry-test-agent.md"));
+
+      const agents = testApi.discoverAgentDefinitions();
+      assert.ok(
+        agents.some((agent: any) => agent.name === "readable-sibling-test-agent"),
+        "a broken sibling entry should not prevent discovery of valid agents",
+      );
+    });
+  });
+
+  it("buildAvailableAgentCatalog reflects a config.json model override, not just frontmatter", () => {
+    const agents = [
+      {
+        name: "config-override-test-agent",
+        source: "project" as const,
+        description: "Agent without a frontmatter model",
+        disableModelInvocation: false,
+      },
+    ];
+
+    const withoutOverride = testApi.buildAvailableAgentCatalog(agents, 24, { agents: {} });
+    assert.doesNotMatch(withoutOverride, /model /);
+
+    const withOverride = testApi.buildAvailableAgentCatalog(agents, 24, {
+      agents: { "config-override-test-agent": "anthropic/test-config-model" },
+    });
+    assert.match(withOverride, /model anthropic\/test-config-model/);
+  });
 });
 describe("subagent-done.ts", () => {
   describe("shouldMarkUserTookOver", () => {


### PR DESCRIPTION
## Summary

Follow-up from review on #16. Three issues in the new agent-catalog/routing-guidance code:

- `loadAgentDefaults()` looked up agents strictly by **filename**, while `discoverAgentDefinitions()` (which feeds the tool-guidance catalog shown to the orchestrator) keys agents by **frontmatter `name`**. If an agent's `name:` differs from its filename, the catalog advertises a name that silently fails to resolve (or resolves to the wrong file) at spawn time — no error, just the wrong agent running with none of its intended config. `loadAgentDefaults()` now resolves through the same name-keyed map `discoverAgentDefinitions()` builds, so catalog and spawn lookup can never diverge.
- `discoverAgentDefinitions()` had no error handling around `readFileSync` for each entry. Since #16 made `session_start` call this eagerly on every session hydration, one unreadable/racy `.md` entry (or non-file `.md`-suffixed entry) would abort discovery entirely. It now skips a bad entry and continues.
- `buildAvailableAgentCatalog()`'s "defaults:" line only reflected frontmatter `model`, never a `config.json` `models.agents` override, contradicting the README's claim that bundled agents get defaults from `config.json`. It now runs each agent through `resolveModelDefault()` like the actual spawn path does.

## Tests

- Added 3 regression tests (`npm test`, 177 passed) — verified each fails against the pre-fix code (assertion failure, uncaught `EISDIR`, missing export) before confirming they pass with the fix.
- `npm run lint` clean.