### PR TITLE
feat(subagents): per-agent time limits with warned wrap-up reports

### DIFF
--- a/README.md
+++ b/README.md
@@ -369,8 +369,13 @@ You are a specialized agent that does X...
 | `deny-tools`  | string  | Comma-separated extension tool names to deny                                                                                                                                                                                                                                |
 | `auto-exit`   | boolean | Auto-shutdown when the agent finishes its turn — no `subagent_done` call needed. If the user sends any input, auto-exit is permanently disabled and the user takes over the session. Recommended for autonomous agents (scout, worker); not for interactive ones (planner). Also determines the default value of `interactive` (see below). |
 | `interactive` | boolean | derived        | Override whether stall/recovery transitions wake the parent session. Defaults to the inverse of `auto-exit`: autonomous agents (`auto-exit: true`) are non-interactive and get stall pings; agents without `auto-exit` are interactive and stay quiet. Explicit values take precedence. |
+| `time-limit` | positive integer seconds | — | Whole-run deadline for a non-interactive agent. At the deadline the pane closes and the parent receives a timed-out failure with the session still resumable. |
+| `idle-timeout` | positive integer seconds | — | Deadline measured from the latest Pi activity snapshot; it is ignored when no activity snapshots are available. |
+| `timeout-warn-threshold` | fraction `0 < n < 1` | — | Optional warning fraction for either limit on Pi-backed children. At the threshold the child receives one report-only continuation; omit it for hard-stop only. Other CLIs retain the hard deadline only. |
 | `cwd`         | string  | Default working directory (absolute or relative to project root)                                                                                                                                                                                                            |
 | `disable-model-invocation` | boolean | Hide this agent from discovery surfaces like `subagents_list`. The agent still remains directly invokable by explicit name via `subagent({ agent: "name", ... })`. |
+
+A warning writes a directive beside the child session, sends Escape only to interrupt the active turn, and reserves the original deadline for one final report-only turn. That normal completion is delivered as a **partial report under time limit** (not a full completion); the directive never types text into the child pane and fresh report activity cannot extend an idle deadline.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -175,6 +175,14 @@ export PI_SUBAGENT_RECOVERY_DELAYS_MS=30000,60000,90000
 
 Missing or malformed values use those defaults; each value below `10000` ms is clamped to `10000` ms. The ladder runs only from the stalled pane projection, so active/streaming/provider work is not timed out by wall clock. Interactive children and report-only wrap-up stages are exempt.
 
+A child wedged inside a single long-running tool call never leaves the `tool` activity scope, so by default it also projects `stalled` after `600000` ms (10 minutes) of tool-scope silence — the last tool-scope activity snapshot aging past the window — and drives the same wait→nudge→kill ladder automatically. Hung tool calls therefore recover without extra configuration; set to `0` to disable:
+
+```bash
+export PI_SUBAGENT_ACTIVE_TOOL_STALL_MS=600000
+```
+
+Missing or malformed values use that default. Only `tool`-scope staleness counts: provider/streaming/agent scopes are never stale-stalled because LLM calls may legitimately think silently. When fresh tool activity arrives, the child emits a `recovered` transition like any other stall recovery.
+
 **Interactive subagents stay silent.** Long-running user-driven subagents (e.g. `planner`, or any `/iterate` fork) do not wake the parent session on `stalled`/`recovered` transitions — the user is working directly in the subagent's pane, and a steer message there would just burn an orchestrator turn on a no-op "still waiting" ping. The widget still updates normally, and activity snapshots are still recorded/classified regardless of the `interactive` setting. By default, agents with `auto-exit: true` are treated as autonomous and get stall pings; agents without it are treated as interactive and stay quiet. Override per-agent with `interactive: true|false` in frontmatter, or per-spawn with `interactive: true|false` on the tool call.
 
 #### Configuration

--- a/README.md
+++ b/README.md
@@ -167,6 +167,14 @@ When `activeCount === 0` (every tracked row is open), the border uses an amber a
 
 A fixed internal watchdog marks a run as `stalled` when pane inspection fails or the pane disappears without a completion sidecar; valid long-running `active` or `waiting` states do not become `stalled` just because time passes. When a run enters `stalled` or recovers from it, the parent agent receives a steer message so it can react. All other status transitions stay in the widget only.
 
