### PR TITLE
feat(subagents): disarm auto-exit on operator takeover, /auto-exit re-arm once

### DIFF
--- a/README.md
+++ b/README.md
@@ -359,7 +359,7 @@ You are a specialized agent that does X...
 | `session-mode` | string | Default child-session mode: `standalone`, `lineage-only`, or `fork` |
 | `spawning`    | boolean | Set `false` to deny all subagent-spawning tools                                                                                                                                                                                                                             |
 | `deny-tools`  | string  | Comma-separated extension tool names to deny                                                                                                                                                                                                                                |
-| `auto-exit`   | boolean | Auto-shutdown when the agent finishes its turn — no `subagent_done` call needed. If the user sends any input, auto-exit is permanently disabled and the user takes over the session. Recommended for autonomous agents (scout, worker); not for interactive ones (planner). Also determines the default value of `interactive` (see below). |
+| `auto-exit`   | boolean | Auto-shutdown when the agent finishes its turn — no `subagent_done` call needed. Operator input or an Escape abort permanently disarms it for that session (with a one-time warning); the `/auto-exit` slash command re-arms it for exactly one completion. Recommended for autonomous agents (scout, worker); not for interactive ones (planner). Also determines the default value of `interactive` (see below). |
 | `interactive` | boolean | derived        | Override whether stall/recovery transitions wake the parent session. Defaults to the inverse of `auto-exit`: autonomous agents (`auto-exit: true`) are non-interactive and get stall pings; agents without `auto-exit` are interactive and stay quiet. Explicit values take precedence. |
 | `cwd`         | string  | Default working directory (absolute or relative to project root)                                                                                                                                                                                                            |
 | `disable-model-invocation` | boolean | Hide this agent from discovery surfaces like `subagents_list`. The agent still remains directly invokable by explicit name via `subagent({ agent: "name", ... })`. |
@@ -393,8 +393,10 @@ When set to `true`, the agent session shuts down automatically as soon as the ag
 
 **Behavior:**
 
