### PR TITLE
feat(subagents): deny-by-default spawn grants with decrementing depth ceiling

### DIFF
--- a/README.md
+++ b/README.md
@@ -357,7 +357,7 @@ You are a specialized agent that does X...
 | `tools`       | string  | Comma-separated **native pi tools only**: `read`, `bash`, `edit`, `write`, `grep`, `find`, `ls`                                                                                                                                                                             |
 | `skills`      | string  | Comma-separated skill names to auto-load                                                                                                                                                                                                                                    |
 | `session-mode` | string | Default child-session mode: `standalone`, `lineage-only`, or `fork` |
-| `spawning`    | boolean | Set `false` to deny all subagent-spawning tools                                                                                                                                                                                                                             |
+| `spawning`    | boolean | **Spawn grant.** Subagent-spawning tools are denied for every child by default; set `true` to grant them (still bounded by `PI_SUBAGENT_SPAWN_DEPTH`, see below).                                                                                                              |
 | `deny-tools`  | string  | Comma-separated extension tool names to deny                                                                                                                                                                                                                                |
 | `auto-exit`   | boolean | Auto-shutdown when the agent finishes its turn — no `subagent_done` call needed. If the user sends any input, auto-exit is permanently disabled and the user takes over the session. Recommended for autonomous agents (scout, worker); not for interactive ones (planner). Also determines the default value of `interactive` (see below). |
 | `interactive` | boolean | derived        | Override whether stall/recovery transitions wake the parent session. Defaults to the inverse of `auto-exit`: autonomous agents (`auto-exit: true`) are non-interactive and get stall pings; agents without `auto-exit` are interactive and stay quiet. Explicit values take precedence. |
@@ -439,18 +439,32 @@ subagent({ name: "Scout", agent: "scout", interactive: true, task: "..." });
 
 ## Tool Access Control
 
-By default, every sub-agent can spawn further sub-agents. Control this with frontmatter:
+By default, every sub-agent is launched **without** the subagent lifecycle tools (`subagent`, `subagent_interrupt`, `subagents_list`, `subagent_resume`) — spawning is a granted capability, not a given.
 
-### `spawning: false`
+### `spawning: true`
 
-Denies all subagent lifecycle tools (`subagent`, `subagent_interrupt`, `subagents_list`, `subagent_resume`):
+Grants the full subagent lifecycle tools to this agent:
 
 ```yaml
 ---
-name: worker
-spawning: false
+name: planner
+spawning: true
 ---
 ```
+
+Without this grant (the default), a child cannot spawn further sub-agents even if it tries. Any `deny-tools` entries still stack on top of a grant.
+
+### Recursion depth: `PI_SUBAGENT_SPAWN_DEPTH`
+
+Spawning agents can be bounded by setting `PI_SUBAGENT_SPAWN_DEPTH` in the top-level session's environment. The value is a generation ceiling for direct children:
+
+- Generation-1 children receive an allowance equal to the env value; each granted agent passes `remaining − 1` down to its own children, so the allowance decrements every generation and never rises.
+- A granted agent with `remaining = 0` cannot spawn — exhaustion overrides the frontmatter grant.
+- When the variable is unset, depth is unlimited but the `spawning: true` grant is still required.
+
+Example: `PI_SUBAGENT_SPAWN_DEPTH=2` allows children to spawn grandchildren, but great-grandchildren are denied. Mutually-spawning agents (`A` spawns `B`, `B` spawns `A`) therefore always terminate.
+
+Resumed sessions (`subagent_resume`) never receive more allowance than their first launch recorded in `<session-file>.spawn.json`; if that metadata is missing, resume denies spawning entirely.
 
 ### `deny-tools`
 
@@ -467,11 +481,11 @@ deny-tools: subagent
 
 | Agent      | `spawning`  | Rationale                                    |
 | ---------- | ----------- | -------------------------------------------- |
-| planner    | _(default)_ | Legitimately spawns scouts for investigation |
-| worker     | `false`     | Should implement tasks, not delegate         |
-| researcher | `false`     | Should research, not spawn                   |
-| reviewer   | `false`     | Should review, not spawn                     |
-| scout      | `false`     | Should gather context, not spawn             |
+| planner    | `true`      | Legitimately spawns scouts for investigation |
+| worker     | _(default)_ | Should implement tasks, not delegate         |
+| researcher | _(default)_ | Should research, not spawn                   |
+| reviewer   | _(default)_ | Should review, not spawn                     |
+| scout      | _(default)_ | Should gather context, not spawn             |
 
 ---
 

