### PR TITLE
fix(subagents): only auto-exit on final stop/error

### DIFF
--- a/pi-extension/subagents/subagent-done.ts
+++ b/pi-extension/subagents/subagent-done.ts
@@ -17,24 +17,16 @@ export function shouldAutoExitOnAgentEnd(
   _userTookOver: boolean,
   messages: any[] | undefined,
 ): boolean {
-  // Manual input should not strand an auto-exit subagent. If the latest agent
-  // turn completed normally, close the session. Escape/abort still leaves it
-  // open for inspection or another prompt.
-  //
-  // stopReason: "error" (e.g. exhausted retries on a provider overload) also
-  // returns true — we want to shut down so the parent is woken up — but we
-  // pair this with findLatestAssistantError() so the parent learns it was an
-  // error, not a clean completion.
   if (messages) {
     for (let i = messages.length - 1; i >= 0; i--) {
       const msg = messages[i];
       if (msg?.role === "assistant") {
-        return msg.stopReason !== "aborted";
+        return msg.stopReason === "stop" || msg.stopReason === "error";
       }
     }
   }
 
-  return true;
+  return false;
 }
 
 export interface SubagentErrorInfo {

--- a/test/test.ts
+++ b/test/test.ts
@@ -1489,6 +1489,11 @@ describe("subagent-done.ts", () => {
       assert.equal(shouldAutoExitOnAgentEnd(false, messages), false);
     });
 
+    it("stays open after a tool-use turn", () => {
+      const messages = [{ role: "assistant", stopReason: "toolUse" }];
+      assert.equal(shouldAutoExitOnAgentEnd(false, messages), false);
+    });
+
     it("still exits when the latest turn ended with stopReason=error", () => {
       // Auto-exit subagents must shut down on retry-exhaustion errors so the
       // parent is woken. The error sidecar (written separately) carries the


### PR DESCRIPTION
## Summary

The auto-exit subagent predicate previously closed the session after *any* assistant turn that was not aborted. This closed sessions prematurely during multi-turn work: a tool-use turn (stopReason=`toolUse`) or an intermediate turn before the agent settles would tear down the subagent while the task was still in flight.

This PR narrows the predicate to terminal states only: the session auto-exits when the latest assistant turn ended with `stop` or `error`, and otherwise stays open for the next turn or user prompt.

## Changes

- `pi-extension/subagents/subagent-done.ts`: return `true` only for `stopReason === "stop" || stopReason === "error"`; return `false` when no assistant message exists.
- `test/test.ts`: new test asserting the session stays open after a `toolUse` turn.

## Tests

`npm test`: 218/218 pass.

Closes behavior introduced in #14 — this replaces the earlier `fix: wait for agent settling before auto-exit` (commit 68e798c) approach with the terminal-predicate fix on top of current upstream `main`.