+For a non-interactive child that remains genuinely `stalled`, the recovery ladder waits 30 seconds, sends one Escape nudge, waits another 60 seconds to escalate, then waits 90 seconds before closing the pane and aborting the watcher. The delivered result is a `recovery-kill` failure, never a completion. Configure the three consecutive delays (stall→nudge, nudge→escalation, escalation→kill) with comma-separated milliseconds:
+
+```bash
+export PI_SUBAGENT_RECOVERY_DELAYS_MS=30000,60000,90000
+```
+
+Missing or malformed values use those defaults; each value below `10000` ms is clamped to `10000` ms. The ladder runs only from the stalled pane projection, so active/streaming/provider work is not timed out by wall clock. Interactive children and report-only wrap-up stages are exempt.
+
 **Interactive subagents stay silent.** Long-running user-driven subagents (e.g. `planner`, or any `/iterate` fork) do not wake the parent session on `stalled`/`recovered` transitions — the user is working directly in the subagent's pane, and a steer message there would just burn an orchestrator turn on a no-op "still waiting" ping. The widget still updates normally, and activity snapshots are still recorded/classified regardless of the `interactive` setting. By default, agents with `auto-exit: true` are treated as autonomous and get stall pings; agents without it are treated as interactive and stay quiet. Override per-agent with `interactive: true|false` in frontmatter, or per-spawn with `interactive: true|false` on the tool call.
 
 #### Configuration

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "type": "module",
   "scripts": {
     "lint": "oxlint pi-extension test",
-    "test": "node --test test/test.ts test/runtime-routing.test.ts test/release-workflow.test.ts test/harness-drivers.test.ts",
+    "test": "node --test test/test.ts test/runtime-routing.test.ts test/release-workflow.test.ts test/harness-drivers.test.ts test/time-limits.test.ts",
     "test:integration": "node --test --test-concurrency=1 test/integration/*.test.ts"
   },
   "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "type": "module",
   "scripts": {
     "lint": "oxlint pi-extension test",
-    "test": "node --test test/test.ts test/runtime-routing.test.ts test/release-workflow.test.ts test/harness-drivers.test.ts",
+    "test": "node --test test/test.ts test/runtime-routing.test.ts test/release-workflow.test.ts test/harness-drivers.test.ts test/recovery-ladder.test.ts test/stale-active-stall.test.ts",
     "test:integration": "node --test --test-concurrency=1 test/integration/*.test.ts"
   },
   "peerDependencies": {

--- a/pi-extension/subagents/completion.ts
+++ b/pi-extension/subagents/completion.ts
@@ -6,6 +6,8 @@ const TERMINAL_SENTINEL = /__SUBAGENT_DONE_(\d+)__/;
 export interface CompletionResult {
   reason: "done" | "ping" | "sentinel" | "error";
   exitCode: number;
+  /** The child completed its one-shot report-only continuation after a time warning. */
+  wrapup?: boolean;
   ping?: { name: string; message: string };
   errorMessage?: string;
 }
@@ -31,6 +33,7 @@ export function interpretExitSidecar(data: unknown): CompletionResult {
     name?: unknown;
     message?: unknown;
     errorMessage?: unknown;
+    wrapup?: unknown;
   };
 
   if (payload?.type === "ping") {
@@ -52,7 +55,9 @@ export function interpretExitSidecar(data: unknown): CompletionResult {
     return { reason: "error", exitCode: 1, errorMessage };
   }
 
-  if (payload?.type === "done") return { reason: "done", exitCode: 0 };
+  if (payload?.type === "done") {
+    return { reason: "done", exitCode: 0, ...(payload.wrapup === true ? { wrapup: true } : {}) };
+  }
 
   return {
     reason: "error",

--- a/pi-extension/subagents/harness/drivers/pi.ts
+++ b/pi-extension/subagents/harness/drivers/pi.ts
@@ -6,6 +6,7 @@ import type {
   BuiltHarnessCommand,
 } from "../types.ts";
 import type { ResolvedRuntimePlan } from "../../runtime-routing.ts";
+import { getSubagentActivityFile } from "../../activity.ts";
 
 const SUBAGENT_CONTROL_TOOLS = ["caller_ping", "subagent_done"] as const;
 
@@ -133,7 +134,7 @@ export class PiHarnessDriver implements HarnessDriver {
     }
     envParts.push(`PI_SUBAGENT_SESSION=${shellQuote(subagentSessionFile)}`);
     envParts.push(`PI_SUBAGENT_ID=${shellQuote(params.id)}`);
-    const activityFile = join(artifactDir, `subagent-activity-${params.id}.json`);
+    const activityFile = getSubagentActivityFile(artifactDir, params.id);
     envParts.push(`PI_SUBAGENT_ACTIVITY_FILE=${shellQuote(activityFile)}`);
     envParts.push(`PI_SUBAGENT_SURFACE=${shellQuote(surface)}`);
 

--- a/pi-extension/subagents/index.ts
+++ b/pi-extension/subagents/index.ts
@@ -81,6 +81,7 @@ import {
 import {
   advanceRecoveryLadder,
   formatRecoveryKillError,
+  parseActiveToolStallMs,
   parseRecoveryDelays,
   type RecoveryDelays,
   type RecoveryState,
@@ -783,7 +784,12 @@ function formatLifecycleWidgetLabel(
 
 function renderSubagentWidgetLines(agents: RunningSubagent[], width: number): string[] {
   const now = Date.now();
-  const rendered = agents.map((agent) => ({ agent, projection: projectLifecycle(ensureLifecycle(agent), now) }));
+  const rendered = agents.map((agent) => ({
+    agent,
+    projection: projectLifecycle(ensureLifecycle(agent), now, {
+      activeToolStallMs: parseActiveToolStallMs(process.env.PI_SUBAGENT_ACTIVE_TOOL_STALL_MS),
+    }),
+  }));
   const activeCount = rendered.filter(({ projection }) =>
     projection.kind === "active" ||
     projection.kind === "starting" ||
@@ -1090,6 +1096,7 @@ function handleSubagentInterrupt(
 function startStatusRefresh(pi: ExtensionAPI) {
   if (!statusConfig.enabled || statusInterval) return;
   const recoveryDelays = parseRecoveryDelays(process.env.PI_SUBAGENT_RECOVERY_DELAYS_MS);
+  const activeToolStallMs = parseActiveToolStallMs(process.env.PI_SUBAGENT_ACTIVE_TOOL_STALL_MS);
 
   statusInterval = setInterval(() => {
     if (runningSubagents.size === 0) {
@@ -1108,7 +1115,7 @@ function startStatusRefresh(pi: ExtensionAPI) {
     for (const running of runningSubagents.values()) {
       // Dual-writes lifecycle + statusState for reload hydration; steers use lifecycle only.
       observeRunningSubagent(running, now);
-      const projection = projectLifecycle(ensureLifecycle(running), now);
+      const projection = projectLifecycle(ensureLifecycle(running), now, { activeToolStallMs });
       const recovery = advanceRunningRecovery(running, projection, now, recoveryDelays);
       if (recovery.action) shouldRefreshWidget = true;
       const transition = lifecycleTransition(running.lastProjectedKind, projection.kind);

--- a/pi-extension/subagents/index.ts
+++ b/pi-extension/subagents/index.ts
@@ -78,6 +78,13 @@ import {
   type SubagentLifecycle,
   type PaneInspection,
 } from "./lifecycle.ts";
+import {
+  advanceRecoveryLadder,
+  formatRecoveryKillError,
+  parseRecoveryDelays,
+  type RecoveryDelays,
+  type RecoveryState,
+} from "./recovery.ts";
 
 /** Absolute path to `pi-extension/subagents`. https://github.com/nodejs/node/issues/37845 */
 const SUBAGENTS_DIR = dirname(fileURLToPath(import.meta.url));
@@ -584,6 +591,10 @@ interface RunningSubagent {
     error?: string;
   };
   abortController?: AbortController;
+  recovery?: RecoveryState;
+  recoveryKilled?: { errorMessage: string; killedAt: number };
+  /** Reserved for the L-96 report-only continuation. */
+  wrapupPending?: boolean;
   cli?: string;
   sentinelFile?: string;
   /**
@@ -604,6 +615,18 @@ interface RunningSubagent {
   /** Parent-resolved model/thinking selection and provenance. */
   runtimePlan: ResolvedRuntimePlan | undefined;
 }
+
+interface RecoveryPaneOperations {
+  interruptPane: (surface: string) => void;
+  closePane: (surface: string) => void;
+  abortWatcher: (controller: AbortController | undefined) => void;
+}
+
+const DEFAULT_RECOVERY_PANE_OPERATIONS: RecoveryPaneOperations = {
+  interruptPane,
+  closePane,
+  abortWatcher: (controller) => controller?.abort(),
+};
 
 interface SubagentRuntime {
   runningSubagents: Map<string, RunningSubagent>;
@@ -946,6 +969,75 @@ function requestSubagentInterrupt(
   }
 }
 
+function isTerminalLifecycle(lifecycle: SubagentLifecycle): boolean {
+  return lifecycle.process.kind === "completed" || lifecycle.process.kind === "failed";
+}
+
+/** Idempotent failure teardown shared with future hard-stop paths. */
+function failAndTeardownSubagent(
+  running: RunningSubagent,
+  error: string,
+  now: number,
+  operations: Pick<RecoveryPaneOperations, "closePane" | "abortWatcher"> = DEFAULT_RECOVERY_PANE_OPERATIONS,
+  beforeAbort?: () => void,
+): boolean {
+  const lifecycle = ensureLifecycle(running);
+  if (isTerminalLifecycle(lifecycle)) return false;
+
+  beforeAbort?.();
+  running.lifecycle = markFailed(lifecycle, error, now, 1);
+  try {
+    operations.closePane(running.surface);
+  } catch {}
+  try {
+    operations.abortWatcher(running.abortController);
+  } catch {}
+  return true;
+}
+
+function advanceRunningRecovery(
+  running: RunningSubagent,
+  projection: LifecycleProjection,
+  now: number,
+  delays: RecoveryDelays,
+  operations: RecoveryPaneOperations = DEFAULT_RECOVERY_PANE_OPERATIONS,
+) {
+  const advance = advanceRecoveryLadder(running.recovery, {
+    now,
+    stalled: projection.kind === "stalled",
+    exempt: running.interactive || running.wrapupPending === true,
+    delays,
+  });
+  running.recovery = advance.state;
+
+  if (advance.action === "nudge") {
+    requestSubagentInterrupt(running, operations.interruptPane);
+  } else if (advance.action === "kill") {
+    const error = formatRecoveryKillError(now - running.startTime);
+    failAndTeardownSubagent(running, error, now, operations, () => {
+      // The watcher observes its abort asynchronously, so set this first.
+      running.recoveryKilled = { errorMessage: error, killedAt: now };
+    });
+  }
+
+  return advance;
+}
+
+function buildRecoveryKilledResult(running: RunningSubagent, now: number): SubagentResult | null {
+  const recoveryKilled = running.recoveryKilled;
+  if (!recoveryKilled) return null;
+  return {
+    name: running.name,
+    task: running.task,
+    summary: `Subagent error: ${recoveryKilled.errorMessage}`,
+    sessionFile: running.sessionFile,
+    exitCode: 1,
+    elapsed: Math.floor(Math.max(0, now - running.startTime) / 1000),
+    error: recoveryKilled.errorMessage,
+    errorMessage: recoveryKilled.errorMessage,
+  };
+}
+
 function handleSubagentInterrupt(
   params: { id?: string; name?: string },
   interruptPaneKey: (surface: string) => void = interruptPane,
@@ -997,6 +1089,7 @@ function handleSubagentInterrupt(
 
 function startStatusRefresh(pi: ExtensionAPI) {
   if (!statusConfig.enabled || statusInterval) return;
+  const recoveryDelays = parseRecoveryDelays(process.env.PI_SUBAGENT_RECOVERY_DELAYS_MS);
 
   statusInterval = setInterval(() => {
     if (runningSubagents.size === 0) {
@@ -1016,6 +1109,8 @@ function startStatusRefresh(pi: ExtensionAPI) {
       // Dual-writes lifecycle + statusState for reload hydration; steers use lifecycle only.
       observeRunningSubagent(running, now);
       const projection = projectLifecycle(ensureLifecycle(running), now);
+      const recovery = advanceRunningRecovery(running, projection, now, recoveryDelays);
+      if (recovery.action) shouldRefreshWidget = true;
       const transition = lifecycleTransition(running.lastProjectedKind, projection.kind);
       if (running.lastProjectedKind !== projection.kind) {
         shouldRefreshWidget = true;
@@ -1081,6 +1176,9 @@ export const __test__ = {
   resolveDenyTools,
   resolveInterruptTarget,
   requestSubagentInterrupt,
+  failAndTeardownSubagent,
+  advanceRunningRecovery,
+  buildRecoveryKilledResult,
   handleSubagentInterrupt,
   resolveResultPresentation,
   resolveResumeLaunchBehavior,
@@ -1301,6 +1399,11 @@ async function watchSubagent(
     });
 
     const detectedAt = Date.now();
+    const recoveryResult = buildRecoveryKilledResult(running, detectedAt);
+    if (recoveryResult) {
+      updateWidget();
+      return recoveryResult;
+    }
     running.lifecycle = markCompletionDetected(running.lifecycle, result, detectedAt);
     updateWidget();
     const elapsed = Math.floor((detectedAt - startTime) / 1000);
@@ -1395,13 +1498,21 @@ async function watchSubagent(
       ...(result.errorMessage ? { errorMessage: result.errorMessage } : {}),
     };
   } catch (err: any) {
+    const now = Date.now();
+    const recoveryResult = buildRecoveryKilledResult(running, now);
+    if (recoveryResult) {
+      running.lifecycle = markFailed(running.lifecycle, recoveryResult.errorMessage!, now, 1);
+      updateWidget();
+      return recoveryResult;
+    }
+
     try {
       closePane(surface);
     } catch {}
     running.lifecycle = markFailed(
       running.lifecycle,
       signal.aborted ? "Subagent cancelled." : err?.message ?? String(err),
-      Date.now(),
+      now,
       1,
     );
     updateWidget();
@@ -1412,7 +1523,7 @@ async function watchSubagent(
         task,
         summary: "Subagent cancelled.",
         exitCode: 1,
-        elapsed: Math.floor((Date.now() - startTime) / 1000),
+        elapsed: Math.floor((now - startTime) / 1000),
         error: "cancelled",
         sessionFile,
       };
@@ -1422,7 +1533,7 @@ async function watchSubagent(
       task,
       summary: `Subagent error: ${err?.message ?? String(err)}`,
       exitCode: 1,
-      elapsed: Math.floor((Date.now() - startTime) / 1000),
+      elapsed: Math.floor((now - startTime) / 1000),
       error: err?.message ?? String(err),
     };
   }

--- a/pi-extension/subagents/index.ts
+++ b/pi-extension/subagents/index.ts
@@ -85,6 +85,16 @@ import {
   type RecoveryDelays,
   type RecoveryState,
 } from "./recovery.ts";
+import {
+  cleanupWrapupDirective,
+  evalTimeLimit,
+  formatTimeLimitError,
+  getTimeLimitDeadlineAt,
+  parsePositiveIntegerSeconds,
+  parseTimeoutWarnThreshold,
+  writeWrapupDirective,
+  type TimeLimitConfig,
+} from "./time-limits.ts";
 
 /** Absolute path to `pi-extension/subagents`. https://github.com/nodejs/node/issues/37845 */
 const SUBAGENTS_DIR = dirname(fileURLToPath(import.meta.url));
@@ -196,6 +206,9 @@ interface AgentDefaults {
   spawning?: boolean;
   autoExit?: boolean;
   interactive?: boolean;
+  timeLimitSeconds?: number;
+  idleTimeoutSeconds?: number;
+  timeoutWarnThreshold?: number;
   systemPromptMode?: "append" | "replace";
   sessionMode?: SubagentSessionMode;
   cwd?: string;
@@ -310,6 +323,11 @@ function parseAgentDefinition(content: string, fallbackName: string): AgentDefin
     spawning: parseOptionalBoolean(getFrontmatterValue(frontmatter, "spawning")),
     autoExit: parseOptionalBoolean(getFrontmatterValue(frontmatter, "auto-exit")),
     interactive: parseOptionalBoolean(getFrontmatterValue(frontmatter, "interactive")),
+    timeLimitSeconds: parsePositiveIntegerSeconds(getFrontmatterValue(frontmatter, "time-limit")),
+    idleTimeoutSeconds: parsePositiveIntegerSeconds(getFrontmatterValue(frontmatter, "idle-timeout")),
+    timeoutWarnThreshold: parseTimeoutWarnThreshold(
+      getFrontmatterValue(frontmatter, "timeout-warn-threshold"),
+    ),
     sessionMode: parseSessionMode(getFrontmatterValue(frontmatter, "session-mode")),
     cwd: getFrontmatterValue(frontmatter, "cwd"),
     cli: getFrontmatterValue(frontmatter, "cli"),
@@ -471,6 +489,20 @@ function resolveEffectiveInteractive(
   return !resolveEffectiveAutoExit(params, agentDefs);
 }
 
+function resolveTimeLimitConfig(
+  agentDefs: AgentDefaults | null,
+  interactive: boolean,
+  supportsWrapup = true,
+): TimeLimitConfig | undefined {
+  if (interactive || !agentDefs) return undefined;
+  const config: TimeLimitConfig = {
+    timeLimitSeconds: agentDefs.timeLimitSeconds,
+    idleTimeoutSeconds: agentDefs.idleTimeoutSeconds,
+    timeoutWarnThreshold: supportsWrapup ? agentDefs.timeoutWarnThreshold : undefined,
+  };
+  return config.timeLimitSeconds || config.idleTimeoutSeconds ? config : undefined;
+}
+
 function loadAgentDefaults(agentName: string): AgentDefaults | null {
   // Resolve through the same name-keyed map discoverAgentDefinitions() builds
   // for the tool-guidance catalog, so a name advertised there always resolves
@@ -527,7 +559,7 @@ const modelConfig = loadModelConfig();
 function resolveResultPresentation(
   result: Pick<
     SubagentResult,
-    "exitCode" | "elapsed" | "summary" | "sessionFile" | "errorMessage"
+    "exitCode" | "elapsed" | "summary" | "sessionFile" | "errorMessage" | "partial" | "timeout"
   >,
   name: string,
 ): string {
@@ -549,9 +581,23 @@ function resolveResultPresentation(
     );
   }
 
+  if (result.partial) {
+    return (
+      `Sub-agent "${name}" delivered a partial report under its time limit ` +
+      `(${formatElapsed(result.elapsed)}).\n\n${result.summary}${sessionRef}`
+    );
+  }
+
   return result.exitCode !== 0
     ? `Sub-agent "${name}" failed (exit code ${result.exitCode}).\n\n${result.summary}${sessionRef}`
     : `Sub-agent "${name}" completed (${formatElapsed(result.elapsed)}).\n\n${result.summary}${sessionRef}`;
+}
+
+function buildResultTimeoutDetails(result: Pick<SubagentResult, "partial" | "timeout">) {
+  return {
+    ...(result.partial ? { partial: true } : {}),
+    ...(result.timeout ? { timeout: result.timeout } : {}),
+  };
 }
 
 /**
@@ -568,6 +614,9 @@ interface SubagentResult {
   error?: string;
   /** Provider/agent error message when auto-retry exhausted (overload, rate limit, etc.). */
   errorMessage?: string;
+  /** A normal completion produced by the one-shot time-limit report continuation. */
+  partial?: boolean;
+  timeout?: "warned-wrapup" | "hard-stop";
   ping?: { name: string; message: string };
 }
 
@@ -593,7 +642,12 @@ interface RunningSubagent {
   abortController?: AbortController;
   recovery?: RecoveryState;
   recoveryKilled?: { errorMessage: string; killedAt: number };
-  /** Reserved for the L-96 report-only continuation. */
+  timeLimit?: TimeLimitConfig;
+  timeLimitWarned?: boolean;
+  /** The deadline fixed at warning time so fresh report activity cannot extend an idle limit. */
+  timeLimitDeadlineAt?: number;
+  timeLimitStopped?: { errorMessage: string; stoppedAt: number };
+  /** A report-only continuation has been requested and awaits its normal completion. */
   wrapupPending?: boolean;
   cli?: string;
   sentinelFile?: string;
@@ -626,6 +680,17 @@ const DEFAULT_RECOVERY_PANE_OPERATIONS: RecoveryPaneOperations = {
   interruptPane,
   closePane,
   abortWatcher: (controller) => controller?.abort(),
+};
+
+interface TimeLimitPaneOperations extends RecoveryPaneOperations {
+  writeWrapup: (sessionFile: string) => void;
+  removeWrapup: (sessionFile: string) => void;
+}
+
+const DEFAULT_TIME_LIMIT_PANE_OPERATIONS: TimeLimitPaneOperations = {
+  ...DEFAULT_RECOVERY_PANE_OPERATIONS,
+  writeWrapup: writeWrapupDirective,
+  removeWrapup: cleanupWrapupDirective,
 };
 
 interface SubagentRuntime {
@@ -1005,7 +1070,10 @@ function advanceRunningRecovery(
   const advance = advanceRecoveryLadder(running.recovery, {
     now,
     stalled: projection.kind === "stalled",
-    exempt: running.interactive || running.wrapupPending === true,
+    exempt:
+      running.interactive ||
+      running.wrapupPending === true ||
+      running.timeLimitStopped != null,
     delays,
   });
   running.recovery = advance.state;
@@ -1035,6 +1103,94 @@ function buildRecoveryKilledResult(running: RunningSubagent, now: number): Subag
     elapsed: Math.floor(Math.max(0, now - running.startTime) / 1000),
     error: recoveryKilled.errorMessage,
     errorMessage: recoveryKilled.errorMessage,
+  };
+}
+
+function advanceRunningTimeLimit(
+  running: RunningSubagent,
+  now: number,
+  operations: TimeLimitPaneOperations = DEFAULT_TIME_LIMIT_PANE_OPERATIONS,
+): { action: "warn" | "hard-stop" | null } {
+  if (
+    running.interactive ||
+    !running.timeLimit ||
+    running.recoveryKilled ||
+    running.timeLimitStopped
+  ) {
+    return { action: null };
+  }
+
+  const lastActivityAt = running.activity?.updatedAt;
+  const action = running.timeLimitDeadlineAt != null
+    ? now >= running.timeLimitDeadlineAt ? "hard-stop" : "none"
+    : evalTimeLimit(
+      now,
+      running.startTime,
+      lastActivityAt,
+      running.timeLimit,
+      running.timeLimitWarned === true,
+    );
+
+  if (action === "warn") {
+    try {
+      operations.writeWrapup(running.sessionFile);
+    } catch {
+      return { action: null };
+    }
+    const interruption = requestSubagentInterrupt(running, operations.interruptPane);
+    if ("error" in interruption) {
+      try {
+        operations.removeWrapup(running.sessionFile);
+      } catch {}
+      return { action: null };
+    }
+
+    running.timeLimitWarned = true;
+    running.wrapupPending = true;
+    running.timeLimitDeadlineAt = getTimeLimitDeadlineAt(
+      running.startTime,
+      lastActivityAt,
+      running.timeLimit,
+    );
+    running.lifecycle = markInterruptRequested(ensureLifecycle(running), now);
+    return { action: "warn" };
+  }
+
+  if (action === "hard-stop") {
+    const error = formatTimeLimitError(now - running.startTime);
+    const stopped = failAndTeardownSubagent(running, error, now, operations, () => {
+      running.timeLimitStopped = { errorMessage: error, stoppedAt: now };
+      running.wrapupPending = false;
+      try {
+        operations.removeWrapup(running.sessionFile);
+      } catch {}
+    });
+    return { action: stopped ? "hard-stop" : null };
+  }
+
+  return { action: null };
+}
+
+function buildTimeLimitStoppedResult(running: RunningSubagent, now: number): SubagentResult | null {
+  const stopped = running.timeLimitStopped;
+  if (!stopped) return null;
+
+  let tail: string | null = null;
+  try {
+    if (existsSync(running.sessionFile)) {
+      tail = findLastAssistantMessage(getNewEntries(running.sessionFile, 0));
+    }
+  } catch {}
+
+  return {
+    name: running.name,
+    task: running.task,
+    summary: `${stopped.errorMessage}${tail ? `\n\nLast session output:\n${tail}` : ""}`,
+    sessionFile: running.sessionFile,
+    exitCode: 1,
+    elapsed: Math.floor(Math.max(0, now - running.startTime) / 1_000),
+    error: stopped.errorMessage,
+    timeout: "hard-stop",
   };
 }
 
@@ -1170,6 +1326,8 @@ export const __test__ = {
   resolveLaunchBehavior,
   resolveEffectiveAutoExit,
   resolveEffectiveInteractive,
+  resolveTimeLimitConfig,
+  parseAgentDefinition,
   buildSubagentToolAllowlist,
   buildPiPromptArgs,
   observeRunningSubagent,
@@ -1179,6 +1337,9 @@ export const __test__ = {
   failAndTeardownSubagent,
   advanceRunningRecovery,
   buildRecoveryKilledResult,
+  advanceRunningTimeLimit,
+  buildTimeLimitStoppedResult,
+  buildResultTimeoutDetails,
   handleSubagentInterrupt,
   resolveResultPresentation,
   resolveResumeLaunchBehavior,
@@ -1234,6 +1395,9 @@ async function launchSubagent(
   const effectiveThinking = runtimePlan.thinking;
   const effectiveAutoExit = resolveEffectiveAutoExit(params, agentDefs);
   const effectiveInteractive = resolveEffectiveInteractive(params, agentDefs);
+  const cliId = agentDefs?.cli ?? "pi";
+  const driver = getHarnessDriver(cliId);
+  const timeLimit = resolveTimeLimitConfig(agentDefs, effectiveInteractive, driver.id === "pi");
 
   const sessionFile = ctx.sessionManager.getSessionFile();
   if (!sessionFile) throw new Error("No session file");
@@ -1256,8 +1420,6 @@ async function launchSubagent(
   ].join("-");
   const subagentSessionFile = join(sessionDir, `${timestamp}_${uuid}.jsonl`);
 
-  const cliId = agentDefs?.cli ?? "pi";
-  const driver = getHarnessDriver(cliId);
   driver.validateRuntimePlan?.(runtimePlan, parentThinking);
 
   const surfacePreCreated = !!options?.surface;
@@ -1361,6 +1523,7 @@ async function launchSubagent(
     interactive: effectiveInteractive,
     runtimePlan,
     activityFile: driver.hasActivitySnapshots ? activityFile : undefined,
+    timeLimit,
     lifecycle: !driver.hasActivitySnapshots
       ? markProcessRunning(createLifecycle(startTime), Date.now())
       : createLifecycle(startTime),
@@ -1394,11 +1557,18 @@ async function watchSubagent(
         updateWidget();
       },
       onTick() {
-        observeRunningSubagent(running);
+        const now = Date.now();
+        observeRunningSubagent(running, now);
+        if (advanceRunningTimeLimit(running, now).action) updateWidget();
       },
     });
 
     const detectedAt = Date.now();
+    const timeLimitResult = buildTimeLimitStoppedResult(running, detectedAt);
+    if (timeLimitResult) {
+      updateWidget();
+      return timeLimitResult;
+    }
     const recoveryResult = buildRecoveryKilledResult(running, detectedAt);
     if (recoveryResult) {
       updateWidget();
@@ -1432,6 +1602,7 @@ async function watchSubagent(
           exitCode: result.exitCode,
           elapsed,
           ...(extracted.sessionId ? { claudeSessionId: extracted.sessionId } : {}),
+          ...(result.wrapup ? { partial: true, timeout: "warned-wrapup" as const } : {}),
           ...extracted.details,
         };
       }
@@ -1495,10 +1666,16 @@ async function watchSubagent(
       exitCode: result.exitCode,
       elapsed,
       ping: result.ping,
+      ...(result.wrapup ? { partial: true, timeout: "warned-wrapup" as const } : {}),
       ...(result.errorMessage ? { errorMessage: result.errorMessage } : {}),
     };
   } catch (err: any) {
     const now = Date.now();
+    const timeLimitResult = buildTimeLimitStoppedResult(running, now);
+    if (timeLimitResult) {
+      updateWidget();
+      return timeLimitResult;
+    }
     const recoveryResult = buildRecoveryKilledResult(running, now);
     if (recoveryResult) {
       running.lifecycle = markFailed(running.lifecycle, recoveryResult.errorMessage!, now, 1);
@@ -1536,6 +1713,8 @@ async function watchSubagent(
       elapsed: Math.floor((now - startTime) / 1000),
       error: err?.message ?? String(err),
     };
+  } finally {
+    cleanupWrapupDirective(sessionFile);
   }
 }
 
@@ -1717,6 +1896,7 @@ export default function subagentsExtension(pi: ExtensionAPI) {
                   exitCode: result.exitCode,
                   elapsed: result.elapsed,
                   sessionFile: result.sessionFile,
+                  ...buildResultTimeoutDetails(result),
                   ...(result.errorMessage ? { errorMessage: result.errorMessage } : {}),
                   ...(result.claudeSessionId ? { claudeSessionId: result.claudeSessionId } : {}),
                   ...(running.runtimePlan ? { runtimePlan: running.runtimePlan } : {}),
@@ -2179,6 +2359,7 @@ export default function subagentsExtension(pi: ExtensionAPI) {
                   exitCode: result.exitCode,
                   elapsed: result.elapsed,
                   sessionFile: params.sessionPath,
+                  ...buildResultTimeoutDetails(result),
                   ...(result.errorMessage ? { errorMessage: result.errorMessage } : {}),
                   ...(running.runtimePlan ? { runtimePlan: running.runtimePlan } : {}),
                 },
@@ -2273,18 +2454,25 @@ export default function subagentsExtension(pi: ExtensionAPI) {
         const exitCode = details.exitCode ?? 0;
         const errorMessage = typeof details.errorMessage === "string" ? details.errorMessage : "";
         const failed = exitCode !== 0 || !!errorMessage;
+        const partial = !failed && (details.partial === true || details.timeout === "warned-wrapup");
         const elapsed = details.elapsed != null ? formatElapsed(details.elapsed) : "?";
         const bgFn = failed
           ? (text: string) => theme.bg("toolErrorBg", text)
-          : (text: string) => theme.bg("toolSuccessBg", text);
+          : partial
+            ? (text: string) => theme.bg("customMessageBg", text)
+            : (text: string) => theme.bg("toolSuccessBg", text);
         const icon = failed
           ? theme.fg("error", "✗")
-          : theme.fg("success", "✓");
+          : partial
+            ? theme.fg("warning", "⚠")
+            : theme.fg("success", "✓");
         const status = errorMessage
           ? "failed (provider/agent error)"
           : failed
             ? `failed (exit ${exitCode})`
-            : "completed";
+            : partial
+              ? "partial report (time limit)"
+              : "completed";
         const agentTag = details.agent ? theme.fg("dim", ` (${details.agent})`) : "";
 
         const header = `${icon} ${theme.fg("toolTitle", theme.bold(name))}${agentTag} ${theme.fg("dim", "—")} ${status} ${theme.fg("dim", `(${elapsed})`)}`;

--- a/pi-extension/subagents/lifecycle.ts
+++ b/pi-extension/subagents/lifecycle.ts
@@ -1,5 +1,6 @@
 import type { ActivityReadResult, SubagentActivityScope } from "./activity.ts";
 import type { CompletionResult } from "./completion.ts";
+import { DEFAULT_ACTIVE_TOOL_STALL_MS } from "./recovery.ts";
 
 export type HerdrAgentStatus =
   | "idle"
@@ -387,7 +388,11 @@ export function markDelivery(lifecycle: SubagentLifecycle, delivery: CompletionD
   return { ...lifecycle, delivery };
 }
 
-export function projectLifecycle(lifecycle: SubagentLifecycle, now: number): LifecycleProjection {
+export function projectLifecycle(
+  lifecycle: SubagentLifecycle,
+  now: number,
+  opts?: { activeToolStallMs?: number },
+): LifecycleProjection {
   const process = lifecycle.process;
   if (process.kind === "finalizing") return { kind: "finalizing", runtimeEndedAt: process.detectedAt };
   if (process.kind === "completed") return { kind: "completed", runtimeEndedAt: process.completedAt };
@@ -407,6 +412,18 @@ export function projectLifecycle(lifecycle: SubagentLifecycle, now: number): Lif
     case "interrupted":
       return { kind: "interrupted", stateDurationSince: turn.requestedAt };
     case "active": {
+      // A child wedged in one tool call keeps phase=active but stops emitting
+      // events, so a tool-scope detail older than the stall window counts as
+      // stalled; stateDurationSince = last activity so duration == silence.
+      const activeToolStallMs = opts?.activeToolStallMs ?? DEFAULT_ACTIVE_TOOL_STALL_MS;
+      if (
+        turn.activity?.kind === "scope" &&
+        turn.activity.scope === "tool" &&
+        activeToolStallMs > 0 &&
+        now - turn.activity.observedAt >= activeToolStallMs
+      ) {
+        return { kind: "stalled", stateDurationSince: turn.activity.observedAt };
+      }
       if (turn.activity?.kind === "scope") {
         const label = turn.activity.label ?? turn.activity.scope;
         return { kind: "active", label, stateDurationSince: turn.startedAt };

--- a/pi-extension/subagents/recovery.ts
+++ b/pi-extension/subagents/recovery.ts
@@ -1,0 +1,61 @@
+export const MIN_RECOVERY_DELAY_MS = 10_000;
+export const DEFAULT_RECOVERY_DELAYS = [30_000, 60_000, 90_000] as const;
+
+export type RecoveryDelays = readonly [number, number, number];
+export type RecoveryStage = "waiting" | "nudged" | "escalated" | "killed";
+export type RecoveryAction = "nudge" | "escalate" | "kill" | null;
+
+export interface RecoveryState {
+  stage: RecoveryStage;
+  stageSince: number;
+}
+
+export interface RecoveryAdvance {
+  state: RecoveryState | undefined;
+  action: RecoveryAction;
+}
+
+function defaultRecoveryDelays(): RecoveryDelays {
+  return [...DEFAULT_RECOVERY_DELAYS];
+}
+
+/** Parse PI_SUBAGENT_RECOVERY_DELAYS_MS without reading process.env. */
+export function parseRecoveryDelays(raw: string | undefined): RecoveryDelays {
+  const parts = raw?.split(",").map((part) => part.trim());
+  if (!parts || parts.length !== 3 || parts.some((part) => !part)) {
+    return defaultRecoveryDelays();
+  }
+
+  const values = parts.map(Number);
+  if (values.some((value) => !Number.isSafeInteger(value))) {
+    return defaultRecoveryDelays();
+  }
+
+  return values.map((value) => Math.max(MIN_RECOVERY_DELAY_MS, value)) as RecoveryDelays;
+}
+
+/** Advance one stalled-child recovery tick using the caller's clock. */
+export function advanceRecoveryLadder(
+  state: RecoveryState | undefined,
+  input: { now: number; stalled: boolean; exempt: boolean; delays: RecoveryDelays },
+): RecoveryAdvance {
+  if (state?.stage === "killed") return { state, action: null };
+  if (!input.stalled || input.exempt) return { state: undefined, action: null };
+  if (!state) return { state: { stage: "waiting", stageSince: input.now }, action: null };
+
+  const elapsed = Math.max(0, input.now - state.stageSince);
+  if (state.stage === "waiting" && elapsed >= input.delays[0]) {
+    return { state: { stage: "nudged", stageSince: input.now }, action: "nudge" };
+  }
+  if (state.stage === "nudged" && elapsed >= input.delays[1]) {
+    return { state: { stage: "escalated", stageSince: input.now }, action: "escalate" };
+  }
+  if (state.stage === "escalated" && elapsed >= input.delays[2]) {
+    return { state: { stage: "killed", stageSince: input.now }, action: "kill" };
+  }
+  return { state, action: null };
+}
+
+export function formatRecoveryKillError(elapsedMs: number): string {
+  return `Subagent recovery-kill after ${Math.floor(Math.max(0, elapsedMs) / 1000)}s.`;
+}

--- a/pi-extension/subagents/recovery.ts
+++ b/pi-extension/subagents/recovery.ts
@@ -19,6 +19,17 @@ function defaultRecoveryDelays(): RecoveryDelays {
   return [...DEFAULT_RECOVERY_DELAYS];
 }
 
+export const DEFAULT_ACTIVE_TOOL_STALL_MS = 600_000;
+
+/** Parse PI_SUBAGENT_ACTIVE_TOOL_STALL_MS without reading process.env; 0 disables. */
+export function parseActiveToolStallMs(raw: string | undefined): number {
+  const trimmed = raw?.trim();
+  if (!trimmed) return DEFAULT_ACTIVE_TOOL_STALL_MS;
+  const value = Number(trimmed);
+  if (!Number.isSafeInteger(value) || value < 0) return DEFAULT_ACTIVE_TOOL_STALL_MS;
+  return value;
+}
+
 /** Parse PI_SUBAGENT_RECOVERY_DELAYS_MS without reading process.env. */
 export function parseRecoveryDelays(raw: string | undefined): RecoveryDelays {
   const parts = raw?.split(",").map((part) => part.trim());

--- a/pi-extension/subagents/subagent-done.ts
+++ b/pi-extension/subagents/subagent-done.ts
@@ -8,6 +8,7 @@ import { Box, Text } from "@earendil-works/pi-tui";
 import { Type } from "@sinclair/typebox";
 import { writeFileSync } from "node:fs";
 import { createSubagentActivityRecorder } from "./activity.ts";
+import { consumeWrapupDirective } from "./time-limits.ts";
 
 export function shouldMarkUserTookOver(agentStarted: boolean): boolean {
   return agentStarted;
@@ -68,11 +69,19 @@ export function findLatestAssistantError(
   return null;
 }
 
-export function buildCompletionSidecar(messages: any[] | undefined):
-  | { type: "done" }
+export function buildCompletionSidecar(messages: any[] | undefined, wrapup = false):
+  | { type: "done"; wrapup?: true }
   | { type: "error"; errorMessage: string; stopReason: "error" } {
   const errorInfo = findLatestAssistantError(messages);
-  return errorInfo ? { type: "error", ...errorInfo } : { type: "done" };
+  return errorInfo ? { type: "error", ...errorInfo } : { type: "done", ...(wrapup ? { wrapup: true } : {}) };
+}
+
+export function latestAssistantWasAborted(messages: any[] | undefined): boolean {
+  if (!messages) return false;
+  for (let i = messages.length - 1; i >= 0; i--) {
+    if (messages[i]?.role === "assistant") return messages[i].stopReason === "aborted";
+  }
+  return false;
 }
 
 export function parseDeniedTools(rawValue: string | undefined): string[] {
@@ -151,6 +160,7 @@ export default function (pi: ExtensionAPI) {
   let userTookOver = false;
   let agentStarted = false;
   let latestAgentMessages: any[] | undefined;
+  let wrapupInProgress = false;
 
   // Show widget + status bar on session start
   pi.on("session_start", (_event, ctx) => {
@@ -162,8 +172,11 @@ export default function (pi: ExtensionAPI) {
     renderWidget(ctx, null);
   });
 
-  pi.on("input", () => {
+  pi.on("input", (event) => {
     recorder.input();
+    // Extension-injected report directives are not operator takeover. This keeps
+    // the report-only continuation compatible with sticky auto-exit disarming.
+    if ((event as any).source === "extension") return;
     // Ignore the initial task message that starts an autonomous subagent.
     // Only inputs after the first agent run has started count as user takeover.
     if (!shouldMarkUserTookOver(agentStarted)) return;
@@ -188,19 +201,30 @@ export default function (pi: ExtensionAPI) {
   });
 
   pi.on("agent_settled", (_event, ctx) => {
-    const shouldExit = autoExit
-      && shouldAutoExitOnAgentEnd(userTookOver, latestAgentMessages);
+    const sessionFile = process.env.PI_SUBAGENT_SESSION;
+    const directive = !wrapupInProgress && latestAssistantWasAborted(latestAgentMessages)
+      ? consumeWrapupDirective(sessionFile)
+      : null;
+    if (directive) {
+      wrapupInProgress = true;
+      // This creates an extension-sourced turn; it is not text typed into the pane.
+      pi.sendUserMessage(directive);
+      return;
+    }
+
+    const shouldExit =
+      (autoExit && shouldAutoExitOnAgentEnd(userTookOver, latestAgentMessages)) ||
+      (wrapupInProgress && !latestAssistantWasAborted(latestAgentMessages));
 
     if (shouldExit) {
       // Surface stopReason: "error" turns (auto-retry exhausted, provider
       // overload, etc.) to the parent via the .exit sidecar so the watcher
       // can report a clear failure with the underlying error message.
-      const sessionFile = process.env.PI_SUBAGENT_SESSION;
       if (sessionFile) {
         try {
           writeFileSync(
             `${sessionFile}.exit`,
-            JSON.stringify(buildCompletionSidecar(latestAgentMessages)),
+            JSON.stringify(buildCompletionSidecar(latestAgentMessages, wrapupInProgress)),
           );
         } catch {
           // Best effort — the watcher can still detect the terminal sentinel
@@ -320,7 +344,10 @@ export default function (pi: ExtensionAPI) {
       const sessionFile = process.env.PI_SUBAGENT_SESSION;
       recorder.subagentDone();
       if (sessionFile) {
-        writeFileSync(`${sessionFile}.exit`, JSON.stringify({ type: "done" }));
+        writeFileSync(
+          `${sessionFile}.exit`,
+          JSON.stringify({ type: "done", ...(wrapupInProgress ? { wrapup: true } : {}) }),
+        );
       }
       ctx.shutdown();
       return {

--- a/pi-extension/subagents/time-limits.ts
+++ b/pi-extension/subagents/time-limits.ts
@@ -1,0 +1,134 @@
+import { existsSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+
+export interface TimeLimitConfig {
+  timeLimitSeconds?: number;
+  idleTimeoutSeconds?: number;
+  timeoutWarnThreshold?: number;
+}
+
+export type TimeLimitAction = "none" | "warn" | "hard-stop";
+
+export const REPORT_ONLY_WRAPUP_DIRECTIVE =
+  "Your time limit is nearly exhausted. Do not continue implementation or use tools. " +
+  "Provide a concise final partial report with completed work, remaining work, and blockers.";
+
+export interface WrapupFileOperations {
+  exists(file: string): boolean;
+  read(file: string): string;
+  write(file: string, content: string): void;
+  remove(file: string): void;
+}
+
+const DEFAULT_WRAPUP_FILE_OPERATIONS: WrapupFileOperations = {
+  exists: existsSync,
+  read: (file) => readFileSync(file, "utf8"),
+  write: (file, content) => writeFileSync(file, content, "utf8"),
+  remove: (file) => rmSync(file, { force: true }),
+};
+
+export function parsePositiveIntegerSeconds(value: string | undefined): number | undefined {
+  if (!value || !/^[1-9]\d*$/.test(value)) return undefined;
+  const seconds = Number(value);
+  return Number.isSafeInteger(seconds) ? seconds : undefined;
+}
+
+export function parseTimeoutWarnThreshold(value: string | undefined): number | undefined {
+  if (!value) return undefined;
+  const threshold = Number(value);
+  return Number.isFinite(threshold) && threshold > 0 && threshold < 1 ? threshold : undefined;
+}
+
+function deadlineAt(start: number, seconds: number | undefined): number | undefined {
+  if (!Number.isFinite(start) || !Number.isFinite(seconds) || seconds <= 0) return undefined;
+  const deadline = start + seconds * 1_000;
+  return Number.isFinite(deadline) ? deadline : undefined;
+}
+
+function earlierDeadline(...deadlines: Array<number | undefined>): number | undefined {
+  const valid = deadlines.filter((deadline): deadline is number => deadline != null);
+  return valid.length > 0 ? Math.min(...valid) : undefined;
+}
+
+/** The earliest hard deadline; idle limits require a child activity timestamp. */
+export function getTimeLimitDeadlineAt(
+  startTime: number,
+  lastActivityAt: number | undefined,
+  config: TimeLimitConfig,
+): number | undefined {
+  return earlierDeadline(
+    deadlineAt(startTime, config.timeLimitSeconds),
+    Number.isFinite(lastActivityAt) ? deadlineAt(lastActivityAt!, config.idleTimeoutSeconds) : undefined,
+  );
+}
+
+function getWarnDeadlineAt(
+  startTime: number,
+  lastActivityAt: number | undefined,
+  config: TimeLimitConfig,
+): number | undefined {
+  const threshold = config.timeoutWarnThreshold;
+  if (!Number.isFinite(threshold) || threshold! <= 0 || threshold! >= 1) return undefined;
+  return earlierDeadline(
+    deadlineAt(startTime, config.timeLimitSeconds == null ? undefined : config.timeLimitSeconds * threshold!),
+    Number.isFinite(lastActivityAt)
+      ? deadlineAt(lastActivityAt!, config.idleTimeoutSeconds == null ? undefined : config.idleTimeoutSeconds * threshold!)
+      : undefined,
+  );
+}
+
+/** Evaluate a single tick using only caller-supplied time and state. */
+export function evalTimeLimit(
+  now: number,
+  startTime: number,
+  lastActivityAt: number | undefined,
+  config: TimeLimitConfig,
+  warned = false,
+): TimeLimitAction {
+  const hardDeadline = getTimeLimitDeadlineAt(startTime, lastActivityAt, config);
+  if (hardDeadline != null && now >= hardDeadline) return "hard-stop";
+  if (warned) return "none";
+  const warnDeadline = getWarnDeadlineAt(startTime, lastActivityAt, config);
+  return warnDeadline != null && now >= warnDeadline ? "warn" : "none";
+}
+
+export function wrapupDirectiveFile(sessionFile: string): string {
+  return `${sessionFile}.wrapup`;
+}
+
+export function writeWrapupDirective(
+  sessionFile: string,
+  operations: WrapupFileOperations = DEFAULT_WRAPUP_FILE_OPERATIONS,
+): void {
+  operations.write(wrapupDirectiveFile(sessionFile), REPORT_ONLY_WRAPUP_DIRECTIVE);
+}
+
+/** Consume the one-shot parent directive before starting the report-only turn. */
+export function consumeWrapupDirective(
+  sessionFile: string | undefined,
+  operations: WrapupFileOperations = DEFAULT_WRAPUP_FILE_OPERATIONS,
+): string | null {
+  if (!sessionFile) return null;
+  const file = wrapupDirectiveFile(sessionFile);
+  if (!operations.exists(file)) return null;
+  try {
+    const directive = operations.read(file).trim();
+    operations.remove(file);
+    return directive || null;
+  } catch {
+    return null;
+  }
+}
+
+export function cleanupWrapupDirective(
+  sessionFile: string | undefined,
+  operations: Pick<WrapupFileOperations, "remove"> = DEFAULT_WRAPUP_FILE_OPERATIONS,
+): void {
+  if (!sessionFile) return;
+  try {
+    operations.remove(wrapupDirectiveFile(sessionFile));
+  } catch {}
+}
+
+export function formatTimeLimitError(elapsedMs: number): string {
+  return `Subagent timed out after ${Math.floor(Math.max(0, elapsedMs) / 1_000)}s.`;
+}

--- a/test/harness-drivers.test.ts
+++ b/test/harness-drivers.test.ts
@@ -134,6 +134,10 @@ describe("Pi Harness Driver", () => {
     assert.ok(built.command.includes("pi --session '/tmp/sessions/subagent.jsonl'"));
     assert.ok(built.command.includes("--model 'anthropic/claude-sonnet-4-5'"));
     assert.ok(built.command.includes("--thinking 'high'"));
+    assert.ok(
+      built.command.includes("PI_SUBAGENT_ACTIVITY_FILE='/tmp/artifacts/subagent-activity/abc12345.json'"),
+      "the child and parent must use the same activity file for idle-timeout supervision",
+    );
     assert.ok(built.command.includes("echo '__SUBAGENT_DONE_'$?'__'"));
   });
 });

--- a/test/recovery-ladder.test.ts
+++ b/test/recovery-ladder.test.ts
@@ -1,0 +1,211 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import * as subagentsModule from "../pi-extension/subagents/index.ts";
+import {
+  DEFAULT_RECOVERY_DELAYS,
+  advanceRecoveryLadder,
+  parseRecoveryDelays,
+  type RecoveryState,
+} from "../pi-extension/subagents/recovery.ts";
+import {
+  createLifecycle,
+  observeActivity,
+  observePaneInspection,
+  projectLifecycle,
+} from "../pi-extension/subagents/lifecycle.ts";
+
+const delays = [30_000, 60_000, 90_000] as const;
+
+function makeRunning(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "child-1",
+    name: "Worker",
+    task: "Recover the provider failure",
+    surface: "pane-1",
+    startTime: 0,
+    sessionFile: "/tmp/worker.jsonl",
+    interactive: false,
+    lifecycle: createLifecycle(0),
+    ...overrides,
+  };
+}
+
+describe("recovery delay parsing", () => {
+  it("uses defaults for missing or malformed values and clamps short stages", () => {
+    for (const [raw, expected] of [
+      [undefined, DEFAULT_RECOVERY_DELAYS],
+      ["", DEFAULT_RECOVERY_DELAYS],
+      ["30000,60000", DEFAULT_RECOVERY_DELAYS],
+      ["30000,wat,90000", DEFAULT_RECOVERY_DELAYS],
+      ["30000,60000,90000,120000", DEFAULT_RECOVERY_DELAYS],
+      ["30000,60000,90000.5", DEFAULT_RECOVERY_DELAYS],
+      [" 12000, 22000, 32000 ", [12_000, 22_000, 32_000]],
+      ["1,9999,-2", [10_000, 10_000, 10_000]],
+    ] as const) {
+      assert.deepEqual(parseRecoveryDelays(raw), expected, String(raw));
+    }
+  });
+});
+
+describe("recovery ladder", () => {
+  it("advances wait, nudge, escalation, and kill from injected fake-clock ticks", () => {
+    let now = 0;
+    let state: RecoveryState | undefined;
+    const tick = (nextNow: number, stalled = true, exempt = false) => {
+      now = nextNow;
+      const advance = advanceRecoveryLadder(state, { now, stalled, exempt, delays });
+      state = advance.state;
+      return advance;
+    };
+
+    assert.deepEqual(tick(0), { state: { stage: "waiting", stageSince: 0 }, action: null });
+    assert.equal(tick(29_999).action, null);
+    assert.deepEqual(tick(30_000), { state: { stage: "nudged", stageSince: 30_000 }, action: "nudge" });
+    assert.equal(tick(30_001).action, null);
+    assert.equal(tick(89_999).action, null);
+    assert.deepEqual(tick(90_000), { state: { stage: "escalated", stageSince: 90_000 }, action: "escalate" });
+    assert.equal(tick(179_999).action, null);
+    assert.deepEqual(tick(180_000), { state: { stage: "killed", stageSince: 180_000 }, action: "kill" });
+    assert.equal(tick(999_999).action, null, "terminal recovery state must be a no-op");
+  });
+
+  it("uses injected pane operations, tears down once, and reports recovery-kill as a failure", () => {
+    const testApi = (subagentsModule as any).__test__;
+    const running = makeRunning({
+      abortController: {
+        abort() {
+          aborts += 1;
+        },
+      },
+    });
+    let nudges = 0;
+    let closes = 0;
+    let aborts = 0;
+    const operations = {
+      interruptPane(surface: string) {
+        assert.equal(surface, "pane-1");
+        nudges += 1;
+      },
+      closePane(surface: string) {
+        assert.equal(surface, "pane-1");
+        closes += 1;
+      },
+      abortWatcher() {
+        assert.match(running.recoveryKilled?.errorMessage ?? "", /recovery-kill after 180s/);
+        running.abortController.abort();
+      },
+    };
+
+    for (const now of [0, 30_000, 90_000, 180_000]) {
+      testApi.advanceRunningRecovery(running, { kind: "stalled" }, now, delays, operations);
+    }
+
+    assert.equal(nudges, 1);
+    assert.equal(closes, 1);
+    assert.equal(aborts, 1);
+    assert.equal(running.recovery.stage, "killed");
+    assert.equal(running.lifecycle.process.kind, "failed");
+    assert.match(running.lifecycle.process.error, /recovery-kill after 180s/);
+
+    const result = testApi.buildRecoveryKilledResult(running, 180_001);
+    assert.equal(result.exitCode, 1);
+    assert.equal(result.error, running.lifecycle.process.error);
+    assert.match(result.errorMessage, /recovery-kill after 180s/);
+    assert.match(result.summary, /recovery-kill/);
+    assert.doesNotMatch(result.summary, /cancelled|wrap-up|completed/i);
+
+    const presentation = testApi.resolveResultPresentation(result, running.name);
+    assert.match(presentation, /failed/);
+    assert.doesNotMatch(presentation, /completed/);
+
+    const repeated = testApi.advanceRunningRecovery(running, { kind: "stalled" }, 999_999, delays, operations);
+    assert.equal(repeated.action, null, "terminal recovery state must not produce a duplicate result");
+    assert.equal(closes, 1, "repeated ticks must not close a pane twice");
+    assert.equal(aborts, 1, "repeated ticks must not abort twice");
+    running.lifecycle = { ...running.lifecycle, delivery: "delivered" };
+    assert.equal(subagentsModule.shouldDeliverSubagentCompletion(running), false);
+  });
+
+  it("does not arm interactive or wrap-up children", () => {
+    const testApi = (subagentsModule as any).__test__;
+    for (const overrides of [{ interactive: true }, { wrapupPending: true }]) {
+      const running = makeRunning(overrides);
+      let paneCalls = 0;
+      const advance = testApi.advanceRunningRecovery(
+        running,
+        { kind: "stalled" },
+        1_000_000,
+        delays,
+        {
+          interruptPane() {
+            paneCalls += 1;
+          },
+          closePane() {
+            paneCalls += 1;
+          },
+          abortWatcher() {
+            paneCalls += 1;
+          },
+        },
+      );
+      assert.equal(advance.action, null);
+      assert.equal(running.recovery, undefined);
+      assert.equal(paneCalls, 0);
+    }
+  });
+
+  it("never advances healthy tool, streaming, or provider activity despite long runtime", () => {
+    const testApi = (subagentsModule as any).__test__;
+    for (const scope of ["tool", "streaming", "provider"] as const) {
+      const now = 1_000_000;
+      let lifecycle = createLifecycle(0);
+      lifecycle = observePaneInspection(lifecycle, {
+        kind: "present",
+        observedAt: now,
+        agentStatus: "working",
+      }, now);
+      lifecycle = observeActivity(lifecycle, {
+        ok: true,
+        activity: {
+          version: 1,
+          runningChildId: "child-1",
+          createdAt: 0,
+          updatedAt: now,
+          sequence: 1,
+          latestEvent: "agent_start",
+          phase: "active",
+          agentActive: true,
+          turnActive: true,
+          providerActive: scope === "provider",
+          toolActive: scope === "tool",
+          activeScope: scope,
+          activeSince: now,
+          ...(scope === "tool" ? { toolName: "bash", toolStartedAt: now } : {}),
+        },
+      }, now);
+      const projection = projectLifecycle(lifecycle, now + 1);
+      assert.equal(projection.kind, "active", scope);
+
+      const running = makeRunning({ lifecycle });
+      const advance = testApi.advanceRunningRecovery(
+        running,
+        projection,
+        now + delays[0] + delays[1] + delays[2] + 1,
+        delays,
+        {
+          interruptPane() {
+            throw new Error("healthy activity must not be nudged");
+          },
+          closePane() {
+            throw new Error("healthy activity must not be killed");
+          },
+          abortWatcher() {
+            throw new Error("healthy activity must not be aborted");
+          },
+        },
+      );
+      assert.equal(advance.action, null, scope);
+      assert.equal(running.recovery, undefined, scope);
+    }
+  });
+});

--- a/test/stale-active-stall.test.ts
+++ b/test/stale-active-stall.test.ts
@@ -1,0 +1,193 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import * as subagentsModule from "../pi-extension/subagents/index.ts";
+import { DEFAULT_ACTIVE_TOOL_STALL_MS, parseActiveToolStallMs } from "../pi-extension/subagents/recovery.ts";
+import {
+  createLifecycle,
+  lifecycleTransition,
+  observeActivity,
+  observePaneInspection,
+  projectLifecycle,
+} from "../pi-extension/subagents/lifecycle.ts";
+
+const delays = [30_000, 60_000, 90_000] as const;
+
+function makeRunning(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "child-1",
+    name: "Worker",
+    task: "Run the hung tool",
+    surface: "pane-1",
+    startTime: 0,
+    sessionFile: "/tmp/worker.jsonl",
+    interactive: false,
+    lifecycle: createLifecycle(0),
+    ...overrides,
+  };
+}
+
+function toolActivity(observedAt: number, sequence = 1) {
+  return {
+    ok: true as const,
+    activity: {
+      version: 1 as const,
+      runningChildId: "child-1",
+      createdAt: 0,
+      updatedAt: observedAt,
+      sequence,
+      latestEvent: "tool_execution_start" as const,
+      phase: "active" as const,
+      agentActive: true,
+      turnActive: true,
+      providerActive: false,
+      toolActive: true,
+      activeScope: "tool" as const,
+      activeSince: observedAt,
+      toolName: "bash",
+      toolStartedAt: observedAt,
+    },
+  };
+}
+
+function scopeActivity(scope: "provider" | "streaming" | "agent", observedAt: number) {
+  return {
+    ok: true as const,
+    activity: {
+      version: 1 as const,
+      runningChildId: "child-1",
+      createdAt: 0,
+      updatedAt: observedAt,
+      sequence: 1,
+      latestEvent: "agent_start" as const,
+      phase: "active" as const,
+      agentActive: true,
+      turnActive: true,
+      providerActive: scope === "provider",
+      toolActive: false,
+      activeScope: scope,
+      activeSince: observedAt,
+    },
+  };
+}
+
+/** Lifecycle whose turn is active on a tool-scope detail observed at `observedAt`. */
+function activeToolLifecycle(observedAt: number, sequence = 1) {
+  let lifecycle = createLifecycle(0);
+  lifecycle = observePaneInspection(lifecycle, {
+    kind: "present",
+    observedAt,
+    agentStatus: "working",
+  }, observedAt);
+  return observeActivity(lifecycle, toolActivity(observedAt, sequence), observedAt);
+}
+
+describe("active tool stall parsing", () => {
+  it("defaults for missing/malformed values, honors non-negative ints, and treats 0 as disabled", () => {
+    for (const [raw, expected] of [
+      [undefined, DEFAULT_ACTIVE_TOOL_STALL_MS],
+      ["", DEFAULT_ACTIVE_TOOL_STALL_MS],
+      ["   ", DEFAULT_ACTIVE_TOOL_STALL_MS],
+      ["wat", DEFAULT_ACTIVE_TOOL_STALL_MS],
+      ["-1", DEFAULT_ACTIVE_TOOL_STALL_MS],
+      ["1.5", DEFAULT_ACTIVE_TOOL_STALL_MS],
+      ["0", 0],
+      [" 120000 ", 120_000],
+      ["123456", 123_456],
+    ] as const) {
+      assert.equal(parseActiveToolStallMs(raw), expected, String(raw));
+    }
+  });
+});
+
+describe("stale tool-scope projection", () => {
+  it("projects stalled once tool silence reaches the window, with duration equal to silence", () => {
+    const stall = 600_000;
+    const lifecycle = activeToolLifecycle(1000);
+    const fresh = projectLifecycle(lifecycle, 1000 + stall - 1);
+    assert.equal(fresh.kind, "active");
+    assert.equal(fresh.label, "bash");
+
+    const stale = projectLifecycle(lifecycle, 1000 + stall);
+    assert.deepEqual(stale, { kind: "stalled", stateDurationSince: 1000 });
+  });
+
+  it("omitted opts defaults to the enabled 600000ms window", () => {
+    const lifecycle = activeToolLifecycle(0);
+    assert.equal(projectLifecycle(lifecycle, 599_999).kind, "active");
+    assert.equal(projectLifecycle(lifecycle, 600_000).kind, "stalled");
+  });
+
+  it("threshold 0 disables stale-stalling entirely", () => {
+    const lifecycle = activeToolLifecycle(0);
+    const projection = projectLifecycle(lifecycle, Number.MAX_SAFE_INTEGER / 2, { activeToolStallMs: 0 });
+    assert.equal(projection.kind, "active");
+  });
+
+  it("provider, streaming, and agent scopes never stale-stall regardless of age", () => {
+    for (const scope of ["provider", "streaming", "agent"] as const) {
+      let lifecycle = createLifecycle(0);
+      lifecycle = observePaneInspection(lifecycle, {
+        kind: "present",
+        observedAt: 0,
+        agentStatus: "working",
+      }, 0);
+      lifecycle = observeActivity(lifecycle, scopeActivity(scope, 0), 0);
+      const projection = projectLifecycle(lifecycle, DEFAULT_ACTIVE_TOOL_STALL_MS * 10);
+      assert.equal(projection.kind, "active", scope);
+    }
+  });
+
+  it("fresh tool activity after a stalled projection emits a recovered transition", () => {
+    let lifecycle = activeToolLifecycle(0);
+    assert.equal(projectLifecycle(lifecycle, 600_000).kind, "stalled");
+
+    lifecycle = observeActivity(lifecycle, toolActivity(600_500, 2), 600_500);
+    const next = projectLifecycle(lifecycle, 600_501);
+    assert.equal(next.kind, "active");
+    assert.equal(lifecycleTransition("stalled", next.kind), "recovered");
+  });
+});
+
+describe("stale tool child drives the recovery ladder", () => {
+  it("nudges after delays[0] and kills after delays[2] using fake-clock ticks", () => {
+    const testApi = (subagentsModule as any).__test__;
+    const running = makeRunning();
+    let nudges = 0;
+    let closes = 0;
+    let aborts = 0;
+    const operations = {
+      interruptPane() {
+        nudges += 1;
+      },
+      closePane() {
+        closes += 1;
+      },
+      abortWatcher() {
+        aborts += 1;
+      },
+    };
+
+    // Child enters a bash call at t=1000 and the activity file goes silent.
+    running.lifecycle = activeToolLifecycle(1000);
+    const tick = (now: number) => {
+      const projection = projectLifecycle(running.lifecycle, now);
+      return testApi.advanceRunningRecovery(running, projection, now, delays, operations);
+    };
+
+    assert.equal(tick(1000).action, null, "fresh tool activity must not arm the ladder");
+    assert.equal(running.recovery, undefined);
+
+    const stalledAt = 1000 + 600_000;
+    assert.equal(tick(stalledAt).state?.stage, "waiting", "silence past the window arms the ladder");
+    assert.equal(tick(stalledAt + 30_000 - 1).action, null, "below delays[0] must not nudge");
+    assert.equal(tick(stalledAt + delays[0]).action, "nudge");
+    assert.equal(tick(stalledAt + delays[0] + delays[1]).action, "escalate");
+    assert.equal(tick(stalledAt + delays[0] + delays[1] + delays[2] - 1).action, null);
+    const killTick = tick(stalledAt + delays[0] + delays[1] + delays[2]);
+    assert.equal(killTick.action, "kill");
+    assert.equal(nudges, 1);
+    assert.equal(closes, 1);
+    assert.equal(aborts, 1);
+    assert.match(running.lifecycle.process.error, /recovery-kill after 781s/);
+  });
+});

--- a/test/time-limits.test.ts
+++ b/test/time-limits.test.ts
@@ -1,0 +1,435 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import * as subagentsModule from "../pi-extension/subagents/index.ts";
+import subagentDoneExtension from "../pi-extension/subagents/subagent-done.ts";
+import { interpretExitSidecar } from "../pi-extension/subagents/completion.ts";
+import {
+  REPORT_ONLY_WRAPUP_DIRECTIVE,
+  consumeWrapupDirective,
+  evalTimeLimit,
+  writeWrapupDirective,
+} from "../pi-extension/subagents/time-limits.ts";
+import { createLifecycle } from "../pi-extension/subagents/lifecycle.ts";
+
+function withTempDir(run: (dir: string) => void) {
+  const dir = mkdtempSync(join(tmpdir(), "subagent-time-limits-"));
+  try {
+    run(dir);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+function makeRunning(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "child-1",
+    name: "Worker",
+    task: "Implement the feature",
+    surface: "pane-1",
+    startTime: 0,
+    sessionFile: "/tmp/worker.jsonl",
+    interactive: false,
+    lifecycle: createLifecycle(0),
+    timeLimit: { timeLimitSeconds: 100, timeoutWarnThreshold: 0.8 },
+    ...overrides,
+  };
+}
+
+function createMockExtensionApi() {
+  const eventHandlers = new Map<string, Array<Function>>();
+  const sentUserMessages: string[] = [];
+  return {
+    eventHandlers,
+    sentUserMessages,
+    api: {
+      on(event: string, handler: Function) {
+        const handlers = eventHandlers.get(event) ?? [];
+        handlers.push(handler);
+        eventHandlers.set(event, handlers);
+      },
+      registerShortcut() {},
+      registerTool() {},
+      registerCommand() {},
+      registerMessageRenderer(name: string, renderer: Function) {
+        this.renderers.push({ name, renderer });
+      },
+      renderers: [] as Array<{ name: string; renderer: Function }>,
+      getAllTools() {
+        return [];
+      },
+      sendUserMessage(message: string) {
+        sentUserMessages.push(message);
+      },
+    } as any,
+  };
+}
+
+function createTheme(calls: string[]) {
+  return {
+    fg(color: string, text: string) {
+      calls.push(`fg:${color}`);
+      return text;
+    },
+    bg(color: string, text: string) {
+      calls.push(`bg:${color}`);
+      return text;
+    },
+    bold(text: string) {
+      return text;
+    },
+  };
+}
+
+describe("time-limit frontmatter", () => {
+  it("parses valid values and ignores invalid or absent values", () => {
+    const parse = (subagentsModule as any).__test__.parseAgentDefinition;
+    const parseFields = (frontmatter: string) =>
+      parse(`---\nname: worker\n${frontmatter}\n---\nWorker body`, "fallback");
+
+    assert.deepEqual(
+      {
+        timeLimitSeconds: parseFields("time-limit: 120\nidle-timeout: 15\ntimeout-warn-threshold: 0.8").timeLimitSeconds,
+        idleTimeoutSeconds: parseFields("time-limit: 120\nidle-timeout: 15\ntimeout-warn-threshold: 0.8").idleTimeoutSeconds,
+        timeoutWarnThreshold: parseFields("time-limit: 120\nidle-timeout: 15\ntimeout-warn-threshold: 0.8").timeoutWarnThreshold,
+      },
+      { timeLimitSeconds: 120, idleTimeoutSeconds: 15, timeoutWarnThreshold: 0.8 },
+    );
+
+    for (const frontmatter of [
+      "time-limit: 0",
+      "time-limit: -1",
+      "time-limit: 1.5",
+      "time-limit: 1e3",
+      "idle-timeout: nope",
+      "idle-timeout: 0",
+      "timeout-warn-threshold: 0",
+      "timeout-warn-threshold: 1",
+      "timeout-warn-threshold: 1.1",
+      "timeout-warn-threshold: nope",
+      "",
+    ]) {
+      const parsed = parseFields(frontmatter);
+      assert.equal(parsed.timeLimitSeconds, undefined, frontmatter);
+      assert.equal(parsed.idleTimeoutSeconds, undefined, frontmatter);
+      assert.equal(parsed.timeoutWarnThreshold, undefined, frontmatter);
+    }
+  });
+});
+
+describe("evalTimeLimit", () => {
+  it("uses an injected clock for no-limit, warn-only, hard-only, both, and idle cases", () => {
+    const cases: Array<[
+      string,
+      number,
+      number | undefined,
+      { timeLimitSeconds?: number; idleTimeoutSeconds?: number; timeoutWarnThreshold?: number },
+      boolean | undefined,
+      "none" | "warn" | "hard-stop",
+    ]> = [
+      ["no limit", 999_999, undefined, {}, undefined, "none"],
+      ["before whole-run warning", 79_999, undefined, { timeLimitSeconds: 100, timeoutWarnThreshold: 0.8 }, false, "none"],
+      ["whole-run warning", 80_000, undefined, { timeLimitSeconds: 100, timeoutWarnThreshold: 0.8 }, false, "warn"],
+      ["warning fires once", 81_000, undefined, { timeLimitSeconds: 100, timeoutWarnThreshold: 0.8 }, true, "none"],
+      ["whole-run hard stop", 100_000, undefined, { timeLimitSeconds: 100, timeoutWarnThreshold: 0.8 }, true, "hard-stop"],
+      ["hard-only before deadline", 99_999, undefined, { timeLimitSeconds: 100 }, false, "none"],
+      ["hard-only at deadline", 100_000, undefined, { timeLimitSeconds: 100 }, false, "hard-stop"],
+      ["idle warning uses activity timestamp", 57_999, 50_000, { idleTimeoutSeconds: 10, timeoutWarnThreshold: 0.8 }, false, "none"],
+      ["idle warning at fraction", 58_000, 50_000, { idleTimeoutSeconds: 10, timeoutWarnThreshold: 0.8 }, false, "warn"],
+      ["idle hard stop", 60_000, 50_000, { idleTimeoutSeconds: 10, timeoutWarnThreshold: 0.8 }, true, "hard-stop"],
+      ["idle does not use wall clock without an activity snapshot", 100_000, undefined, { idleTimeoutSeconds: 10, timeoutWarnThreshold: 0.8 }, false, "none"],
+      ["the earliest configured deadline wins", 60_000, 55_000, { timeLimitSeconds: 100, idleTimeoutSeconds: 5, timeoutWarnThreshold: 0.8 }, true, "hard-stop"],
+    ];
+
+    for (const [label, now, lastActivityAt, config, warned, expected] of cases) {
+      assert.equal(evalTimeLimit(now, 0, lastActivityAt, config, warned), expected, label);
+    }
+  });
+});
+
+describe("parent time-limit actions", () => {
+  it("writes one directive then only sends Escape for a warned wrap-up", () => {
+    const testApi = (subagentsModule as any).__test__;
+    const running = makeRunning();
+    const calls: string[] = [];
+    let typed = 0;
+    const operations = {
+      interruptPane(surface: string) {
+        calls.push(`escape:${surface}`);
+      },
+      closePane() {
+        calls.push("close");
+      },
+      abortWatcher() {
+        calls.push("abort");
+      },
+      writeWrapup(sessionFile: string) {
+        calls.push(`write:${sessionFile}.wrapup`);
+      },
+      removeWrapup(sessionFile: string) {
+        calls.push(`remove:${sessionFile}.wrapup`);
+      },
+    };
+
+    assert.equal(testApi.advanceRunningTimeLimit(running, 80_000, operations).action, "warn");
+    assert.equal(running.wrapupPending, true);
+    assert.equal(running.timeLimitWarned, true);
+    assert.deepEqual(calls, ["write:/tmp/worker.jsonl.wrapup", "escape:pane-1"]);
+
+    assert.equal(testApi.advanceRunningTimeLimit(running, 81_000, operations).action, null);
+    assert.deepEqual(calls, ["write:/tmp/worker.jsonl.wrapup", "escape:pane-1"]);
+    assert.equal(typed, 0, "the warning path must not type free text into the child pane");
+  });
+
+  it("pins the warned idle deadline, tears down once at hard stop, and reports a timed-out session tail", () => {
+    withTempDir((dir) => {
+      const testApi = (subagentsModule as any).__test__;
+      const sessionFile = join(dir, "worker.jsonl");
+      writeFileSync(sessionFile, `${JSON.stringify({
+        type: "message",
+        message: { role: "assistant", content: [{ type: "text", text: "Halfway through the migration." }] },
+      })}\n`);
+      const running = makeRunning({
+        sessionFile,
+        activity: { updatedAt: 50_000 },
+        timeLimit: { idleTimeoutSeconds: 10, timeoutWarnThreshold: 0.8 },
+      });
+      let closes = 0;
+      let aborts = 0;
+      let removes = 0;
+      const operations = {
+        interruptPane() {},
+        closePane() {
+          closes += 1;
+        },
+        abortWatcher() {
+          aborts += 1;
+        },
+        writeWrapup() {},
+        removeWrapup() {
+          removes += 1;
+        },
+      };
+
+      assert.equal(testApi.advanceRunningTimeLimit(running, 58_000, operations).action, "warn");
+      running.activity = { updatedAt: 59_999 };
+      assert.equal(
+        testApi.advanceRunningTimeLimit(running, 60_000, operations).action,
+        "hard-stop",
+        "the original idle deadline must stay pinned after the warning",
+      );
+      assert.equal(closes, 1);
+      assert.equal(aborts, 1);
+      assert.equal(removes, 1);
+      assert.equal(running.wrapupPending, false);
+      assert.equal(running.lifecycle.process.kind, "failed");
+
+      const result = testApi.buildTimeLimitStoppedResult(running, 60_001);
+      assert.deepEqual(
+        { exitCode: result.exitCode, timeout: result.timeout, partial: result.partial },
+        { exitCode: 1, timeout: "hard-stop", partial: undefined },
+      );
+      assert.match(result.summary, /timed out after 60s/i);
+      assert.match(result.summary, /Halfway through the migration/);
+      assert.match(testApi.resolveResultPresentation(result, running.name), /failed/);
+      assert.doesNotMatch(testApi.resolveResultPresentation(result, running.name), /completed/);
+
+      assert.equal(testApi.advanceRunningTimeLimit(running, 61_000, operations).action, null);
+      assert.equal(closes, 1, "terminal hard-stop must not close twice");
+      assert.equal(aborts, 1, "terminal hard-stop must not abort twice");
+    });
+  });
+
+  it("keeps recovery, interactive, and resumed runs out of time-limit actions", () => {
+    const testApi = (subagentsModule as any).__test__;
+    const noPaneCalls = {
+      interruptPane() { throw new Error("must not interrupt"); },
+      closePane() { throw new Error("must not close"); },
+      abortWatcher() { throw new Error("must not abort"); },
+      writeWrapup() { throw new Error("must not write"); },
+      removeWrapup() { throw new Error("must not remove"); },
+    };
+
+    assert.equal(
+      testApi.advanceRunningTimeLimit(makeRunning({ interactive: true }), 100_000, noPaneCalls).action,
+      null,
+    );
+    assert.equal(
+      testApi.advanceRunningTimeLimit(makeRunning({ recoveryKilled: { errorMessage: "recovery-kill", killedAt: 1 } }), 100_000, noPaneCalls).action,
+      null,
+    );
+    assert.equal(
+      testApi.advanceRunningTimeLimit(makeRunning({ timeLimit: undefined }), 100_000, noPaneCalls).action,
+      null,
+      "a resume registration without re-specified frontmatter has no deadline",
+    );
+
+    assert.equal(
+      testApi.resolveTimeLimitConfig(
+        { timeLimitSeconds: 100, timeoutWarnThreshold: 0.8 },
+        false,
+        false,
+      ).timeoutWarnThreshold,
+      undefined,
+      "non-Pi children retain a hard deadline but cannot promise a file-based report continuation",
+    );
+
+    const hardStopped = makeRunning({ timeLimitStopped: { errorMessage: "timed out", stoppedAt: 1 } });
+    const recovery = testApi.advanceRunningRecovery(
+      hardStopped,
+      { kind: "stalled" },
+      100_000,
+      [1, 1, 1],
+      noPaneCalls,
+    );
+    assert.equal(recovery.action, null);
+    assert.equal(hardStopped.recovery, undefined);
+  });
+});
+
+describe("completion classification", () => {
+  it("keeps partial, timed-out, recovery-kill, and clean outcomes mutually exclusive", () => {
+    const testApi = (subagentsModule as any).__test__;
+    const partial = {
+      name: "Worker",
+      task: "Task",
+      summary: "Partial report",
+      exitCode: 0,
+      elapsed: 80,
+      partial: true,
+      timeout: "warned-wrapup" as const,
+    };
+    const timedOut = testApi.buildTimeLimitStoppedResult(
+      makeRunning({ timeLimitStopped: { errorMessage: "Subagent timed out after 100s.", stoppedAt: 100_000 } }),
+      100_000,
+    );
+    const recovery = testApi.buildRecoveryKilledResult(
+      makeRunning({ recoveryKilled: { errorMessage: "Subagent recovery-kill after 100s.", killedAt: 100_000 } }),
+      100_000,
+    );
+    const clean = {
+      name: "Worker",
+      task: "Task",
+      summary: "Completed",
+      exitCode: 0,
+      elapsed: 10,
+    };
+
+    const classify = (result: any) =>
+      result.partial ? "partial" : result.timeout === "hard-stop" ? "timed-out" : result.errorMessage ? "recovery-kill" : "clean";
+    assert.deepEqual(
+      [partial, timedOut, recovery, clean].map(classify),
+      ["partial", "timed-out", "recovery-kill", "clean"],
+    );
+    assert.match(testApi.resolveResultPresentation(partial, partial.name), /partial report/i);
+    assert.match(testApi.resolveResultPresentation(timedOut, timedOut.name), /failed/i);
+    assert.match(testApi.resolveResultPresentation(recovery, recovery.name), /failed/i);
+    assert.match(testApi.resolveResultPresentation(clean, clean.name), /completed/i);
+  });
+});
+
+describe("wrap-up directive and completion delivery", () => {
+  it("is consumed once, starts a report-only continuation, and publishes a normal partial completion", () => {
+    withTempDir((dir) => {
+      const artifactDir = join(dir, "artifacts");
+      mkdirSync(artifactDir);
+      const sessionFile = join(artifactDir, "worker.jsonl");
+      writeFileSync(sessionFile, "");
+      writeWrapupDirective(sessionFile);
+      assert.equal(readFileSync(`${sessionFile}.wrapup`, "utf8"), REPORT_ONLY_WRAPUP_DIRECTIVE);
+      assert.equal(consumeWrapupDirective(sessionFile), REPORT_ONLY_WRAPUP_DIRECTIVE);
+      assert.equal(consumeWrapupDirective(sessionFile), null, "a directive is consumed once");
+      assert.equal(existsSync(`${sessionFile}.wrapup`), false);
+
+      writeWrapupDirective(sessionFile);
+      const previousAutoExit = process.env.PI_SUBAGENT_AUTO_EXIT;
+      const previousSession = process.env.PI_SUBAGENT_SESSION;
+      process.env.PI_SUBAGENT_AUTO_EXIT = "1";
+      process.env.PI_SUBAGENT_SESSION = sessionFile;
+      try {
+        const { api, eventHandlers, sentUserMessages } = createMockExtensionApi();
+        subagentDoneExtension(api);
+        let shutdowns = 0;
+        const ctx = { shutdown() { shutdowns += 1; } };
+        const agentEnd = eventHandlers.get("agent_end")![0];
+        const agentSettled = eventHandlers.get("agent_settled")![0];
+
+        agentEnd({ messages: [{ role: "assistant", stopReason: "aborted" }] }, ctx);
+        agentSettled({}, ctx);
+        assert.deepEqual(sentUserMessages, [REPORT_ONLY_WRAPUP_DIRECTIVE]);
+        assert.equal(shutdowns, 0);
+        assert.equal(existsSync(`${sessionFile}.wrapup`), false);
+
+        agentEnd({ messages: [{ role: "assistant", stopReason: "stop" }] }, ctx);
+        agentSettled({}, ctx);
+        assert.equal(shutdowns, 1);
+        assert.deepEqual(JSON.parse(readFileSync(`${sessionFile}.exit`, "utf8")), {
+          type: "done",
+          wrapup: true,
+        });
+        assert.deepEqual(interpretExitSidecar({ type: "done", wrapup: true }), {
+          reason: "done",
+          exitCode: 0,
+          wrapup: true,
+        });
+        assert.equal(existsSync(sessionFile), true, "the partial-report session remains resumable");
+        assert.deepEqual(
+          readdirSync(artifactDir).filter((file) => file.endsWith(".wrapup")),
+          [],
+          "cleanup leaves no stray wrap-up directives in the artifact directory",
+        );
+      } finally {
+        if (previousAutoExit == null) delete process.env.PI_SUBAGENT_AUTO_EXIT;
+        else process.env.PI_SUBAGENT_AUTO_EXIT = previousAutoExit;
+        if (previousSession == null) delete process.env.PI_SUBAGENT_SESSION;
+        else process.env.PI_SUBAGENT_SESSION = previousSession;
+      }
+    });
+  });
+
+  it("marks warned reports in details, presentation, and warning-styled rendering", () => {
+    const testApi = (subagentsModule as any).__test__;
+    const result = {
+      name: "Worker",
+      task: "Implement the feature",
+      summary: "Implemented the parser; remaining tests need review.",
+      sessionFile: "/tmp/worker.jsonl",
+      exitCode: 0,
+      elapsed: 80,
+      partial: true,
+      timeout: "warned-wrapup" as const,
+    };
+    assert.deepEqual(testApi.buildResultTimeoutDetails(result), {
+      partial: true,
+      timeout: "warned-wrapup",
+    });
+
+    const presentation = testApi.resolveResultPresentation(result, result.name);
+    assert.match(presentation, /partial report under .*time limit/i);
+    assert.doesNotMatch(presentation, /failed/);
+
+    const { api } = createMockExtensionApi();
+    (subagentsModule as any).default(api);
+    const renderer = api.renderers.find((entry: any) => entry.name === "subagent_result")!.renderer;
+    const calls: string[] = [];
+    const rendered = renderer(
+      {
+        customType: "subagent_result",
+        content: presentation,
+        details: {
+          name: result.name,
+          exitCode: 0,
+          elapsed: result.elapsed,
+          partial: true,
+          timeout: "warned-wrapup",
+        },
+      },
+      { expanded: true },
+      createTheme(calls),
+    );
+    assert.match(rendered.render(100).join("\n"), /partial report \(time limit\)/i);
+    assert.ok(calls.includes("fg:warning"), "partial completion uses warning styling");
+  });
+});


### PR DESCRIPTION
## What / Why

Adds per-agent time limits with warned wrap-up reports. Each subagent runs with a configurable time limit and produces a wrap-up report when the limit is approached, giving the operator visibility into long-running agents before forced termination. This PR is stacked on top of the recovery ladder (PR #24) and shares its teardown helper for clean process group cleanup.

## Key semantics

- **Per-agent time limits**: configurable per-subagent via environment
- **Warned wrap-up reports**: agent produces summary before forced exit
- **Stacked on recovery-ladder**: shares teardown helper from #24
- **Graceful degradation**: agents that finish before limit produce normal reports

## Test evidence

Full test suite: 271/271 exit 0 (≤180 s on merged integration main 6690dde, oxlint clean)
Per-feature file pass counts:
- spawn-grants: 19
- recovery-ladder: 5
- **time-limits: 10**
- autoexit: 20

Independently verified: Baldr functional verification PASS (all acceptance criteria)

Depends on: PR #24 (feat/subagent-recovery-ladder) — shares teardown helper.
Related to upstream PR #23 (fix/reload-stale-widget-ctx — guards updateWidget against stale ctx after /reload).

Base: 7180d98 (v0.2.0)