--- a/agents/planner.md
+++ b/agents/planner.md
@@ -1,6 +1,7 @@
 ---
 name: planner
 description: Interactive planning agent - clarifies WHAT to build and figures out HOW. Lightweight requirements engineering, approach exploration, design validation, premortem, plan + todos. Can spawn scouts/researchers mid-session when it needs facts.
+spawning: true
 system-prompt: append
 ---
 

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "type": "module",
   "scripts": {
     "lint": "oxlint pi-extension test",
-    "test": "node --test test/test.ts test/runtime-routing.test.ts test/release-workflow.test.ts test/harness-drivers.test.ts",
+    "test": "node --test test/test.ts test/runtime-routing.test.ts test/release-workflow.test.ts test/harness-drivers.test.ts test/spawn-grants.test.ts",
     "test:integration": "node --test --test-concurrency=1 test/integration/*.test.ts"
   },
   "peerDependencies": {

--- a/pi-extension/subagents/harness/drivers/pi.ts
+++ b/pi-extension/subagents/harness/drivers/pi.ts
@@ -70,6 +70,7 @@ export class PiHarnessDriver implements HarnessDriver {
       effectiveAutoExit,
       taskDelivery,
       denySet,
+      childSpawnDepth,
       identity,
       identityInSystemPrompt,
       systemPromptMode,
@@ -123,6 +124,9 @@ export class PiHarnessDriver implements HarnessDriver {
 
     if (denySet && denySet.size > 0) {
       envParts.push(`PI_DENY_TOOLS=${shellQuote([...denySet].join(","))}`);
+    }
+    if (childSpawnDepth != null) {
+      envParts.push(`PI_SUBAGENT_SPAWN_DEPTH=${childSpawnDepth}`);
     }
     envParts.push(`PI_SUBAGENT_NAME=${shellQuote(params.name)}`);
     if (params.agent) {

--- a/pi-extension/subagents/harness/types.ts
+++ b/pi-extension/subagents/harness/types.ts
@@ -48,6 +48,8 @@ export interface SubagentLaunchContext {
   inheritsConversationContext: boolean;
   taskDelivery: "direct" | "artifact";
   denySet?: Set<string>;
+  /** PI_SUBAGENT_SPAWN_DEPTH handed to this child (its children's ceiling); null = unlimited. */
+  childSpawnDepth?: number | null;
   identity?: string | null;
   identityInSystemPrompt?: boolean;
   systemPromptMode?: string;

--- a/pi-extension/subagents/index.ts
+++ b/pi-extension/subagents/index.ts
@@ -210,7 +210,7 @@ interface ListedAgentDefinition extends AgentDefinition {
   source: AgentSource;
 }
 
-/** Tools that are gated by `spawning: false` */
+/** Tools gated behind an explicit frontmatter spawn grant (`spawning: true`) */
 const SPAWNING_TOOLS = new Set([
   "subagent",
   "subagent_interrupt",
@@ -219,21 +219,51 @@ const SPAWNING_TOOLS = new Set([
 ]);
 
 /**
- * Resolve the effective set of denied tool names from agent defaults.
- * `spawning: false` expands to all SPAWNING_TOOLS.
- * `deny-tools` adds individual tool names on top.
+ * Parse PI_SUBAGENT_SPAWN_DEPTH into a child-spawning allowance.
+ * Unset/blank/unparsable/negative → null (unlimited; a frontmatter grant is
+ * still required). A non-negative integer is the generation ceiling granted
+ * to this process's direct children.
  */
-function resolveDenyTools(agentDefs: AgentDefaults | null): Set<string> {
-  const denied = new Set<string>();
-  if (!agentDefs) return denied;
+function parseSpawnDepth(raw: string | undefined | null): number | null {
+  if (raw == null) return null;
+  const trimmed = raw.trim();
+  if (!trimmed) return null;
+  const parsed = Number.parseInt(trimmed, 10);
+  if (!Number.isFinite(parsed) || parsed < 0) return null;
+  return parsed;
+}
 
-  // spawning: false → deny all spawning tools
-  if (agentDefs.spawning === false) {
+/**
+ * Depth handed down to the next generation: decrements by one per
+ * generation, never rises, clamps at zero. Unlimited stays unlimited.
+ */
+function decrementSpawnDepth(allowance: number | null): number | null {
+  return allowance === null ? null : Math.max(0, allowance - 1);
+}
+
+/**
+ * Resolve the effective set of denied tool names from agent defaults.
+ *
+ * Spawning is deny-by-default: all SPAWNING_TOOLS are denied unless the
+ * agent frontmatter explicitly grants `spawning: true` AND depth remains
+ * (`spawnAllowance > 0`, or null = unlimited).
+ * `deny-tools` additions stack on top either way.
+ */
+function resolveDenyTools(
+  agentDefs: AgentDefaults | null,
+  spawnAllowance: number | null = null,
+): Set<string> {
+  const denied = new Set<string>();
+
+  // Deny-by-default: only spawning:true + remaining depth keeps the tools.
+  const spawnGranted =
+    agentDefs?.spawning === true && (spawnAllowance === null || spawnAllowance > 0);
+  if (!spawnGranted) {
     for (const t of SPAWNING_TOOLS) denied.add(t);
   }
 
-  // deny-tools: explicit list
-  if (agentDefs.denyTools) {
+  // deny-tools: explicit list stacks on top of the default denial
+  if (agentDefs?.denyTools) {
     for (const t of agentDefs.denyTools
       .split(",")
       .map((s) => s.trim())
@@ -243,6 +273,48 @@ function resolveDenyTools(agentDefs: AgentDefaults | null): Set<string> {
   }
 
   return denied;
+}
+
+/**
+ * Resume clamp: first-launch metadata is authoritative. The resumed session
+ * never receives more spawning allowance than its first launch recorded —
+ * min(recorded, requested). Missing/corrupt metadata resolves to 0 (deny).
+ */
+function clampResumeSpawn(
+  recorded: { allowance?: unknown } | null | undefined,
+  requestedAllowance: number | null,
+): { maySpawn: boolean; childEnvDepth: number | null } {
+  const capRaw = recorded?.allowance;
+  if (capRaw !== null && (typeof capRaw !== "number" || !Number.isFinite(capRaw) || capRaw < 0)) {
+    return { maySpawn: false, childEnvDepth: 0 };
+  }
+  const cap = capRaw === null ? null : Math.floor(capRaw);
+  const effective =
+    cap === null
+      ? requestedAllowance
+      : requestedAllowance === null
+        ? cap
+        : Math.min(cap, requestedAllowance);
+  const maySpawn = effective === null || effective > 0;
+  return { maySpawn, childEnvDepth: decrementSpawnDepth(effective) };
+}
+
+/**
+ * Read the first-launch spawn metadata sidecar written next to a subagent
+ * session file. Any failure (missing file, corrupt JSON) → null, which the
+ * clamp treats as zero allowance.
+ */
+function readSpawnMetadata(sessionFile: string): { allowance?: unknown } | null {
+  try {
+    return JSON.parse(readFileSync(`${sessionFile}.spawn.json`, "utf8"));
+  } catch {
+    return null;
+  }
+}
+
+/** Same-agent respawn guard: an agent never spawns another instance of itself. */
+function blockedSelfSpawn(requestedAgent: string | undefined, currentAgent: string | undefined): boolean {
+  return !!requestedAgent && !!currentAgent && requestedAgent === currentAgent;
 }
 
 /** Resolve the global agent config directory, respecting PI_CODING_AGENT_DIR. */
@@ -1079,6 +1151,12 @@ export const __test__ = {
   buildPiPromptArgs,
   observeRunningSubagent,
   resolveDenyTools,
+  parseSpawnDepth,
+  decrementSpawnDepth,
+  clampResumeSpawn,
+  readSpawnMetadata,
+  blockedSelfSpawn,
+  SPAWNING_TOOLS,
   resolveInterruptTarget,
   requestSubagentInterrupt,
   handleSubagentInterrupt,
@@ -1197,7 +1275,12 @@ async function launchSubagent(
   const summaryInstruction = effectiveAutoExit
     ? "Your FINAL assistant message should summarize what you accomplished."
     : "Your FINAL assistant message (before calling subagent_done or before the user exits) should summarize what you accomplished.";
-  const denySet = resolveDenyTools(agentDefs);
+  // Spawn grant + depth: this process's PI_SUBAGENT_SPAWN_DEPTH is the
+  // generation ceiling for our direct children; they receive one less so
+  // mutual spawning terminates.
+  const launcherAllowance = parseSpawnDepth(process.env.PI_SUBAGENT_SPAWN_DEPTH);
+  const spawnGranted = agentDefs?.spawning === true;
+  const denySet = resolveDenyTools(agentDefs, launcherAllowance);
   const identity = agentDefs?.body ?? params.systemPrompt ?? null;
   const systemPromptMode = agentDefs?.systemPromptMode;
   const identityInSystemPrompt = systemPromptMode && identity;
@@ -1222,6 +1305,7 @@ async function launchSubagent(
     inheritsConversationContext,
     taskDelivery: launchBehavior.taskDelivery,
     denySet,
+    childSpawnDepth: decrementSpawnDepth(launcherAllowance),
     identity,
     identityInSystemPrompt: Boolean(identityInSystemPrompt),
     systemPromptMode,
@@ -1267,6 +1351,18 @@ async function launchSubagent(
       ? markProcessRunning(createLifecycle(startTime), Date.now())
       : createLifecycle(startTime),
   };
+
+  // First-launch spawn metadata: authoritative cap for later subagent_resume.
+  // Non-granted agents record 0 so resume can never enlarge their rights.
+  try {
+    writeFileSync(
+      `${running.sessionFile}.spawn.json`,
+      JSON.stringify({ allowance: spawnGranted ? launcherAllowance ?? null : 0 }),
+      "utf8",
+    );
+  } catch {
+    // Unwritable sidecar ⇒ resume conservatively denies spawning.
+  }
 
   runningSubagents.set(id, running);
   return running;
@@ -1501,8 +1597,7 @@ export default function subagentsExtension(pi: ExtensionAPI) {
 
       async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
         // Prevent self-spawning (e.g. planner spawning another planner)
-        const currentAgent = process.env.PI_SUBAGENT_AGENT;
-        if (params.agent && currentAgent && params.agent === currentAgent) {
+        if (blockedSelfSpawn(params.agent, process.env.PI_SUBAGENT_AGENT)) {
           return {
             content: [
               {
@@ -1964,6 +2059,18 @@ export default function subagentsExtension(pi: ExtensionAPI) {
         resumeEnvParts.push(`PI_SUBAGENT_ACTIVITY_FILE=${shellQuote(activityFile)}`);
         if (autoExit) {
           resumeEnvParts.push(`PI_SUBAGENT_AUTO_EXIT=1`);
+        }
+        // Spawn rights on resume are clamped to what the first launch recorded:
+        // missing metadata ⇒ 0 (deny); never larger than first launch.
+        const resumeSpawn = clampResumeSpawn(
+          readSpawnMetadata(params.sessionPath),
+          parseSpawnDepth(process.env.PI_SUBAGENT_SPAWN_DEPTH),
+        );
+        if (!resumeSpawn.maySpawn) {
+          resumeEnvParts.push(`PI_DENY_TOOLS=${shellQuote([...SPAWNING_TOOLS].join(","))}`);
+        }
+        if (resumeSpawn.childEnvDepth !== null) {
+          resumeEnvParts.push(`PI_SUBAGENT_SPAWN_DEPTH=${resumeSpawn.childEnvDepth}`);
         }
         const resumeEnvPrefix = resumeEnvParts.join(" ") + " ";
 

--- a/pi-extension/subagents/index.ts
+++ b/pi-extension/subagents/index.ts
@@ -1597,7 +1597,10 @@ export default function subagentsExtension(pi: ExtensionAPI) {
 
       async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
         // Prevent self-spawning (e.g. planner spawning another planner)
-        if (blockedSelfSpawn(params.agent, process.env.PI_SUBAGENT_AGENT)) {
+        // Non-empty here is guaranteed by blockedSelfSpawn requiring both args
+        // truthy and equal, so the message always renders a real identity.
+        const currentAgent = process.env.PI_SUBAGENT_AGENT;
+        if (blockedSelfSpawn(params.agent, currentAgent)) {
           return {
             content: [
               {

--- a/test/spawn-grants.test.ts
+++ b/test/spawn-grants.test.ts
@@ -6,6 +6,7 @@ import { tmpdir } from "node:os";
 import { PiHarnessDriver } from "../pi-extension/subagents/harness/index.ts";
 import type { SubagentLaunchContext } from "../pi-extension/subagents/harness/types.ts";
 import * as subagentsModule from "../pi-extension/subagents/index.ts";
+import subagentsExtension from "../pi-extension/subagents/index.ts";
 
 const testApi = (subagentsModule as any).__test__;
 const SPAWNING_TOOLS = [...testApi.SPAWNING_TOOLS as Set<string>].sort();
@@ -208,5 +209,83 @@ describe("termination regression", () => {
     assert.equal(testApi.blockedSelfSpawn("planner", "scout"), false);
     assert.equal(testApi.blockedSelfSpawn(undefined, "scout"), false);
     assert.equal(testApi.blockedSelfSpawn("scout", undefined), false);
+  });
+});
+
+describe("self-spawn guard via the real registered tool execute()", () => {
+  function registerExtensionAndGetTools() {
+    const tools = new Map<string, any>();
+    // Registration-time calls only; handler bodies never run in these tests.
+    const mockPi = {
+      on: () => {},
+      registerTool: (tool: any) => tools.set(tool.name, tool),
+      registerCommand: () => {},
+      registerMessageRenderer: () => {},
+      sendMessage: () => {},
+      sendUserMessage: () => {},
+      getThinkingLevel: () => "off",
+    };
+    // Strip child-agent env so no spawning tools look denied during registration.
+    const savedId = process.env.PI_SUBAGENT_ID;
+    const savedDeny = process.env.PI_DENY_TOOLS;
+    delete process.env.PI_SUBAGENT_ID;
+    delete process.env.PI_DENY_TOOLS;
+    try {
+      subagentsExtension(mockPi as any);
+    } finally {
+      if (savedId === undefined) delete process.env.PI_SUBAGENT_ID;
+      else process.env.PI_SUBAGENT_ID = savedId;
+      if (savedDeny === undefined) delete process.env.PI_DENY_TOOLS;
+      else process.env.PI_DENY_TOOLS = savedDeny;
+    }
+    return tools;
+  }
+
+  it("returns guidance text instead of throwing when an agent spawns itself", async () => {
+    const previousAgent = process.env.PI_SUBAGENT_AGENT;
+    process.env.PI_SUBAGENT_AGENT = "planner";
+    try {
+      const tool = registerExtensionAndGetTools().get("subagent");
+      assert.ok(tool, "subagent tool must be registered");
+
+      const result = await tool.execute(
+        "test-call",
+        { name: "dup", task: "do work", agent: "planner" },
+        undefined,
+        undefined,
+        {},
+      );
+
+      const text = result.content[0].text as string;
+      assert.match(text, /You are the planner agent/);
+      assert.match(text, /do not start another planner/);
+      assert.deepEqual(result.details, { error: "self-spawn blocked" });
+    } finally {
+      if (previousAgent === undefined) delete process.env.PI_SUBAGENT_AGENT;
+      else process.env.PI_SUBAGENT_AGENT = previousAgent;
+    }
+  });
+
+  it("does not block spawning a different agent", async () => {
+    process.env.PI_SUBAGENT_AGENT = "planner";
+    try {
+      const tool = registerExtensionAndGetTools().get("subagent");
+      assert.ok(tool);
+
+      await assert.rejects(
+        () =>
+          tool.execute(
+            "test-call",
+            { name: "s", task: "t", agent: "scout" },
+            undefined,
+            undefined,
+            {},
+          ),
+        // Guard passes; execution then fails later on missing prerequisites.
+        // Any throw proves it got past the self-spawn guard without one.
+      );
+    } finally {
+      delete process.env.PI_SUBAGENT_AGENT;
+    }
   });
 });

--- a/test/spawn-grants.test.ts
+++ b/test/spawn-grants.test.ts
@@ -1,0 +1,212 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { PiHarnessDriver } from "../pi-extension/subagents/harness/index.ts";
+import type { SubagentLaunchContext } from "../pi-extension/subagents/harness/types.ts";
+import * as subagentsModule from "../pi-extension/subagents/index.ts";
+
+const testApi = (subagentsModule as any).__test__;
+const SPAWNING_TOOLS = [...testApi.SPAWNING_TOOLS as Set<string>].sort();
+
+function createMockLaunchContext(overrides?: Partial<SubagentLaunchContext>): SubagentLaunchContext {
+  return {
+    params: {
+      id: "abc12345",
+      name: "worker",
+      task: "Analyze the repository structure",
+    },
+    runtimePlan: {
+      provider: "anthropic",
+      modelId: "claude-sonnet-4-5",
+      model: "anthropic/claude-sonnet-4-5",
+      thinking: "medium",
+      modelSource: "request",
+      thinkingSource: "request",
+    },
+    effectiveModel: "anthropic/claude-sonnet-4-5",
+    effectiveThinking: "medium",
+    parentThinking: "medium",
+    surface: "pane-1",
+    artifactDir: "/tmp/artifacts",
+    sessionDir: "/tmp/sessions",
+    subagentSessionFile: "/tmp/sessions/subagent.jsonl",
+    effectiveCwd: "/tmp/project",
+    effectiveAutoExit: true,
+    effectiveInteractive: false,
+    inheritsConversationContext: true,
+    taskDelivery: "direct",
+    subagentsDir: "/path/to/subagents",
+    shellQuote: (s: string) => `'${s.replace(/'/g, "'\\''")}'`,
+    ...overrides,
+  };
+}
+
+describe("resolveDenyTools — deny-by-default spawn grants", () => {
+  it("denies all spawning tools by default (no agent defs, bare spawn)", () => {
+    const denied = testApi.resolveDenyTools(null);
+    for (const tool of SPAWNING_TOOLS) assert.equal(denied.has(tool), true, `expected ${tool} denied`);
+  });
+
+  it("denies all spawning tools when frontmatter omits `spawning`", () => {
+    const denied = testApi.resolveDenyTools({ name: "worker" });
+    for (const tool of SPAWNING_TOOLS) assert.equal(denied.has(tool), true);
+  });
+
+  it("denies all spawning tools when frontmatter sets spawning:false", () => {
+    const denied = testApi.resolveDenyTools({ spawning: false });
+    for (const tool of SPAWNING_TOOLS) assert.equal(denied.has(tool), true);
+  });
+
+  it("grants spawning tools only with explicit spawning:true and remaining depth", () => {
+    const granted = testApi.resolveDenyTools({ spawning: true }, null);
+    for (const tool of SPAWNING_TOOLS) assert.equal(granted.has(tool), false);
+    assert.equal(testApi.resolveDenyTools({ spawning: true }, 3).size, 0);
+  });
+
+  it("remaining 0 denies spawning despite a frontmatter grant", () => {
+    const denied = testApi.resolveDenyTools({ spawning: true }, 0);
+    for (const tool of SPAWNING_TOOLS) assert.equal(denied.has(tool), true);
+  });
+
+  it("deny-tools additions stack on top of grants and denials", () => {
+    // Granted agent with extra denials
+    const grantedWithExtra = testApi.resolveDenyTools(
+      { spawning: true, denyTools: "bash, read" },
+      null,
+    );
+    assert.deepEqual([...grantedWithExtra].sort(), ["bash", "read"]);
+
+    // Denied-by-default agent stacking an unrelated denial
+    const deniedWithExtra = testApi.resolveDenyTools({ denyTools: "write" });
+    for (const tool of SPAWNING_TOOLS) assert.equal(deniedWithExtra.has(tool), true);
+    assert.equal(deniedWithExtra.has("write"), true);
+
+    // Redundant listing of a spawning tool changes nothing
+    assert.equal(testApi.resolveDenyTools({ spawning: true, denyTools: "subagent" }, 2).has("subagent"), true);
+
+    // Empty / junk entries are ignored
+    assert.equal(testApi.resolveDenyTools({ spawning: true, denyTools: " , ," }, 1).size, 0);
+  });
+});
+
+describe("spawn depth math", () => {
+  it("parseSpawnDepth reads PI_SUBAGENT_SPAWN_DEPTH conservatively", () => {
+    assert.equal(testApi.parseSpawnDepth(undefined), null); // unset → unlimited (grant still required)
+    assert.equal(testApi.parseSpawnDepth(""), null);
+    assert.equal(testApi.parseSpawnDepth("  "), null);
+    assert.equal(testApi.parseSpawnDepth("junk"), null);
+    assert.equal(testApi.parseSpawnDepth("-1"), null);
+    assert.equal(testApi.parseSpawnDepth("0"), 0);
+    assert.equal(testApi.parseSpawnDepth("7"), 7);
+    assert.equal(testApi.parseSpawnDepth(" 3 "), 3);
+  });
+
+  it("decrementSpawnDepth never rises and clamps at zero", () => {
+    assert.equal(testApi.decrementSpawnDepth(null), null); // unlimited stays unlimited
+    assert.equal(testApi.decrementSpawnDepth(5), 4);
+    assert.equal(testApi.decrementSpawnDepth(1), 0);
+    assert.equal(testApi.decrementSpawnDepth(0), 0);
+  });
+});
+
+describe("Pi harness driver emits depth + deny env", () => {
+  const driver = new PiHarnessDriver();
+
+  it("emits PI_DENY_TOOLS including spawning tools and PI_SUBAGENT_SPAWN_DEPTH=<remaining>", () => {
+    const denySet = new Set<string>(SPAWNING_TOOLS);
+    const built = driver.buildCommand(createMockLaunchContext({ denySet, childSpawnDepth: 2 }));
+
+    assert.match(built.command, /PI_DENY_TOOLS='[^']*subagent[^']*'/);
+    for (const tool of SPAWNING_TOOLS) {
+      assert.ok(built.command.includes(`'${tool}'`) || built.command.includes(tool),
+        `expected ${tool} in PI_DENY_TOOLS`);
+    }
+    assert.ok(built.command.includes("PI_SUBAGENT_SPAWN_DEPTH=2"));
+  });
+
+  it("emits PI_SUBAGENT_SPAWN_DEPTH=0 at exhaustion (explicit, not absent)", () => {
+    const built = driver.buildCommand(createMockLaunchContext({ childSpawnDepth: 0 }));
+    assert.ok(built.command.includes("PI_SUBAGENT_SPAWN_DEPTH=0"));
+  });
+
+  it("omits PI_SUBAGENT_SPAWN_DEPTH when unlimited (no ceiling configured)", () => {
+    const built = driver.buildCommand(createMockLaunchContext({ childSpawnDepth: null }));
+    assert.equal(built.command.includes("PI_SUBAGENT_SPAWN_DEPTH="), false);
+
+    const legacyBuilt = driver.buildCommand(createMockLaunchContext());
+    assert.equal(legacyBuilt.command.includes("PI_SUBAGENT_SPAWN_DEPTH="), false);
+  });
+});
+
+describe("resume clamp — first-launch metadata wins", () => {
+  it("missing/corrupt metadata resolves to 0 (deny)", () => {
+    assert.deepEqual(testApi.clampResumeSpawn(undefined, 9), { maySpawn: false, childEnvDepth: 0 });
+    assert.deepEqual(testApi.clampResumeSpawn(null, 9), { maySpawn: false, childEnvDepth: 0 });
+    assert.deepEqual(testApi.clampResumeSpawn({}, 9), { maySpawn: false, childEnvDepth: 0 });
+    assert.deepEqual(testApi.clampResumeSpawn({ allowance: "3" }, 9), { maySpawn: false, childEnvDepth: 0 });
+    assert.deepEqual(testApi.clampResumeSpawn({ allowance: -2 }, 9), { maySpawn: false, childEnvDepth: 0 });
+  });
+
+  it("clamps to min(recorded allowance, requested)", () => {
+    // recorded 3, environment would allow 5 → 3, child gets 2
+    assert.deepEqual(testApi.clampResumeSpawn({ allowance: 3 }, 5), { maySpawn: true, childEnvDepth: 2 });
+    // recorded 3, environment allows 1 → 1, child gets 0
+    assert.deepEqual(testApi.clampResumeSpawn({ allowance: 3 }, 1), { maySpawn: true, childEnvDepth: 0 });
+    // recorded 3, no ceiling in environment → recorded 3 stands
+    assert.deepEqual(testApi.clampResumeSpawn({ allowance: 3 }, null), { maySpawn: true, childEnvDepth: 2 });
+    // exhausted at first launch → resume cannot revive
+    assert.deepEqual(testApi.clampResumeSpawn({ allowance: 0 }, 9), { maySpawn: false, childEnvDepth: 0 });
+  });
+
+  it("recorded unlimited stays bounded by the requesting environment only", () => {
+    assert.deepEqual(testApi.clampResumeSpawn({ allowance: null }, 4), { maySpawn: true, childEnvDepth: 3 });
+    assert.deepEqual(testApi.clampResumeSpawn({ allowance: null }, null), { maySpawn: true, childEnvDepth: null });
+  });
+
+  it("readSpawnMetadata returns null on missing or corrupt sidecar files", () => {
+    const dir = mkdtempSync(join(tmpdir(), "spawn-grants-test-"));
+    try {
+      assert.equal(testApi.readSpawnMetadata(join(dir, "missing.jsonl")), null);
+
+      const sessionFile = join(dir, "session.jsonl");
+      writeFileSync(`${sessionFile}.spawn.json`, JSON.stringify({ allowance: 4 }), "utf8");
+      assert.deepEqual(testApi.readSpawnMetadata(sessionFile), { allowance: 4 });
+
+      writeFileSync(`${sessionFile}.spawn.json`, "{not json", "utf8");
+      assert.equal(testApi.readSpawnMetadata(sessionFile), null);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("termination regression", () => {
+  it("A-spawns-B-spawns-A terminates: depth decrements every generation until denial", () => {
+    const grantedDefs = { spawning: true };
+    let allowance: number | null = 3;
+    let spawnerIsA = true;
+    let spawns = 0;
+
+    while (true) {
+      const denied = testApi.resolveDenyTools(grantedDefs, allowance);
+      if (denied.has("subagent")) break;
+      allowance = testApi.decrementSpawnDepth(allowance);
+      spawns++;
+      spawnerIsA = !spawnerIsA;
+      assert.ok(spawns <= 10, "mutual spawning must terminate");
+    }
+
+    // ceiling 3 → A, B, A each spawn once; B's fourth attempt is denied
+    assert.equal(spawns, 3);
+    assert.equal(spawnerIsA, false);
+  });
+
+  it("keeps the same-agent respawn guard working regardless of depth", () => {
+    assert.equal(testApi.blockedSelfSpawn("planner", "planner"), true);
+    assert.equal(testApi.blockedSelfSpawn("planner", "scout"), false);
+    assert.equal(testApi.blockedSelfSpawn(undefined, "scout"), false);
+    assert.equal(testApi.blockedSelfSpawn("scout", undefined), false);
+  });
+});


### PR DESCRIPTION
## What / Why

Introduces a deny-by-default spawn grant system with a decrementing depth ceiling. Subagents can only spawn child agents if they hold a grant, and each spawn decrements the depth counter. This prevents runaway spawning while still allowing controlled delegation trees. The agent identity for the self-spawn guard message is also defined, ensuring agents can spawn themselves when needed.

## Key semantics

- **Deny-by-default**: no spawn without explicit grant
- **Decrementing depth ceiling**: each spawn consumes one grant, limiting tree depth
- **Agent identity defined**: self-spawn guard message references agent identity
- **Env-unset = unlimited but grant-gated**: when not set, grants are still required but depth is unlimited
- **Invalid env values parse as unlimited**: graceful degradation for misconfiguration
- **Corrupt sidecar parses 0**: deliberate conservative asymmetry between env parse and sidecar parse
- **Bundled planner granted spawning**: bundled agent file `planner.md` sets `spawning:true` — without this grant the bundled planner could not delegate at all

## Test evidence

Full test suite: 271/271 exit 0 (≤180 s on merged integration main 6690dde, oxlint clean)
Per-feature file pass counts:
- **spawn-grants: 19**
- recovery-ladder: 5
- time-limits: 10
- autoexit: 20

Independently verified: Baldr functional verification PASS (all acceptance criteria)

Related to upstream PR #23 (fix/reload-stale-widget-ctx — guards updateWidget against stale ctx after /reload).

Base: 7180d98 (v0.2.0)