-- The session closes after the agent's final message (on the `agent_end` event)
-- If the user sends **any input** before the agent finishes, auto-exit is permanently disabled for that session — the user takes over interactively
+- The session closes after the agent's settled final message
+- **Operator takeover disarms auto-exit permanently:** any input sent after the first agent run starts, or an Escape-triggered abort, disables auto-exit for the rest of the session and emits a one-time warning in the child pane. The session then behaves like a normal interactive session
+- **`/auto-exit` re-arms once:** run this slash command inside the child pane after taking over; auto-exit closes the session after its next completed turn (writing the usual done/error sidecar) and is disarmed again until the command is run once more. It is a no-op while auto-exit is already armed or already re-armed
+- Background children that never receive operator input keep exiting on their first normal completion — behavior is unchanged from previous releases
 - The modeHint injected into the agent's task is adjusted accordingly: autonomous agents see "Complete your task autonomously." rather than instructions to call `subagent_done`
 
 **When to use:**

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "type": "module",
   "scripts": {
     "lint": "oxlint pi-extension test",
-    "test": "node --test test/test.ts test/runtime-routing.test.ts test/release-workflow.test.ts test/harness-drivers.test.ts",
+    "test": "node --test test/test.ts test/subagent-done-autoexit.test.ts test/runtime-routing.test.ts test/release-workflow.test.ts test/harness-drivers.test.ts",
     "test:integration": "node --test --test-concurrency=1 test/integration/*.test.ts"
   },
   "peerDependencies": {

--- a/pi-extension/subagents/subagent-done.ts
+++ b/pi-extension/subagents/subagent-done.ts
@@ -37,6 +37,40 @@ export function shouldAutoExitOnAgentEnd(
   return true;
 }
 
+export interface AutoExitDecisionState {
+  /** Sticky: set when the operator typed into the session or Escape-aborted a run. */
+  disarmed: boolean;
+  /** Set by /auto-exit: allows exactly one more settled completion to exit. */
+  oneShotReArm: boolean;
+}
+
+/**
+ * Pure auto-exit decision for a settled agent turn.
+ *
+ * - Armed and untouched: exits on terminal stops and errors exactly as
+ *   v0.2.0 did; Escape-aborted runs keep the session open.
+ * - Disarmed (operator takeover): never exits, whatever the stop reason.
+ * - One-shot re-arm (/auto-exit): behaves like armed for a single further
+ *   completion; the caller consumes the flag once that exit happens.
+ */
+export function resolveAutoExit(
+  state: AutoExitDecisionState,
+  stopReason: string | undefined,
+): boolean {
+  if (state.disarmed && !state.oneShotReArm) return false;
+  return stopReason !== "aborted";
+}
+
+function latestAssistantStopReason(messages: any[] | undefined): string | undefined {
+  if (messages) {
+    for (let i = messages.length - 1; i >= 0; i--) {
+      const msg = messages[i];
+      if (msg?.role === "assistant") return msg.stopReason as string | undefined;
+    }
+  }
+  return undefined;
+}
+
 export interface SubagentErrorInfo {
   errorMessage: string;
   stopReason: "error";
@@ -148,9 +182,25 @@ export default function (pi: ExtensionAPI) {
     );
   }
 
-  let userTookOver = false;
+  let disarmed = false;
+  let oneShotReArm = false;
+  let warnedOperatorTakeover = false;
   let agentStarted = false;
   let latestAgentMessages: any[] | undefined;
+
+  // Operator takeover (typed input or an Escape abort) permanently disarms
+  // auto-exit for this session. The warning is latched so it is emitted
+  // exactly once no matter how often the operator interacts afterwards.
+  function disarmAutoExit(cause: string, ctx: any): void {
+    disarmed = true;
+    if (!autoExit || warnedOperatorTakeover) return;
+    warnedOperatorTakeover = true;
+    ctx.ui.notify(
+      `Auto-exit disabled (${cause}). You are driving this session now — ` +
+        "/auto-exit closes it after its next completion.",
+      "warning",
+    );
+  }
 
   // Show widget + status bar on session start
   pi.on("session_start", (_event, ctx) => {
@@ -162,12 +212,12 @@ export default function (pi: ExtensionAPI) {
     renderWidget(ctx, null);
   });
 
-  pi.on("input", () => {
+  pi.on("input", (_event, ctx) => {
     recorder.input();
     // Ignore the initial task message that starts an autonomous subagent.
     // Only inputs after the first agent run has started count as user takeover.
     if (!shouldMarkUserTookOver(agentStarted)) return;
-    userTookOver = true;
+    disarmAutoExit("operator input", ctx);
   });
 
   pi.on("before_agent_start", () => {
@@ -188,8 +238,21 @@ export default function (pi: ExtensionAPI) {
   });
 
   pi.on("agent_settled", (_event, ctx) => {
+    const stopReason = latestAssistantStopReason(latestAgentMessages);
+
+    // An Escape-triggered abort is operator takeover too: permanently disarm
+    // (single warning above) and leave the session open for inspection.
+    if (stopReason === "aborted") {
+      disarmAutoExit("Escape", ctx);
+    }
+
     const shouldExit = autoExit
-      && shouldAutoExitOnAgentEnd(userTookOver, latestAgentMessages);
+      && resolveAutoExit({ disarmed, oneShotReArm }, stopReason);
+    if (shouldExit && oneShotReArm) {
+      // Consume the one-shot re-arm: after this exit auto-exit is disarmed
+      // again until the operator runs /auto-exit once more.
+      oneShotReArm = false;
+    }
 
     if (shouldExit) {
       // Surface stopReason: "error" turns (auto-retry exhausted, provider
@@ -211,12 +274,6 @@ export default function (pi: ExtensionAPI) {
       recorder.agentEndDone();
       ctx.shutdown();
       return;
-    }
-
-    if (autoExit) {
-      // Reset any recorded manual input marker. Auto-exit is decided by whether
-      // the latest settled agent run completed normally, not by who initiated it.
-      userTookOver = false;
     }
   });
 
@@ -265,6 +322,33 @@ export default function (pi: ExtensionAPI) {
   });
 
   // Toggle expand/collapse with Ctrl+J
+  // Re-arm auto-exit for exactly one completion after operator takeover.
+  pi.registerCommand("auto-exit", {
+    description: "Close this session automatically after its next completed turn",
+    handler: async (_args, ctx) => {
+      if (!autoExit) {
+        ctx.ui.notify("Auto-exit is not enabled for this session.", "info");
+        return;
+      }
+      if (!disarmed) {
+        ctx.ui.notify("Auto-exit is already armed.", "info");
+        return;
+      }
+      if (oneShotReArm) {
+        ctx.ui.notify(
+          "Auto-exit is already re-armed for the next completion.",
+          "info",
+        );
+        return;
+      }
+      oneShotReArm = true;
+      ctx.ui.notify(
+        "Auto-exit re-armed: this session will close after its next completion.",
+        "info",
+      );
+    },
+  });
+
   pi.registerShortcut("ctrl+j", {
     description: "Toggle subagent tools widget",
     handler: (ctx) => {

--- a/test/subagent-done-autoexit.test.ts
+++ b/test/subagent-done-autoexit.test.ts
@@ -1,0 +1,263 @@
+import { describe, it, beforeEach, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import subagentDoneExtension, {
+  resolveAutoExit,
+} from "../pi-extension/subagents/subagent-done.ts";
+
+// L-95 — auto-exit hardening: operator input / Escape permanently disarms,
+// /auto-exit re-arms for exactly one completion. Child-side only.
+
+interface Notification {
+  message: string;
+  type?: string;
+}
+
+function createExtensionApi() {
+  const eventHandlers = new Map<string, Array<Function>>();
+  const registeredCommands: Array<{ name: string; handler: Function }> = [];
+  return {
+    eventHandlers,
+    registeredCommands,
+    api: {
+      on(event: string, handler: Function) {
+        const handlers = eventHandlers.get(event) ?? [];
+        handlers.push(handler);
+        eventHandlers.set(event, handlers);
+      },
+      registerTool() {},
+      registerCommand(name: string, command: any) {
+        registeredCommands.push({ name, ...command });
+      },
+      registerMessageRenderer() {},
+      registerShortcut() {},
+      sendUserMessage() {},
+      sendMessage() {},
+      getAllTools() {
+        return [];
+      },
+    } as any,
+  };
+}
+
+const origAutoExit = process.env.PI_SUBAGENT_AUTO_EXIT;
+const origSession = process.env.PI_SUBAGENT_SESSION;
+
+function restoreEnv(name: string, value: string | undefined) {
+  if (value === undefined) delete process.env[name];
+  else process.env[name] = value;
+}
+
+describe("subagent-done auto-exit hardening (L-95)", () => {
+  let dir: string | undefined;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "l95-autoexit-"));
+  });
+
+  afterEach(() => {
+    restoreEnv("PI_SUBAGENT_AUTO_EXIT", origAutoExit);
+    restoreEnv("PI_SUBAGENT_SESSION", origSession);
+    if (dir) rmSync(dir, { recursive: true, force: true });
+    dir = undefined;
+  });
+
+  function boot(opts: { autoExit?: boolean; withSessionFile?: boolean } = {}) {
+    const autoExit = opts.autoExit ?? true;
+    if (autoExit) process.env.PI_SUBAGENT_AUTO_EXIT = "1";
+    else delete process.env.PI_SUBAGENT_AUTO_EXIT;
+
+    let sessionFile: string | undefined;
+    if (opts.withSessionFile !== false) {
+      sessionFile = join(dir!, "child.jsonl");
+      process.env.PI_SUBAGENT_SESSION = sessionFile;
+    } else {
+      delete process.env.PI_SUBAGENT_SESSION;
+    }
+
+    const { api, eventHandlers, registeredCommands } = createExtensionApi();
+    subagentDoneExtension(api);
+
+    const notifications: Notification[] = [];
+    const ctx: any = {
+      shutdowns: 0,
+      ui: {
+        notify(message: string, type?: string) {
+          notifications.push({ message, type });
+        },
+        setWidget() {},
+      },
+      shutdown() {
+        ctx.shutdowns += 1;
+      },
+    };
+
+    return {
+      ctx,
+      notifications,
+      sessionFile,
+      registeredCommands,
+      fire(event: string, payload: any = {}) {
+        for (const handler of eventHandlers.get(event) ?? []) handler(payload, ctx);
+      },
+      // agent_end + agent_settled: mirrors how Pi settles a finished turn.
+      settle(messages: any[]) {
+        this.fire("agent_end", { messages });
+        this.fire("agent_settled", { type: "agent_settled" });
+      },
+      async runCommand(name: string, args = "") {
+        const command = registeredCommands.find((c) => c.name === name);
+        assert.ok(command, `command /${name} must be registered`);
+        await command.handler(args, ctx);
+      },
+    };
+  }
+
+  function sidecarOf(child: ReturnType<typeof boot>): any | null {
+    if (!child.sessionFile || !existsSync(`${child.sessionFile}.exit`)) return null;
+    return JSON.parse(readFileSync(`${child.sessionFile}.exit`, "utf8"));
+  }
+
+  describe("resolveAutoExit decision table", () => {
+    // [disarmed, oneShotReArm, stopReason, expected]
+    const cases: Array<[boolean, boolean, string | undefined, boolean]> = [
+      // Armed (never disarmed): identical to v0.2.0 — terminal stop or error
+      // exits, aborted stays open.
+      [false, false, "stop", true],
+      [false, false, "error", true],
+      [false, false, "aborted", false],
+      [false, false, undefined, true],
+      // Disarmed: never exits, whatever happened.
+      [true, false, "stop", false],
+      [true, false, "error", false],
+      [true, false, "aborted", false],
+      [true, false, undefined, false],
+      // One-shot re-arm via /auto-exit: one more terminal stop or error may
+      // exit; an aborted turn still stays open.
+      [true, true, "stop", true],
+      [true, true, "error", true],
+      [true, true, "aborted", false],
+      // Re-arm while armed cannot occur via CLI but is harmless.
+      [false, true, "stop", true],
+    ];
+
+    for (const [disarmed, reArm, reason, expected] of cases) {
+      it(`disarmed=${disarmed} reArm=${reArm} stop=${reason} -> ${expected}`, () => {
+        assert.equal(resolveAutoExit({ disarmed, oneShotReArm: reArm }, reason), expected);
+      });
+    }
+  });
+
+  it("ignores the initial task input before the first agent run", () => {
+    const child = boot();
+    child.fire("input", { type: "input", text: "do the whole task" });
+    child.settle([{ role: "assistant", stopReason: "stop" }]);
+    assert.equal(child.ctx.shutdowns, 1, "zero-real-input child still exits");
+    assert.deepEqual(sidecarOf(child), { type: "done" });
+    assert.equal(child.notifications.length, 0, "no warning for the injected task");
+  });
+
+  it("operator input disarms auto-exit persistently across settled turns", () => {
+    const child = boot();
+    child.fire("agent_start", {});
+    child.fire("input", { type: "input", text: "hold on, steer this way" });
+    for (let i = 0; i < 3; i++) {
+      child.settle([{ role: "assistant", stopReason: "stop" }]);
+    }
+    assert.equal(child.ctx.shutdowns, 0, "disarm survives settled turns (no reset)");
+    assert.equal(sidecarOf(child), null, "no done sidecar after disarm");
+  });
+
+  it("warns exactly once when input first disarms auto-exit", () => {
+    const child = boot();
+    child.fire("agent_start", {});
+    child.fire("input", { type: "input", text: "first takeover" });
+    child.fire("input", { type: "input", text: "second takeover" });
+    child.fire("input", { type: "input", text: "third takeover" });
+    child.settle([{ role: "assistant", stopReason: "aborted" }]);
+    const warnings = child.notifications.filter((n) => n.type === "warning");
+    assert.equal(warnings.length, 1, "exactly one warning despite repeated inputs");
+    assert.match(warnings[0].message, /auto-exit/i);
+  });
+
+  it("Escape-triggered abort disarms auto-exit and keeps the session open", () => {
+    const child = boot();
+    child.settle([{ role: "assistant", stopReason: "aborted" }]);
+    assert.equal(child.ctx.shutdowns, 0, "aborted run does not exit");
+    assert.equal(
+      child.notifications.filter((n) => n.type === "warning").length,
+      1,
+      "one takeover warning for the Escape abort",
+    );
+    // Session stays open and disarmed: a later normal completion must not exit.
+    child.settle([{ role: "assistant", stopReason: "stop" }]);
+    assert.equal(child.ctx.shutdowns, 0);
+  });
+
+  it("/auto-exit re-arms for exactly one completion, then disarms again", async () => {
+    const child = boot();
+    child.fire("agent_start", {});
+    child.fire("input", { type: "input", text: "taking over" });
+    child.settle([{ role: "assistant", stopReason: "stop" }]);
+    assert.equal(child.ctx.shutdowns, 0);
+
+    // Double invocation must not stack two completions.
+    await child.runCommand("auto-exit");
+    await child.runCommand("auto-exit");
+
+    child.settle([{ role: "assistant", stopReason: "stop" }]);
+    assert.equal(child.ctx.shutdowns, 1, "re-armed child exits on next completion");
+    assert.deepEqual(sidecarOf(child), { type: "done" }, "done sidecar written");
+
+    // One-shot consumed: another settled completion does not exit again.
+    child.settle([{ role: "assistant", stopReason: "stop" }]);
+    assert.equal(child.ctx.shutdowns, 1, "auto-exit is disarmed again after one-shot exit");
+  });
+
+  it("/auto-exit is a no-op while auto-exit is still armed", async () => {
+    const child = boot();
+    await child.runCommand("auto-exit");
+    child.settle([{ role: "assistant", stopReason: "stop" }]);
+    assert.equal(child.ctx.shutdowns, 1, "plain armed behavior unchanged");
+  });
+
+  it("background regression: zero-input child behaves byte-for-byte like v0.2.0", () => {
+    const child = boot();
+    child.fire("session_start", {});
+    child.fire("agent_end", { messages: [{ role: "assistant", stopReason: "stop" }] });
+    assert.equal(child.ctx.shutdowns, 0, "no shutdown before agent_settled");
+    assert.equal(existsSync(`${child.sessionFile}.exit`), false);
+    child.fire("agent_settled", { type: "agent_settled" });
+    assert.equal(child.ctx.shutdowns, 1);
+    assert.deepEqual(sidecarOf(child), { type: "done" });
+    assert.equal(child.notifications.length, 0, "silent for background children");
+
+    const failing = boot();
+    failing.settle([
+      { role: "assistant", stopReason: "error", errorMessage: "529 overloaded" },
+    ]);
+    assert.equal(failing.ctx.shutdowns, 1, "error stopReason still wakes the parent");
+    assert.deepEqual(sidecarOf(failing), {
+      type: "error",
+      errorMessage: "529 overloaded",
+      stopReason: "error",
+    });
+  });
+
+  it("non-auto-exit sessions never warn and ignore /auto-exit state changes", async () => {
+    const child = boot({ autoExit: false });
+    child.fire("agent_start", {});
+    child.fire("input", { type: "input", text: "interactive use" });
+    child.settle([{ role: "assistant", stopReason: "stop" }]);
+    child.settle([{ role: "assistant", stopReason: "aborted" }]);
+    await child.runCommand("auto-exit");
+    assert.equal(child.ctx.shutdowns, 0, "interactive child never auto-exits");
+    assert.equal(
+      child.notifications.filter((n) => n.type === "warning").length,
+      0,
+      "nothing to disarm, so no takeover warning",
+    );
+  });
+});

--- a/test/test.ts
+++ b/test/test.ts
@@ -1542,7 +1542,7 @@ describe("subagent-done.ts", () => {
         const { api, eventHandlers } = createMockExtensionApi();
         subagentDoneExtension(api);
         let shutdowns = 0;
-        const ctx = { shutdown: () => { shutdowns += 1; } };
+        const ctx = { shutdown: () => { shutdowns += 1; }, ui: { notify() {} } };
         eventHandlers.get("agent_end")![0]({
           messages: [{ role: "assistant", stopReason: "aborted" }],
         }, ctx);


### PR DESCRIPTION
## What / Why

When the operator takes over a subagent (via input), auto-exit is disarmed so the agent doesn't exit prematurely during operator interaction. The `/auto-exit` command can re-arm the auto-exit mechanism once, giving the operator explicit control over when to re-enable automatic termination. Behavior is changed only when the operator actually takes over — with zero operator input, behavior is identical to v0.2.0.

## Key semantics

- **Disarm on takeover**: operator input stops the auto-exit timer
- **/auto-exit re-arm**: single re-arm to re-enable auto-exit
- **Zero-input parity**: identical behavior to v0.2.0 when operator is idle
- **Clean state transitions**: well-defined state machine for auto-exit lifecycle

## Test evidence

Full test suite: 271/271 exit 0 (≤180 s on merged integration main 6690dde, oxlint clean)
Per-feature file pass counts:
- spawn-grants: 19
- recovery-ladder: 5
- time-limits: 10
- **autoexit: 20**

Independently verified: Baldr functional verification PASS (all acceptance criteria)

Related to upstream PR #23 (fix/reload-stale-widget-ctx — guards updateWidget against stale ctx after /reload).

Base: 7180d98 (v0.2.0)

