### PR TITLE
chore: release v0.1.7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pi-herdr-subagents",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pi-herdr-subagents",
-      "version": "0.1.6",
+      "version": "0.1.7",
       "license": "MIT",
       "devDependencies": {
         "@earendil-works/pi-ai": "^0.80.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-herdr-subagents",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "Interactive subagents for pi running in herdr",
   "keywords": [
     "pi-package"


### PR DESCRIPTION
## Release v0.1.7

### Changes
- `feat(subagents)`: set `$task` token via `herdr pane report-metadata` for sidebar task visibility (#18, #19).

Bumps version from `0.1.6` to `0.1.7`.