### PR TITLE
feat(subagents): set $task token via report-metadata for sidebar visibility

### DIFF
--- a/pi-extension/subagents/herdr.ts
+++ b/pi-extension/subagents/herdr.ts
@@ -267,8 +267,40 @@ export function renameHerdrWorkspace(title: string): void {
   herdrExec(["workspace", "rename", workspaceId, title]);
 }
 
+function buildPaneReportTaskArgs(
+  paneId: string,
+  task: string,
+  source = "pi",
+): string[] {
+  const normalizedTask = task.replace(/[\r\n\t]+/g, " ").trim();
+  return [
+    "pane",
+    "report-metadata",
+    paneId,
+    "--source",
+    source,
+    "--token",
+    `task=${normalizedTask}`,
+  ];
+}
+
+export function reportHerdrPaneTask(
+  paneId: string,
+  task: string,
+  source = "pi",
+): void {
+  const normalizedTask = task.replace(/[\r\n\t]+/g, " ").trim();
+  if (!normalizedTask) return;
+  try {
+    herdrExec(buildPaneReportTaskArgs(paneId, task, source));
+  } catch {
+    // Non-fatal: cosmetic metadata report failure should not abort subagent launch.
+  }
+}
+
 export const __herdrTest__ = {
   buildTabCreateArgs,
+  buildPaneReportTaskArgs,
   parseHerdrJson,
   extractHerdrPaneId,
   extractHerdrRootPaneId,

--- a/pi-extension/subagents/herdr.ts
+++ b/pi-extension/subagents/herdr.ts
@@ -292,7 +292,7 @@ export function reportHerdrPaneTask(
   const normalizedTask = task.replace(/[\r\n\t]+/g, " ").trim();
   if (!normalizedTask) return;
   try {
-    herdrExec(buildPaneReportTaskArgs(paneId, task, source));
+    herdrExec(buildPaneReportTaskArgs(paneId, normalizedTask, source));
   } catch {
     // Non-fatal: cosmetic metadata report failure should not abort subagent launch.
   }

--- a/pi-extension/subagents/index.ts
+++ b/pi-extension/subagents/index.ts
@@ -25,6 +25,7 @@ import {
   readPane,
   readPaneAsync,
   inspectPane,
+  setPaneTask,
 } from "./terminal.ts";
 import { waitForCompletion } from "./completion.ts";
 import {
@@ -1196,6 +1197,9 @@ async function launchSubagent(
 
   const surfacePreCreated = !!options?.surface;
   const surface = options?.surface ?? createSubagentPane(params.name);
+  if (params.task) {
+    setPaneTask(surface, params.task);
+  }
   if (!surfacePreCreated) {
     await new Promise<void>((resolve) => setTimeout(resolve, getShellReadyDelayMs()));
   }
@@ -2117,6 +2121,9 @@ export default function subagentsExtension(pi: ExtensionAPI) {
         const entryCountBefore = getNewEntries(params.sessionPath, 0).length;
 
         const surface = createSubagentPane(name);
+        if (params.message) {
+          setPaneTask(surface, params.message);
+        }
         await new Promise<void>((resolve) => setTimeout(resolve, getShellReadyDelayMs()));
 
         // Build pi resume command

--- a/pi-extension/subagents/terminal.ts
+++ b/pi-extension/subagents/terminal.ts
@@ -11,6 +11,7 @@ import {
   inspectHerdrPane,
   renameHerdrTab,
   renameHerdrWorkspace,
+  reportHerdrPaneTask,
   sendHerdrCommand,
   sendHerdrEscape,
 } from "./herdr.ts";
@@ -115,4 +116,9 @@ export async function inspectPane(paneId: PaneId): Promise<import("./lifecycle.t
 export function closePane(paneId: PaneId): void {
   assertTerminalAvailable();
   closeHerdrSurface(paneId);
+}
+
+export function setPaneTask(paneId: PaneId, task: string): void {
+  if (!isTerminalAvailable()) return;
+  reportHerdrPaneTask(paneId, task);
 }

--- a/test/test.ts
+++ b/test/test.ts
@@ -3100,6 +3100,40 @@ describe("herdr.ts", () => {
         "--no-focus",
       ]);
     });
+
+    it("constructs report-metadata arguments with normalized task token", () => {
+      assert.deepEqual(
+        __herdrTest__.buildPaneReportTaskArgs("pane-1", "Inspect failing test suite", "pi"),
+        [
+          "pane",
+          "report-metadata",
+          "pane-1",
+          "--source",
+          "pi",
+          "--token",
+          "task=Inspect failing test suite",
+        ],
+      );
+    });
+
+    it("flattens multi-line and tab-padded tasks into a single line", () => {
+      assert.deepEqual(
+        __herdrTest__.buildPaneReportTaskArgs(
+          "pane-2",
+          "  Line 1\n\tLine 2\r\nLine 3  ",
+          "pi",
+        ),
+        [
+          "pane",
+          "report-metadata",
+          "pane-2",
+          "--source",
+          "pi",
+          "--token",
+          "task=Line 1 Line 2 Line 3",
+        ],
+      );
+    });
   });
 
   describe("herdr response parsing", () => {


### PR DESCRIPTION
## Summary
Populate Herdr's pane `$task` token via `herdr pane report-metadata` when launching or resuming subagents, enabling Herdr's sidebar and tab list to show the subagent's actual task rather than generic 'pi'.

- Added `reportHerdrPaneTask` helper in `herdr.ts` that normalizes newlines/whitespace and reports the `task` token.
- Exposed `setPaneTask` helper in `terminal.ts`.
- Called `setPaneTask` in `launchSubagent` and `subagent_resume` in `index.ts`.
- Added unit tests for argument construction and whitespace normalization in `test/test.ts`.

Closes #18