### PR TITLE
fix(subagents): guard updateWidget against stale ctx after /reload

### DIFF
--- a/pi-extension/subagents/index.ts
+++ b/pi-extension/subagents/index.ts
@@ -797,7 +797,15 @@ function renderSubagentWidgetLines(agents: RunningSubagent[], width: number): st
 
 function updateWidget() {
   const latestCtx = runtime.latestCtx;
-  if (!latestCtx?.hasUI) return;
+  if (!latestCtx) return;
+  try {
+    if (!latestCtx.hasUI) return;
+  } catch {
+    // Ctx went stale (session replacement / reload) mid-flight. Drop it and
+    // wait for the next session_start to install a fresh one.
+    runtime.latestCtx = undefined;
+    return;
+  }
 
   if (runningSubagents.size === 0) {
     latestCtx.ui.setWidget("subagent-status", undefined);
@@ -1453,6 +1461,8 @@ export default function subagentsExtension(pi: ExtensionAPI) {
 
   // Clean up on session shutdown
   pi.on("session_shutdown", (event, _ctx) => {
+    // Preserved watchers must not touch a ctx that is about to go stale.
+    runtime.latestCtx = undefined;
     if (widgetInterval) {
       clearInterval(widgetInterval);
       widgetInterval = null;


### PR DESCRIPTION
## Problem

Preserved subagent watchers keep calling `updateWidget()` across `/reload`. Between the old session's teardown and the new `session_start`, `latestCtx.hasUI` throws (`assertActive` on a replaced session) instead of returning false, so the preserved widget interval crashes pi with an uncaughtException.

Two gaps in current `main`:
1. `updateWidget()` reads `latestCtx?.hasUI` — a truthiness check only; it still throws when the ctx object is stale.
2. `runtime.latestCtx` is never cleared on `session_shutdown`, so stale refs survive until the next `session_start`.

Related: #14 (settled auto-exit, same area).

## Fix

- Wrap the `hasUI` access in try/catch in `updateWidget()`; on a stale ctx, drop `runtime.latestCtx` and wait for the next `session_start` to install a fresh one.
- Clear `runtime.latestCtx = undefined` at the top of the `session_shutdown` handler so preserved watchers never touch a dying ctx.

## Testing

- Full unit suite: 217 passed, 0 failed (node --test).
- oxlint clean on pi-extension.
- Manually exercised /reload with a live subagent watcher; no uncaughtException, widget re-registers on the new session.