### PR TITLE
fix(subagents): keep tool-use turns alive before auto-exit (L-84)

### DIFF
--- a/README.md
+++ b/README.md
@@ -369,8 +369,13 @@ You are a specialized agent that does X...
 | `deny-tools`  | string  | Comma-separated extension tool names to deny                                                                                                                                                                                                                                |
 | `auto-exit`   | boolean | Auto-shutdown when the agent finishes its turn — no `subagent_done` call needed. If the user sends any input, auto-exit is permanently disabled and the user takes over the session. Recommended for autonomous agents (scout, worker); not for interactive ones (planner). Also determines the default value of `interactive` (see below). |
 | `interactive` | boolean | derived        | Override whether stall/recovery transitions wake the parent session. Defaults to the inverse of `auto-exit`: autonomous agents (`auto-exit: true`) are non-interactive and get stall pings; agents without `auto-exit` are interactive and stay quiet. Explicit values take precedence. |
+| `time-limit` | positive integer seconds | — | Whole-run deadline for a non-interactive agent. At the deadline the pane closes and the parent receives a timed-out failure with the session still resumable. |
+| `idle-timeout` | positive integer seconds | — | Deadline measured from the latest Pi activity snapshot; it is ignored when no activity snapshots are available. |
+| `timeout-warn-threshold` | fraction `0 < n < 1` | — | Optional warning fraction for either limit on Pi-backed children. At the threshold the child receives one report-only continuation; omit it for hard-stop only. Other CLIs retain the hard deadline only. |
 | `cwd`         | string  | Default working directory (absolute or relative to project root)                                                                                                                                                                                                            |
 | `disable-model-invocation` | boolean | Hide this agent from discovery surfaces like `subagents_list`. The agent still remains directly invokable by explicit name via `subagent({ agent: "name", ... })`. |
+
+A warning writes a directive beside the child session, sends Escape only to interrupt the active turn, and reserves the original deadline for one final report-only turn. That normal completion is delivered as a **partial report under time limit** (not a full completion); the directive never types text into the child pane and fresh report activity cannot extend an idle deadline.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -357,7 +357,7 @@ You are a specialized agent that does X...
 | `tools`       | string  | Comma-separated **native pi tools only**: `read`, `bash`, `edit`, `write`, `grep`, `find`, `ls`                                                                                                                                                                             |
 | `skills`      | string  | Comma-separated skill names to auto-load                                                                                                                                                                                                                                    |
 | `session-mode` | string | Default child-session mode: `standalone`, `lineage-only`, or `fork` |
-| `spawning`    | boolean | Set `false` to deny all subagent-spawning tools                                                                                                                                                                                                                             |
+| `spawning`    | boolean | **Spawn grant.** Subagent-spawning tools are denied for every child by default; set `true` to grant them (still bounded by `PI_SUBAGENT_SPAWN_DEPTH`, see below).                                                                                                              |
 | `deny-tools`  | string  | Comma-separated extension tool names to deny                                                                                                                                                                                                                                |
 | `auto-exit`   | boolean | Auto-shutdown when the agent finishes its turn — no `subagent_done` call needed. If the user sends any input, auto-exit is permanently disabled and the user takes over the session. Recommended for autonomous agents (scout, worker); not for interactive ones (planner). Also determines the default value of `interactive` (see below). |
 | `interactive` | boolean | derived        | Override whether stall/recovery transitions wake the parent session. Defaults to the inverse of `auto-exit`: autonomous agents (`auto-exit: true`) are non-interactive and get stall pings; agents without `auto-exit` are interactive and stay quiet. Explicit values take precedence. |
@@ -439,18 +439,32 @@ subagent({ name: "Scout", agent: "scout", interactive: true, task: "..." });
 
 ## Tool Access Control
 
-By default, every sub-agent can spawn further sub-agents. Control this with frontmatter:
+By default, every sub-agent is launched **without** the subagent lifecycle tools (`subagent`, `subagent_interrupt`, `subagents_list`, `subagent_resume`) — spawning is a granted capability, not a given.
 
-### `spawning: false`
+### `spawning: true`
 
-Denies all subagent lifecycle tools (`subagent`, `subagent_interrupt`, `subagents_list`, `subagent_resume`):
+Grants the full subagent lifecycle tools to this agent:
 
 ```yaml
 ---
-name: worker
-spawning: false
+name: planner
+spawning: true
 ---
 ```
+
+Without this grant (the default), a child cannot spawn further sub-agents even if it tries. Any `deny-tools` entries still stack on top of a grant.
+
+### Recursion depth: `PI_SUBAGENT_SPAWN_DEPTH`
+
+Spawning agents can be bounded by setting `PI_SUBAGENT_SPAWN_DEPTH` in the top-level session's environment. The value is a generation ceiling for direct children:
+
+- Generation-1 children receive an allowance equal to the env value; each granted agent passes `remaining − 1` down to its own children, so the allowance decrements every generation and never rises.
+- A granted agent with `remaining = 0` cannot spawn — exhaustion overrides the frontmatter grant.
+- When the variable is unset, depth is unlimited but the `spawning: true` grant is still required.
+
+Example: `PI_SUBAGENT_SPAWN_DEPTH=2` allows children to spawn grandchildren, but great-grandchildren are denied. Mutually-spawning agents (`A` spawns `B`, `B` spawns `A`) therefore always terminate.
+
+Resumed sessions (`subagent_resume`) never receive more allowance than their first launch recorded in `<session-file>.spawn.json`; if that metadata is missing, resume denies spawning entirely.
 
 ### `deny-tools`
 
@@ -467,11 +481,11 @@ deny-tools: subagent
 
 | Agent      | `spawning`  | Rationale                                    |
 | ---------- | ----------- | -------------------------------------------- |
-| planner    | _(default)_ | Legitimately spawns scouts for investigation |
-| worker     | `false`     | Should implement tasks, not delegate         |
-| researcher | `false`     | Should research, not spawn                   |
-| reviewer   | `false`     | Should review, not spawn                     |
-| scout      | `false`     | Should gather context, not spawn             |
+| planner    | `true`      | Legitimately spawns scouts for investigation |
+| worker     | _(default)_ | Should implement tasks, not delegate         |
+| researcher | _(default)_ | Should research, not spawn                   |
+| reviewer   | _(default)_ | Should review, not spawn                     |
+| scout      | _(default)_ | Should gather context, not spawn             |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -359,7 +359,7 @@ You are a specialized agent that does X...
 | `session-mode` | string | Default child-session mode: `standalone`, `lineage-only`, or `fork` |
 | `spawning`    | boolean | Set `false` to deny all subagent-spawning tools                                                                                                                                                                                                                             |
 | `deny-tools`  | string  | Comma-separated extension tool names to deny                                                                                                                                                                                                                                |
-| `auto-exit`   | boolean | Auto-shutdown when the agent finishes its turn — no `subagent_done` call needed. If the user sends any input, auto-exit is permanently disabled and the user takes over the session. Recommended for autonomous agents (scout, worker); not for interactive ones (planner). Also determines the default value of `interactive` (see below). |
+| `auto-exit`   | boolean | Auto-shutdown when the agent finishes its turn — no `subagent_done` call needed. Operator input or an Escape abort permanently disarms it for that session (with a one-time warning); the `/auto-exit` slash command re-arms it for exactly one completion. Recommended for autonomous agents (scout, worker); not for interactive ones (planner). Also determines the default value of `interactive` (see below). |
 | `interactive` | boolean | derived        | Override whether stall/recovery transitions wake the parent session. Defaults to the inverse of `auto-exit`: autonomous agents (`auto-exit: true`) are non-interactive and get stall pings; agents without `auto-exit` are interactive and stay quiet. Explicit values take precedence. |
 | `cwd`         | string  | Default working directory (absolute or relative to project root)                                                                                                                                                                                                            |
 | `disable-model-invocation` | boolean | Hide this agent from discovery surfaces like `subagents_list`. The agent still remains directly invokable by explicit name via `subagent({ agent: "name", ... })`. |
@@ -393,8 +393,10 @@ When set to `true`, the agent session shuts down automatically as soon as the ag
 
 **Behavior:**
 
-- The session closes after the agent's final message (on the `agent_end` event)
-- If the user sends **any input** before the agent finishes, auto-exit is permanently disabled for that session — the user takes over interactively
+- The session closes after the agent's settled final message
+- **Operator takeover disarms auto-exit permanently:** any input sent after the first agent run starts, or an Escape-triggered abort, disables auto-exit for the rest of the session and emits a one-time warning in the child pane. The session then behaves like a normal interactive session
+- **`/auto-exit` re-arms once:** run this slash command inside the child pane after taking over; auto-exit closes the session after its next completed turn (writing the usual done/error sidecar) and is disarmed again until the command is run once more. It is a no-op while auto-exit is already armed or already re-armed
+- Background children that never receive operator input keep exiting on their first normal completion — behavior is unchanged from previous releases
 - The modeHint injected into the agent's task is adjusted accordingly: autonomous agents see "Complete your task autonomously." rather than instructions to call `subagent_done`
 
 **When to use:**

--- a/README.md
+++ b/README.md
@@ -167,6 +167,14 @@ When `activeCount === 0` (every tracked row is open), the border uses an amber a
 
 A fixed internal watchdog marks a run as `stalled` when pane inspection fails or the pane disappears without a completion sidecar; valid long-running `active` or `waiting` states do not become `stalled` just because time passes. When a run enters `stalled` or recovers from it, the parent agent receives a steer message so it can react. All other status transitions stay in the widget only.
 
+For a non-interactive child that remains genuinely `stalled`, the recovery ladder waits 30 seconds, sends one Escape nudge, waits another 60 seconds to escalate, then waits 90 seconds before closing the pane and aborting the watcher. The delivered result is a `recovery-kill` failure, never a completion. Configure the three consecutive delays (stall→nudge, nudge→escalation, escalation→kill) with comma-separated milliseconds:
+
+```bash
+export PI_SUBAGENT_RECOVERY_DELAYS_MS=30000,60000,90000
+```
+
+Missing or malformed values use those defaults; each value below `10000` ms is clamped to `10000` ms. The ladder runs only from the stalled pane projection, so active/streaming/provider work is not timed out by wall clock. Interactive children and report-only wrap-up stages are exempt.
+
 **Interactive subagents stay silent.** Long-running user-driven subagents (e.g. `planner`, or any `/iterate` fork) do not wake the parent session on `stalled`/`recovered` transitions — the user is working directly in the subagent's pane, and a steer message there would just burn an orchestrator turn on a no-op "still waiting" ping. The widget still updates normally, and activity snapshots are still recorded/classified regardless of the `interactive` setting. By default, agents with `auto-exit: true` are treated as autonomous and get stall pings; agents without it are treated as interactive and stay quiet. Override per-agent with `interactive: true|false` in frontmatter, or per-spawn with `interactive: true|false` on the tool call.
 
 #### Configuration

--- a/agents/planner.md
+++ b/agents/planner.md
@@ -1,6 +1,7 @@
 ---
 name: planner
 description: Interactive planning agent - clarifies WHAT to build and figures out HOW. Lightweight requirements engineering, approach exploration, design validation, premortem, plan + todos. Can spawn scouts/researchers mid-session when it needs facts.
+spawning: true
 system-prompt: append
 ---
 

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "type": "module",
   "scripts": {
     "lint": "oxlint pi-extension test",
-    "test": "node --test test/test.ts test/runtime-routing.test.ts test/release-workflow.test.ts test/harness-drivers.test.ts",
+    "test": "node --test test/test.ts test/runtime-routing.test.ts test/release-workflow.test.ts test/harness-drivers.test.ts test/spawn-grants.test.ts",
     "test:integration": "node --test --test-concurrency=1 test/integration/*.test.ts"
   },
   "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "type": "module",
   "scripts": {
     "lint": "oxlint pi-extension test",
-    "test": "node --test test/test.ts test/subagent-done-autoexit.test.ts test/runtime-routing.test.ts test/release-workflow.test.ts test/harness-drivers.test.ts test/spawn-grants.test.ts",
+    "test": "node --test test/test.ts test/subagent-done-autoexit.test.ts test/runtime-routing.test.ts test/release-workflow.test.ts test/harness-drivers.test.ts test/spawn-grants.test.ts test/recovery-ladder.test.ts",
     "test:integration": "node --test --test-concurrency=1 test/integration/*.test.ts"
   },
   "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "type": "module",
   "scripts": {
     "lint": "oxlint pi-extension test",
-    "test": "node --test test/test.ts test/runtime-routing.test.ts test/release-workflow.test.ts test/harness-drivers.test.ts",
+    "test": "node --test test/test.ts test/subagent-done-autoexit.test.ts test/runtime-routing.test.ts test/release-workflow.test.ts test/harness-drivers.test.ts",
     "test:integration": "node --test --test-concurrency=1 test/integration/*.test.ts"
   },
   "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "type": "module",
   "scripts": {
     "lint": "oxlint pi-extension test",
-    "test": "node --test test/test.ts test/runtime-routing.test.ts test/release-workflow.test.ts test/harness-drivers.test.ts",
+    "test": "node --test test/test.ts test/runtime-routing.test.ts test/release-workflow.test.ts test/harness-drivers.test.ts test/time-limits.test.ts",
     "test:integration": "node --test --test-concurrency=1 test/integration/*.test.ts"
   },
   "peerDependencies": {

--- a/pi-extension/subagents/completion.ts
+++ b/pi-extension/subagents/completion.ts
@@ -6,6 +6,8 @@ const TERMINAL_SENTINEL = /__SUBAGENT_DONE_(\d+)__/;
 export interface CompletionResult {
   reason: "done" | "ping" | "sentinel" | "error";
   exitCode: number;
+  /** The child completed its one-shot report-only continuation after a time warning. */
+  wrapup?: boolean;
   ping?: { name: string; message: string };
   errorMessage?: string;
 }
@@ -31,6 +33,7 @@ export function interpretExitSidecar(data: unknown): CompletionResult {
     name?: unknown;
     message?: unknown;
     errorMessage?: unknown;
+    wrapup?: unknown;
   };
 
   if (payload?.type === "ping") {
@@ -52,7 +55,9 @@ export function interpretExitSidecar(data: unknown): CompletionResult {
     return { reason: "error", exitCode: 1, errorMessage };
   }
 
-  if (payload?.type === "done") return { reason: "done", exitCode: 0 };
+  if (payload?.type === "done") {
+    return { reason: "done", exitCode: 0, ...(payload.wrapup === true ? { wrapup: true } : {}) };
+  }
 
   return {
     reason: "error",

--- a/pi-extension/subagents/harness/drivers/pi.ts
+++ b/pi-extension/subagents/harness/drivers/pi.ts
@@ -70,6 +70,7 @@ export class PiHarnessDriver implements HarnessDriver {
       effectiveAutoExit,
       taskDelivery,
       denySet,
+      childSpawnDepth,
       identity,
       identityInSystemPrompt,
       systemPromptMode,
@@ -123,6 +124,9 @@ export class PiHarnessDriver implements HarnessDriver {
 
     if (denySet && denySet.size > 0) {
       envParts.push(`PI_DENY_TOOLS=${shellQuote([...denySet].join(","))}`);
+    }
+    if (childSpawnDepth != null) {
+      envParts.push(`PI_SUBAGENT_SPAWN_DEPTH=${childSpawnDepth}`);
     }
     envParts.push(`PI_SUBAGENT_NAME=${shellQuote(params.name)}`);
     if (params.agent) {

--- a/pi-extension/subagents/harness/drivers/pi.ts
+++ b/pi-extension/subagents/harness/drivers/pi.ts
@@ -6,6 +6,7 @@ import type {
   BuiltHarnessCommand,
 } from "../types.ts";
 import type { ResolvedRuntimePlan } from "../../runtime-routing.ts";
+import { getSubagentActivityFile } from "../../activity.ts";
 
 const SUBAGENT_CONTROL_TOOLS = ["caller_ping", "subagent_done"] as const;
 
@@ -133,7 +134,7 @@ export class PiHarnessDriver implements HarnessDriver {
     }
     envParts.push(`PI_SUBAGENT_SESSION=${shellQuote(subagentSessionFile)}`);
     envParts.push(`PI_SUBAGENT_ID=${shellQuote(params.id)}`);
-    const activityFile = join(artifactDir, `subagent-activity-${params.id}.json`);
+    const activityFile = getSubagentActivityFile(artifactDir, params.id);
     envParts.push(`PI_SUBAGENT_ACTIVITY_FILE=${shellQuote(activityFile)}`);
     envParts.push(`PI_SUBAGENT_SURFACE=${shellQuote(surface)}`);
 

--- a/pi-extension/subagents/harness/types.ts
+++ b/pi-extension/subagents/harness/types.ts
@@ -48,6 +48,8 @@ export interface SubagentLaunchContext {
   inheritsConversationContext: boolean;
   taskDelivery: "direct" | "artifact";
   denySet?: Set<string>;
+  /** PI_SUBAGENT_SPAWN_DEPTH handed to this child (its children's ceiling); null = unlimited. */
+  childSpawnDepth?: number | null;
   identity?: string | null;
   identityInSystemPrompt?: boolean;
   systemPromptMode?: string;

--- a/pi-extension/subagents/index.ts
+++ b/pi-extension/subagents/index.ts
@@ -2,14 +2,17 @@ import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-a
 import { keyHint } from "@earendil-works/pi-coding-agent";
 import { Type, type Static } from "@sinclair/typebox";
 import { Box, Text, truncateToWidth, visibleWidth } from "@earendil-works/pi-tui";
-import { dirname, join } from "node:path";
+import { basename, dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
+import { randomUUID } from "node:crypto";
 import {
   readdirSync,
   readFileSync,
   writeFileSync,
   existsSync,
   mkdirSync,
+  renameSync,
+  unlinkSync,
 } from "node:fs";
 import { homedir } from "node:os";
 import {
@@ -330,6 +333,72 @@ function readSpawnMetadata(sessionFile: string): { allowance?: unknown } | null 
   } catch {
     return null;
   }
+}
+
+type ResumeSessionCwdResult =
+  | { ok: true; healed: boolean }
+  | { ok: false; error: string };
+
+/** Ensure a resumed session has a cwd that pi can open without prompting. */
+function ensureResumeSessionCwd(sessionFile: string, resumingCwd: string): ResumeSessionCwdResult {
+  let raw: Buffer;
+  try {
+    raw = readFileSync(sessionFile);
+  } catch (error) {
+    const reason = error instanceof Error ? error.message : String(error);
+    return { ok: false, error: `Unable to read session file: ${reason}` };
+  }
+
+  const firstLineEnd = raw.indexOf(0x0a);
+  const firstLine = raw
+    .subarray(0, firstLineEnd === -1 ? raw.length : firstLineEnd)
+    .toString("utf8");
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(firstLine);
+  } catch {
+    return { ok: false, error: "Unable to parse the session header JSON" };
+  }
+  if (
+    parsed === null ||
+    typeof parsed !== "object" ||
+    Array.isArray(parsed) ||
+    typeof (parsed as { cwd?: unknown }).cwd !== "string"
+  ) {
+    return { ok: false, error: "Session header has no valid cwd" };
+  }
+
+  const header = parsed as Record<string, unknown>;
+  if (existsSync(header.cwd as string)) return { ok: true, healed: false };
+
+  const lineEndingStart =
+    firstLineEnd !== -1 && firstLineEnd > 0 && raw[firstLineEnd - 1] === 0x0d
+      ? firstLineEnd - 1
+      : firstLineEnd === -1
+        ? raw.length
+        : firstLineEnd;
+  const rewritten = Buffer.concat([
+    Buffer.from(JSON.stringify({ ...header, cwd: resumingCwd }), "utf8"),
+    raw.subarray(lineEndingStart),
+  ]);
+  const tempFile = join(
+    dirname(sessionFile),
+    `.${basename(sessionFile)}.${process.pid}.${randomUUID()}.tmp`,
+  );
+  try {
+    writeFileSync(tempFile, rewritten, { flag: "wx", mode: 0o600 });
+    renameSync(tempFile, sessionFile);
+  } catch (error) {
+    try {
+      unlinkSync(tempFile);
+    } catch {
+      // Keep the original failure as the block reason.
+    }
+    const reason = error instanceof Error ? error.message : String(error);
+    return { ok: false, error: `Unable to repair missing session cwd: ${reason}` };
+  }
+
+  return { ok: true, healed: true };
 }
 
 /** Same-agent respawn guard: an agent never spawns another instance of itself. */
@@ -1408,6 +1477,7 @@ export const __test__ = {
   decrementSpawnDepth,
   clampResumeSpawn,
   readSpawnMetadata,
+  ensureResumeSessionCwd,
   blockedSelfSpawn,
   SPAWNING_TOOLS,
   resolveInterruptTarget,
@@ -2300,6 +2370,14 @@ export default function subagentsExtension(pi: ExtensionAPI) {
               { type: "text", text: `Error: session file not found: ${params.sessionPath}` },
             ],
             details: { error: "session not found" },
+          };
+        }
+
+        const resumeCwd = ensureResumeSessionCwd(params.sessionPath, ctx.cwd);
+        if (!resumeCwd.ok) {
+          return {
+            content: [{ type: "text", text: `Error: ${resumeCwd.error}` }],
+            details: { error: resumeCwd.error },
           };
         }
 

--- a/pi-extension/subagents/index.ts
+++ b/pi-extension/subagents/index.ts
@@ -210,7 +210,7 @@ interface ListedAgentDefinition extends AgentDefinition {
   source: AgentSource;
 }
 
-/** Tools that are gated by `spawning: false` */
+/** Tools gated behind an explicit frontmatter spawn grant (`spawning: true`) */
 const SPAWNING_TOOLS = new Set([
   "subagent",
   "subagent_interrupt",
@@ -219,21 +219,51 @@ const SPAWNING_TOOLS = new Set([
 ]);
 
 /**
- * Resolve the effective set of denied tool names from agent defaults.
- * `spawning: false` expands to all SPAWNING_TOOLS.
- * `deny-tools` adds individual tool names on top.
+ * Parse PI_SUBAGENT_SPAWN_DEPTH into a child-spawning allowance.
+ * Unset/blank/unparsable/negative → null (unlimited; a frontmatter grant is
+ * still required). A non-negative integer is the generation ceiling granted
+ * to this process's direct children.
  */
-function resolveDenyTools(agentDefs: AgentDefaults | null): Set<string> {
-  const denied = new Set<string>();
-  if (!agentDefs) return denied;
+function parseSpawnDepth(raw: string | undefined | null): number | null {
+  if (raw == null) return null;
+  const trimmed = raw.trim();
+  if (!trimmed) return null;
+  const parsed = Number.parseInt(trimmed, 10);
+  if (!Number.isFinite(parsed) || parsed < 0) return null;
+  return parsed;
+}
 
-  // spawning: false → deny all spawning tools
-  if (agentDefs.spawning === false) {
+/**
+ * Depth handed down to the next generation: decrements by one per
+ * generation, never rises, clamps at zero. Unlimited stays unlimited.
+ */
+function decrementSpawnDepth(allowance: number | null): number | null {
+  return allowance === null ? null : Math.max(0, allowance - 1);
+}
+
+/**
+ * Resolve the effective set of denied tool names from agent defaults.
+ *
+ * Spawning is deny-by-default: all SPAWNING_TOOLS are denied unless the
+ * agent frontmatter explicitly grants `spawning: true` AND depth remains
+ * (`spawnAllowance > 0`, or null = unlimited).
+ * `deny-tools` additions stack on top either way.
+ */
+function resolveDenyTools(
+  agentDefs: AgentDefaults | null,
+  spawnAllowance: number | null = null,
+): Set<string> {
+  const denied = new Set<string>();
+
+  // Deny-by-default: only spawning:true + remaining depth keeps the tools.
+  const spawnGranted =
+    agentDefs?.spawning === true && (spawnAllowance === null || spawnAllowance > 0);
+  if (!spawnGranted) {
     for (const t of SPAWNING_TOOLS) denied.add(t);
   }
 
-  // deny-tools: explicit list
-  if (agentDefs.denyTools) {
+  // deny-tools: explicit list stacks on top of the default denial
+  if (agentDefs?.denyTools) {
     for (const t of agentDefs.denyTools
       .split(",")
       .map((s) => s.trim())
@@ -243,6 +273,48 @@ function resolveDenyTools(agentDefs: AgentDefaults | null): Set<string> {
   }
 
   return denied;
+}
+
+/**
+ * Resume clamp: first-launch metadata is authoritative. The resumed session
+ * never receives more spawning allowance than its first launch recorded —
+ * min(recorded, requested). Missing/corrupt metadata resolves to 0 (deny).
+ */
+function clampResumeSpawn(
+  recorded: { allowance?: unknown } | null | undefined,
+  requestedAllowance: number | null,
+): { maySpawn: boolean; childEnvDepth: number | null } {
+  const capRaw = recorded?.allowance;
+  if (capRaw !== null && (typeof capRaw !== "number" || !Number.isFinite(capRaw) || capRaw < 0)) {
+    return { maySpawn: false, childEnvDepth: 0 };
+  }
+  const cap = capRaw === null ? null : Math.floor(capRaw);
+  const effective =
+    cap === null
+      ? requestedAllowance
+      : requestedAllowance === null
+        ? cap
+        : Math.min(cap, requestedAllowance);
+  const maySpawn = effective === null || effective > 0;
+  return { maySpawn, childEnvDepth: decrementSpawnDepth(effective) };
+}
+
+/**
+ * Read the first-launch spawn metadata sidecar written next to a subagent
+ * session file. Any failure (missing file, corrupt JSON) → null, which the
+ * clamp treats as zero allowance.
+ */
+function readSpawnMetadata(sessionFile: string): { allowance?: unknown } | null {
+  try {
+    return JSON.parse(readFileSync(`${sessionFile}.spawn.json`, "utf8"));
+  } catch {
+    return null;
+  }
+}
+
+/** Same-agent respawn guard: an agent never spawns another instance of itself. */
+function blockedSelfSpawn(requestedAgent: string | undefined, currentAgent: string | undefined): boolean {
+  return !!requestedAgent && !!currentAgent && requestedAgent === currentAgent;
 }
 
 /** Resolve the global agent config directory, respecting PI_CODING_AGENT_DIR. */
@@ -1079,6 +1151,12 @@ export const __test__ = {
   buildPiPromptArgs,
   observeRunningSubagent,
   resolveDenyTools,
+  parseSpawnDepth,
+  decrementSpawnDepth,
+  clampResumeSpawn,
+  readSpawnMetadata,
+  blockedSelfSpawn,
+  SPAWNING_TOOLS,
   resolveInterruptTarget,
   requestSubagentInterrupt,
   handleSubagentInterrupt,
@@ -1197,7 +1275,12 @@ async function launchSubagent(
   const summaryInstruction = effectiveAutoExit
     ? "Your FINAL assistant message should summarize what you accomplished."
     : "Your FINAL assistant message (before calling subagent_done or before the user exits) should summarize what you accomplished.";
-  const denySet = resolveDenyTools(agentDefs);
+  // Spawn grant + depth: this process's PI_SUBAGENT_SPAWN_DEPTH is the
+  // generation ceiling for our direct children; they receive one less so
+  // mutual spawning terminates.
+  const launcherAllowance = parseSpawnDepth(process.env.PI_SUBAGENT_SPAWN_DEPTH);
+  const spawnGranted = agentDefs?.spawning === true;
+  const denySet = resolveDenyTools(agentDefs, launcherAllowance);
   const identity = agentDefs?.body ?? params.systemPrompt ?? null;
   const systemPromptMode = agentDefs?.systemPromptMode;
   const identityInSystemPrompt = systemPromptMode && identity;
@@ -1222,6 +1305,7 @@ async function launchSubagent(
     inheritsConversationContext,
     taskDelivery: launchBehavior.taskDelivery,
     denySet,
+    childSpawnDepth: decrementSpawnDepth(launcherAllowance),
     identity,
     identityInSystemPrompt: Boolean(identityInSystemPrompt),
     systemPromptMode,
@@ -1267,6 +1351,18 @@ async function launchSubagent(
       ? markProcessRunning(createLifecycle(startTime), Date.now())
       : createLifecycle(startTime),
   };
+
+  // First-launch spawn metadata: authoritative cap for later subagent_resume.
+  // Non-granted agents record 0 so resume can never enlarge their rights.
+  try {
+    writeFileSync(
+      `${running.sessionFile}.spawn.json`,
+      JSON.stringify({ allowance: spawnGranted ? launcherAllowance ?? null : 0 }),
+      "utf8",
+    );
+  } catch {
+    // Unwritable sidecar ⇒ resume conservatively denies spawning.
+  }
 
   runningSubagents.set(id, running);
   return running;
@@ -1501,8 +1597,7 @@ export default function subagentsExtension(pi: ExtensionAPI) {
 
       async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
         // Prevent self-spawning (e.g. planner spawning another planner)
-        const currentAgent = process.env.PI_SUBAGENT_AGENT;
-        if (params.agent && currentAgent && params.agent === currentAgent) {
+        if (blockedSelfSpawn(params.agent, process.env.PI_SUBAGENT_AGENT)) {
           return {
             content: [
               {
@@ -1964,6 +2059,18 @@ export default function subagentsExtension(pi: ExtensionAPI) {
         resumeEnvParts.push(`PI_SUBAGENT_ACTIVITY_FILE=${shellQuote(activityFile)}`);
         if (autoExit) {
           resumeEnvParts.push(`PI_SUBAGENT_AUTO_EXIT=1`);
+        }
+        // Spawn rights on resume are clamped to what the first launch recorded:
+        // missing metadata ⇒ 0 (deny); never larger than first launch.
+        const resumeSpawn = clampResumeSpawn(
+          readSpawnMetadata(params.sessionPath),
+          parseSpawnDepth(process.env.PI_SUBAGENT_SPAWN_DEPTH),
+        );
+        if (!resumeSpawn.maySpawn) {
+          resumeEnvParts.push(`PI_DENY_TOOLS=${shellQuote([...SPAWNING_TOOLS].join(","))}`);
+        }
+        if (resumeSpawn.childEnvDepth !== null) {
+          resumeEnvParts.push(`PI_SUBAGENT_SPAWN_DEPTH=${resumeSpawn.childEnvDepth}`);
         }
         const resumeEnvPrefix = resumeEnvParts.join(" ") + " ";
 

--- a/pi-extension/subagents/index.ts
+++ b/pi-extension/subagents/index.ts
@@ -78,6 +78,13 @@ import {
   type SubagentLifecycle,
   type PaneInspection,
 } from "./lifecycle.ts";
+import {
+  advanceRecoveryLadder,
+  formatRecoveryKillError,
+  parseRecoveryDelays,
+  type RecoveryDelays,
+  type RecoveryState,
+} from "./recovery.ts";
 
 /** Absolute path to `pi-extension/subagents`. https://github.com/nodejs/node/issues/37845 */
 const SUBAGENTS_DIR = dirname(fileURLToPath(import.meta.url));
@@ -584,6 +591,10 @@ interface RunningSubagent {
     error?: string;
   };
   abortController?: AbortController;
+  recovery?: RecoveryState;
+  recoveryKilled?: { errorMessage: string; killedAt: number };
+  /** Reserved for the L-96 report-only continuation. */
+  wrapupPending?: boolean;
   cli?: string;
   sentinelFile?: string;
   /**
@@ -604,6 +615,18 @@ interface RunningSubagent {
   /** Parent-resolved model/thinking selection and provenance. */
   runtimePlan: ResolvedRuntimePlan | undefined;
 }
+
+interface RecoveryPaneOperations {
+  interruptPane: (surface: string) => void;
+  closePane: (surface: string) => void;
+  abortWatcher: (controller: AbortController | undefined) => void;
+}
+
+const DEFAULT_RECOVERY_PANE_OPERATIONS: RecoveryPaneOperations = {
+  interruptPane,
+  closePane,
+  abortWatcher: (controller) => controller?.abort(),
+};
 
 interface SubagentRuntime {
   runningSubagents: Map<string, RunningSubagent>;
@@ -946,6 +969,75 @@ function requestSubagentInterrupt(
   }
 }
 
+function isTerminalLifecycle(lifecycle: SubagentLifecycle): boolean {
+  return lifecycle.process.kind === "completed" || lifecycle.process.kind === "failed";
+}
+
+/** Idempotent failure teardown shared with future hard-stop paths. */
+function failAndTeardownSubagent(
+  running: RunningSubagent,
+  error: string,
+  now: number,
+  operations: Pick<RecoveryPaneOperations, "closePane" | "abortWatcher"> = DEFAULT_RECOVERY_PANE_OPERATIONS,
+  beforeAbort?: () => void,
+): boolean {
+  const lifecycle = ensureLifecycle(running);
+  if (isTerminalLifecycle(lifecycle)) return false;
+
+  beforeAbort?.();
+  running.lifecycle = markFailed(lifecycle, error, now, 1);
+  try {
+    operations.closePane(running.surface);
+  } catch {}
+  try {
+    operations.abortWatcher(running.abortController);
+  } catch {}
+  return true;
+}
+
+function advanceRunningRecovery(
+  running: RunningSubagent,
+  projection: LifecycleProjection,
+  now: number,
+  delays: RecoveryDelays,
+  operations: RecoveryPaneOperations = DEFAULT_RECOVERY_PANE_OPERATIONS,
+) {
+  const advance = advanceRecoveryLadder(running.recovery, {
+    now,
+    stalled: projection.kind === "stalled",
+    exempt: running.interactive || running.wrapupPending === true,
+    delays,
+  });
+  running.recovery = advance.state;
+
+  if (advance.action === "nudge") {
+    requestSubagentInterrupt(running, operations.interruptPane);
+  } else if (advance.action === "kill") {
+    const error = formatRecoveryKillError(now - running.startTime);
+    failAndTeardownSubagent(running, error, now, operations, () => {
+      // The watcher observes its abort asynchronously, so set this first.
+      running.recoveryKilled = { errorMessage: error, killedAt: now };
+    });
+  }
+
+  return advance;
+}
+
+function buildRecoveryKilledResult(running: RunningSubagent, now: number): SubagentResult | null {
+  const recoveryKilled = running.recoveryKilled;
+  if (!recoveryKilled) return null;
+  return {
+    name: running.name,
+    task: running.task,
+    summary: `Subagent error: ${recoveryKilled.errorMessage}`,
+    sessionFile: running.sessionFile,
+    exitCode: 1,
+    elapsed: Math.floor(Math.max(0, now - running.startTime) / 1000),
+    error: recoveryKilled.errorMessage,
+    errorMessage: recoveryKilled.errorMessage,
+  };
+}
+
 function handleSubagentInterrupt(
   params: { id?: string; name?: string },
   interruptPaneKey: (surface: string) => void = interruptPane,
@@ -997,6 +1089,7 @@ function handleSubagentInterrupt(
 
 function startStatusRefresh(pi: ExtensionAPI) {
   if (!statusConfig.enabled || statusInterval) return;
+  const recoveryDelays = parseRecoveryDelays(process.env.PI_SUBAGENT_RECOVERY_DELAYS_MS);
 
   statusInterval = setInterval(() => {
     if (runningSubagents.size === 0) {
@@ -1016,6 +1109,8 @@ function startStatusRefresh(pi: ExtensionAPI) {
       // Dual-writes lifecycle + statusState for reload hydration; steers use lifecycle only.
       observeRunningSubagent(running, now);
       const projection = projectLifecycle(ensureLifecycle(running), now);
+      const recovery = advanceRunningRecovery(running, projection, now, recoveryDelays);
+      if (recovery.action) shouldRefreshWidget = true;
       const transition = lifecycleTransition(running.lastProjectedKind, projection.kind);
       if (running.lastProjectedKind !== projection.kind) {
         shouldRefreshWidget = true;
@@ -1081,6 +1176,9 @@ export const __test__ = {
   resolveDenyTools,
   resolveInterruptTarget,
   requestSubagentInterrupt,
+  failAndTeardownSubagent,
+  advanceRunningRecovery,
+  buildRecoveryKilledResult,
   handleSubagentInterrupt,
   resolveResultPresentation,
   resolveResumeLaunchBehavior,
@@ -1301,6 +1399,11 @@ async function watchSubagent(
     });
 
     const detectedAt = Date.now();
+    const recoveryResult = buildRecoveryKilledResult(running, detectedAt);
+    if (recoveryResult) {
+      updateWidget();
+      return recoveryResult;
+    }
     running.lifecycle = markCompletionDetected(running.lifecycle, result, detectedAt);
     updateWidget();
     const elapsed = Math.floor((detectedAt - startTime) / 1000);
@@ -1395,13 +1498,21 @@ async function watchSubagent(
       ...(result.errorMessage ? { errorMessage: result.errorMessage } : {}),
     };
   } catch (err: any) {
+    const now = Date.now();
+    const recoveryResult = buildRecoveryKilledResult(running, now);
+    if (recoveryResult) {
+      running.lifecycle = markFailed(running.lifecycle, recoveryResult.errorMessage!, now, 1);
+      updateWidget();
+      return recoveryResult;
+    }
+
     try {
       closePane(surface);
     } catch {}
     running.lifecycle = markFailed(
       running.lifecycle,
       signal.aborted ? "Subagent cancelled." : err?.message ?? String(err),
-      Date.now(),
+      now,
       1,
     );
     updateWidget();
@@ -1412,7 +1523,7 @@ async function watchSubagent(
         task,
         summary: "Subagent cancelled.",
         exitCode: 1,
-        elapsed: Math.floor((Date.now() - startTime) / 1000),
+        elapsed: Math.floor((now - startTime) / 1000),
         error: "cancelled",
         sessionFile,
       };
@@ -1422,7 +1533,7 @@ async function watchSubagent(
       task,
       summary: `Subagent error: ${err?.message ?? String(err)}`,
       exitCode: 1,
-      elapsed: Math.floor((Date.now() - startTime) / 1000),
+      elapsed: Math.floor((now - startTime) / 1000),
       error: err?.message ?? String(err),
     };
   }

--- a/pi-extension/subagents/index.ts
+++ b/pi-extension/subagents/index.ts
@@ -1597,7 +1597,10 @@ export default function subagentsExtension(pi: ExtensionAPI) {
 
       async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
         // Prevent self-spawning (e.g. planner spawning another planner)
-        if (blockedSelfSpawn(params.agent, process.env.PI_SUBAGENT_AGENT)) {
+        // Non-empty here is guaranteed by blockedSelfSpawn requiring both args
+        // truthy and equal, so the message always renders a real identity.
+        const currentAgent = process.env.PI_SUBAGENT_AGENT;
+        if (blockedSelfSpawn(params.agent, currentAgent)) {
           return {
             content: [
               {

--- a/pi-extension/subagents/index.ts
+++ b/pi-extension/subagents/index.ts
@@ -85,6 +85,16 @@ import {
   type RecoveryDelays,
   type RecoveryState,
 } from "./recovery.ts";
+import {
+  cleanupWrapupDirective,
+  evalTimeLimit,
+  formatTimeLimitError,
+  getTimeLimitDeadlineAt,
+  parsePositiveIntegerSeconds,
+  parseTimeoutWarnThreshold,
+  writeWrapupDirective,
+  type TimeLimitConfig,
+} from "./time-limits.ts";
 
 /** Absolute path to `pi-extension/subagents`. https://github.com/nodejs/node/issues/37845 */
 const SUBAGENTS_DIR = dirname(fileURLToPath(import.meta.url));
@@ -196,6 +206,9 @@ interface AgentDefaults {
   spawning?: boolean;
   autoExit?: boolean;
   interactive?: boolean;
+  timeLimitSeconds?: number;
+  idleTimeoutSeconds?: number;
+  timeoutWarnThreshold?: number;
   systemPromptMode?: "append" | "replace";
   sessionMode?: SubagentSessionMode;
   cwd?: string;
@@ -310,6 +323,11 @@ function parseAgentDefinition(content: string, fallbackName: string): AgentDefin
     spawning: parseOptionalBoolean(getFrontmatterValue(frontmatter, "spawning")),
     autoExit: parseOptionalBoolean(getFrontmatterValue(frontmatter, "auto-exit")),
     interactive: parseOptionalBoolean(getFrontmatterValue(frontmatter, "interactive")),
+    timeLimitSeconds: parsePositiveIntegerSeconds(getFrontmatterValue(frontmatter, "time-limit")),
+    idleTimeoutSeconds: parsePositiveIntegerSeconds(getFrontmatterValue(frontmatter, "idle-timeout")),
+    timeoutWarnThreshold: parseTimeoutWarnThreshold(
+      getFrontmatterValue(frontmatter, "timeout-warn-threshold"),
+    ),
     sessionMode: parseSessionMode(getFrontmatterValue(frontmatter, "session-mode")),
     cwd: getFrontmatterValue(frontmatter, "cwd"),
     cli: getFrontmatterValue(frontmatter, "cli"),
@@ -471,6 +489,20 @@ function resolveEffectiveInteractive(
   return !resolveEffectiveAutoExit(params, agentDefs);
 }
 
+function resolveTimeLimitConfig(
+  agentDefs: AgentDefaults | null,
+  interactive: boolean,
+  supportsWrapup = true,
+): TimeLimitConfig | undefined {
+  if (interactive || !agentDefs) return undefined;
+  const config: TimeLimitConfig = {
+    timeLimitSeconds: agentDefs.timeLimitSeconds,
+    idleTimeoutSeconds: agentDefs.idleTimeoutSeconds,
+    timeoutWarnThreshold: supportsWrapup ? agentDefs.timeoutWarnThreshold : undefined,
+  };
+  return config.timeLimitSeconds || config.idleTimeoutSeconds ? config : undefined;
+}
+
 function loadAgentDefaults(agentName: string): AgentDefaults | null {
   // Resolve through the same name-keyed map discoverAgentDefinitions() builds
   // for the tool-guidance catalog, so a name advertised there always resolves
@@ -527,7 +559,7 @@ const modelConfig = loadModelConfig();
 function resolveResultPresentation(
   result: Pick<
     SubagentResult,
-    "exitCode" | "elapsed" | "summary" | "sessionFile" | "errorMessage"
+    "exitCode" | "elapsed" | "summary" | "sessionFile" | "errorMessage" | "partial" | "timeout"
   >,
   name: string,
 ): string {
@@ -549,9 +581,23 @@ function resolveResultPresentation(
     );
   }
 
+  if (result.partial) {
+    return (
+      `Sub-agent "${name}" delivered a partial report under its time limit ` +
+      `(${formatElapsed(result.elapsed)}).\n\n${result.summary}${sessionRef}`
+    );
+  }
+
   return result.exitCode !== 0
     ? `Sub-agent "${name}" failed (exit code ${result.exitCode}).\n\n${result.summary}${sessionRef}`
     : `Sub-agent "${name}" completed (${formatElapsed(result.elapsed)}).\n\n${result.summary}${sessionRef}`;
+}
+
+function buildResultTimeoutDetails(result: Pick<SubagentResult, "partial" | "timeout">) {
+  return {
+    ...(result.partial ? { partial: true } : {}),
+    ...(result.timeout ? { timeout: result.timeout } : {}),
+  };
 }
 
 /**
@@ -568,6 +614,9 @@ interface SubagentResult {
   error?: string;
   /** Provider/agent error message when auto-retry exhausted (overload, rate limit, etc.). */
   errorMessage?: string;
+  /** A normal completion produced by the one-shot time-limit report continuation. */
+  partial?: boolean;
+  timeout?: "warned-wrapup" | "hard-stop";
   ping?: { name: string; message: string };
 }
 
@@ -593,7 +642,12 @@ interface RunningSubagent {
   abortController?: AbortController;
   recovery?: RecoveryState;
   recoveryKilled?: { errorMessage: string; killedAt: number };
-  /** Reserved for the L-96 report-only continuation. */
+  timeLimit?: TimeLimitConfig;
+  timeLimitWarned?: boolean;
+  /** The deadline fixed at warning time so fresh report activity cannot extend an idle limit. */
+  timeLimitDeadlineAt?: number;
+  timeLimitStopped?: { errorMessage: string; stoppedAt: number };
+  /** A report-only continuation has been requested and awaits its normal completion. */
   wrapupPending?: boolean;
   cli?: string;
   sentinelFile?: string;
@@ -626,6 +680,17 @@ const DEFAULT_RECOVERY_PANE_OPERATIONS: RecoveryPaneOperations = {
   interruptPane,
   closePane,
   abortWatcher: (controller) => controller?.abort(),
+};
+
+interface TimeLimitPaneOperations extends RecoveryPaneOperations {
+  writeWrapup: (sessionFile: string) => void;
+  removeWrapup: (sessionFile: string) => void;
+}
+
+const DEFAULT_TIME_LIMIT_PANE_OPERATIONS: TimeLimitPaneOperations = {
+  ...DEFAULT_RECOVERY_PANE_OPERATIONS,
+  writeWrapup: writeWrapupDirective,
+  removeWrapup: cleanupWrapupDirective,
 };
 
 interface SubagentRuntime {
@@ -1005,7 +1070,10 @@ function advanceRunningRecovery(
   const advance = advanceRecoveryLadder(running.recovery, {
     now,
     stalled: projection.kind === "stalled",
-    exempt: running.interactive || running.wrapupPending === true,
+    exempt:
+      running.interactive ||
+      running.wrapupPending === true ||
+      running.timeLimitStopped != null,
     delays,
   });
   running.recovery = advance.state;
@@ -1035,6 +1103,94 @@ function buildRecoveryKilledResult(running: RunningSubagent, now: number): Subag
     elapsed: Math.floor(Math.max(0, now - running.startTime) / 1000),
     error: recoveryKilled.errorMessage,
     errorMessage: recoveryKilled.errorMessage,
+  };
+}
+
+function advanceRunningTimeLimit(
+  running: RunningSubagent,
+  now: number,
+  operations: TimeLimitPaneOperations = DEFAULT_TIME_LIMIT_PANE_OPERATIONS,
+): { action: "warn" | "hard-stop" | null } {
+  if (
+    running.interactive ||
+    !running.timeLimit ||
+    running.recoveryKilled ||
+    running.timeLimitStopped
+  ) {
+    return { action: null };
+  }
+
+  const lastActivityAt = running.activity?.updatedAt;
+  const action = running.timeLimitDeadlineAt != null
+    ? now >= running.timeLimitDeadlineAt ? "hard-stop" : "none"
+    : evalTimeLimit(
+      now,
+      running.startTime,
+      lastActivityAt,
+      running.timeLimit,
+      running.timeLimitWarned === true,
+    );
+
+  if (action === "warn") {
+    try {
+      operations.writeWrapup(running.sessionFile);
+    } catch {
+      return { action: null };
+    }
+    const interruption = requestSubagentInterrupt(running, operations.interruptPane);
+    if ("error" in interruption) {
+      try {
+        operations.removeWrapup(running.sessionFile);
+      } catch {}
+      return { action: null };
+    }
+
+    running.timeLimitWarned = true;
+    running.wrapupPending = true;
+    running.timeLimitDeadlineAt = getTimeLimitDeadlineAt(
+      running.startTime,
+      lastActivityAt,
+      running.timeLimit,
+    );
+    running.lifecycle = markInterruptRequested(ensureLifecycle(running), now);
+    return { action: "warn" };
+  }
+
+  if (action === "hard-stop") {
+    const error = formatTimeLimitError(now - running.startTime);
+    const stopped = failAndTeardownSubagent(running, error, now, operations, () => {
+      running.timeLimitStopped = { errorMessage: error, stoppedAt: now };
+      running.wrapupPending = false;
+      try {
+        operations.removeWrapup(running.sessionFile);
+      } catch {}
+    });
+    return { action: stopped ? "hard-stop" : null };
+  }
+
+  return { action: null };
+}
+
+function buildTimeLimitStoppedResult(running: RunningSubagent, now: number): SubagentResult | null {
+  const stopped = running.timeLimitStopped;
+  if (!stopped) return null;
+
+  let tail: string | null = null;
+  try {
+    if (existsSync(running.sessionFile)) {
+      tail = findLastAssistantMessage(getNewEntries(running.sessionFile, 0));
+    }
+  } catch {}
+
+  return {
+    name: running.name,
+    task: running.task,
+    summary: `${stopped.errorMessage}${tail ? `\n\nLast session output:\n${tail}` : ""}`,
+    sessionFile: running.sessionFile,
+    exitCode: 1,
+    elapsed: Math.floor(Math.max(0, now - running.startTime) / 1_000),
+    error: stopped.errorMessage,
+    timeout: "hard-stop",
   };
 }
 
@@ -1170,6 +1326,8 @@ export const __test__ = {
   resolveLaunchBehavior,
   resolveEffectiveAutoExit,
   resolveEffectiveInteractive,
+  resolveTimeLimitConfig,
+  parseAgentDefinition,
   buildSubagentToolAllowlist,
   buildPiPromptArgs,
   observeRunningSubagent,
@@ -1179,6 +1337,9 @@ export const __test__ = {
   failAndTeardownSubagent,
   advanceRunningRecovery,
   buildRecoveryKilledResult,
+  advanceRunningTimeLimit,
+  buildTimeLimitStoppedResult,
+  buildResultTimeoutDetails,
   handleSubagentInterrupt,
   resolveResultPresentation,
   resolveResumeLaunchBehavior,
@@ -1234,6 +1395,9 @@ async function launchSubagent(
   const effectiveThinking = runtimePlan.thinking;
   const effectiveAutoExit = resolveEffectiveAutoExit(params, agentDefs);
   const effectiveInteractive = resolveEffectiveInteractive(params, agentDefs);
+  const cliId = agentDefs?.cli ?? "pi";
+  const driver = getHarnessDriver(cliId);
+  const timeLimit = resolveTimeLimitConfig(agentDefs, effectiveInteractive, driver.id === "pi");
 
   const sessionFile = ctx.sessionManager.getSessionFile();
   if (!sessionFile) throw new Error("No session file");
@@ -1256,8 +1420,6 @@ async function launchSubagent(
   ].join("-");
   const subagentSessionFile = join(sessionDir, `${timestamp}_${uuid}.jsonl`);
 
-  const cliId = agentDefs?.cli ?? "pi";
-  const driver = getHarnessDriver(cliId);
   driver.validateRuntimePlan?.(runtimePlan, parentThinking);
 
   const surfacePreCreated = !!options?.surface;
@@ -1361,6 +1523,7 @@ async function launchSubagent(
     interactive: effectiveInteractive,
     runtimePlan,
     activityFile: driver.hasActivitySnapshots ? activityFile : undefined,
+    timeLimit,
     lifecycle: !driver.hasActivitySnapshots
       ? markProcessRunning(createLifecycle(startTime), Date.now())
       : createLifecycle(startTime),
@@ -1394,11 +1557,18 @@ async function watchSubagent(
         updateWidget();
       },
       onTick() {
-        observeRunningSubagent(running);
+        const now = Date.now();
+        observeRunningSubagent(running, now);
+        if (advanceRunningTimeLimit(running, now).action) updateWidget();
       },
     });
 
     const detectedAt = Date.now();
+    const timeLimitResult = buildTimeLimitStoppedResult(running, detectedAt);
+    if (timeLimitResult) {
+      updateWidget();
+      return timeLimitResult;
+    }
     const recoveryResult = buildRecoveryKilledResult(running, detectedAt);
     if (recoveryResult) {
       updateWidget();
@@ -1432,6 +1602,7 @@ async function watchSubagent(
           exitCode: result.exitCode,
           elapsed,
           ...(extracted.sessionId ? { claudeSessionId: extracted.sessionId } : {}),
+          ...(result.wrapup ? { partial: true, timeout: "warned-wrapup" as const } : {}),
           ...extracted.details,
         };
       }
@@ -1495,10 +1666,16 @@ async function watchSubagent(
       exitCode: result.exitCode,
       elapsed,
       ping: result.ping,
+      ...(result.wrapup ? { partial: true, timeout: "warned-wrapup" as const } : {}),
       ...(result.errorMessage ? { errorMessage: result.errorMessage } : {}),
     };
   } catch (err: any) {
     const now = Date.now();
+    const timeLimitResult = buildTimeLimitStoppedResult(running, now);
+    if (timeLimitResult) {
+      updateWidget();
+      return timeLimitResult;
+    }
     const recoveryResult = buildRecoveryKilledResult(running, now);
     if (recoveryResult) {
       running.lifecycle = markFailed(running.lifecycle, recoveryResult.errorMessage!, now, 1);
@@ -1536,6 +1713,8 @@ async function watchSubagent(
       elapsed: Math.floor((now - startTime) / 1000),
       error: err?.message ?? String(err),
     };
+  } finally {
+    cleanupWrapupDirective(sessionFile);
   }
 }
 
@@ -1717,6 +1896,7 @@ export default function subagentsExtension(pi: ExtensionAPI) {
                   exitCode: result.exitCode,
                   elapsed: result.elapsed,
                   sessionFile: result.sessionFile,
+                  ...buildResultTimeoutDetails(result),
                   ...(result.errorMessage ? { errorMessage: result.errorMessage } : {}),
                   ...(result.claudeSessionId ? { claudeSessionId: result.claudeSessionId } : {}),
                   ...(running.runtimePlan ? { runtimePlan: running.runtimePlan } : {}),
@@ -2179,6 +2359,7 @@ export default function subagentsExtension(pi: ExtensionAPI) {
                   exitCode: result.exitCode,
                   elapsed: result.elapsed,
                   sessionFile: params.sessionPath,
+                  ...buildResultTimeoutDetails(result),
                   ...(result.errorMessage ? { errorMessage: result.errorMessage } : {}),
                   ...(running.runtimePlan ? { runtimePlan: running.runtimePlan } : {}),
                 },
@@ -2273,18 +2454,25 @@ export default function subagentsExtension(pi: ExtensionAPI) {
         const exitCode = details.exitCode ?? 0;
         const errorMessage = typeof details.errorMessage === "string" ? details.errorMessage : "";
         const failed = exitCode !== 0 || !!errorMessage;
+        const partial = !failed && (details.partial === true || details.timeout === "warned-wrapup");
         const elapsed = details.elapsed != null ? formatElapsed(details.elapsed) : "?";
         const bgFn = failed
           ? (text: string) => theme.bg("toolErrorBg", text)
-          : (text: string) => theme.bg("toolSuccessBg", text);
+          : partial
+            ? (text: string) => theme.bg("customMessageBg", text)
+            : (text: string) => theme.bg("toolSuccessBg", text);
         const icon = failed
           ? theme.fg("error", "✗")
-          : theme.fg("success", "✓");
+          : partial
+            ? theme.fg("warning", "⚠")
+            : theme.fg("success", "✓");
         const status = errorMessage
           ? "failed (provider/agent error)"
           : failed
             ? `failed (exit ${exitCode})`
-            : "completed";
+            : partial
+              ? "partial report (time limit)"
+              : "completed";
         const agentTag = details.agent ? theme.fg("dim", ` (${details.agent})`) : "";
 
         const header = `${icon} ${theme.fg("toolTitle", theme.bold(name))}${agentTag} ${theme.fg("dim", "—")} ${status} ${theme.fg("dim", `(${elapsed})`)}`;

--- a/pi-extension/subagents/recovery.ts
+++ b/pi-extension/subagents/recovery.ts
@@ -1,0 +1,61 @@
+export const MIN_RECOVERY_DELAY_MS = 10_000;
+export const DEFAULT_RECOVERY_DELAYS = [30_000, 60_000, 90_000] as const;
+
+export type RecoveryDelays = readonly [number, number, number];
+export type RecoveryStage = "waiting" | "nudged" | "escalated" | "killed";
+export type RecoveryAction = "nudge" | "escalate" | "kill" | null;
+
+export interface RecoveryState {
+  stage: RecoveryStage;
+  stageSince: number;
+}
+
+export interface RecoveryAdvance {
+  state: RecoveryState | undefined;
+  action: RecoveryAction;
+}
+
+function defaultRecoveryDelays(): RecoveryDelays {
+  return [...DEFAULT_RECOVERY_DELAYS];
+}
+
+/** Parse PI_SUBAGENT_RECOVERY_DELAYS_MS without reading process.env. */
+export function parseRecoveryDelays(raw: string | undefined): RecoveryDelays {
+  const parts = raw?.split(",").map((part) => part.trim());
+  if (!parts || parts.length !== 3 || parts.some((part) => !part)) {
+    return defaultRecoveryDelays();
+  }
+
+  const values = parts.map(Number);
+  if (values.some((value) => !Number.isSafeInteger(value))) {
+    return defaultRecoveryDelays();
+  }
+
+  return values.map((value) => Math.max(MIN_RECOVERY_DELAY_MS, value)) as RecoveryDelays;
+}
+
+/** Advance one stalled-child recovery tick using the caller's clock. */
+export function advanceRecoveryLadder(
+  state: RecoveryState | undefined,
+  input: { now: number; stalled: boolean; exempt: boolean; delays: RecoveryDelays },
+): RecoveryAdvance {
+  if (state?.stage === "killed") return { state, action: null };
+  if (!input.stalled || input.exempt) return { state: undefined, action: null };
+  if (!state) return { state: { stage: "waiting", stageSince: input.now }, action: null };
+
+  const elapsed = Math.max(0, input.now - state.stageSince);
+  if (state.stage === "waiting" && elapsed >= input.delays[0]) {
+    return { state: { stage: "nudged", stageSince: input.now }, action: "nudge" };
+  }
+  if (state.stage === "nudged" && elapsed >= input.delays[1]) {
+    return { state: { stage: "escalated", stageSince: input.now }, action: "escalate" };
+  }
+  if (state.stage === "escalated" && elapsed >= input.delays[2]) {
+    return { state: { stage: "killed", stageSince: input.now }, action: "kill" };
+  }
+  return { state, action: null };
+}
+
+export function formatRecoveryKillError(elapsedMs: number): string {
+  return `Subagent recovery-kill after ${Math.floor(Math.max(0, elapsedMs) / 1000)}s.`;
+}

--- a/pi-extension/subagents/subagent-done.ts
+++ b/pi-extension/subagents/subagent-done.ts
@@ -8,6 +8,7 @@ import { Box, Text } from "@earendil-works/pi-tui";
 import { Type } from "@sinclair/typebox";
 import { writeFileSync } from "node:fs";
 import { createSubagentActivityRecorder } from "./activity.ts";
+import { consumeWrapupDirective } from "./time-limits.ts";
 
 export function shouldMarkUserTookOver(agentStarted: boolean): boolean {
   return agentStarted;
@@ -68,11 +69,19 @@ export function findLatestAssistantError(
   return null;
 }
 
-export function buildCompletionSidecar(messages: any[] | undefined):
-  | { type: "done" }
+export function buildCompletionSidecar(messages: any[] | undefined, wrapup = false):
+  | { type: "done"; wrapup?: true }
   | { type: "error"; errorMessage: string; stopReason: "error" } {
   const errorInfo = findLatestAssistantError(messages);
-  return errorInfo ? { type: "error", ...errorInfo } : { type: "done" };
+  return errorInfo ? { type: "error", ...errorInfo } : { type: "done", ...(wrapup ? { wrapup: true } : {}) };
+}
+
+export function latestAssistantWasAborted(messages: any[] | undefined): boolean {
+  if (!messages) return false;
+  for (let i = messages.length - 1; i >= 0; i--) {
+    if (messages[i]?.role === "assistant") return messages[i].stopReason === "aborted";
+  }
+  return false;
 }
 
 export function parseDeniedTools(rawValue: string | undefined): string[] {
@@ -151,6 +160,7 @@ export default function (pi: ExtensionAPI) {
   let userTookOver = false;
   let agentStarted = false;
   let latestAgentMessages: any[] | undefined;
+  let wrapupInProgress = false;
 
   // Show widget + status bar on session start
   pi.on("session_start", (_event, ctx) => {
@@ -162,8 +172,11 @@ export default function (pi: ExtensionAPI) {
     renderWidget(ctx, null);
   });
 
-  pi.on("input", () => {
+  pi.on("input", (event) => {
     recorder.input();
+    // Extension-injected report directives are not operator takeover. This keeps
+    // the report-only continuation compatible with sticky auto-exit disarming.
+    if ((event as any).source === "extension") return;
     // Ignore the initial task message that starts an autonomous subagent.
     // Only inputs after the first agent run has started count as user takeover.
     if (!shouldMarkUserTookOver(agentStarted)) return;
@@ -188,19 +201,30 @@ export default function (pi: ExtensionAPI) {
   });
 
   pi.on("agent_settled", (_event, ctx) => {
-    const shouldExit = autoExit
-      && shouldAutoExitOnAgentEnd(userTookOver, latestAgentMessages);
+    const sessionFile = process.env.PI_SUBAGENT_SESSION;
+    const directive = !wrapupInProgress && latestAssistantWasAborted(latestAgentMessages)
+      ? consumeWrapupDirective(sessionFile)
+      : null;
+    if (directive) {
+      wrapupInProgress = true;
+      // This creates an extension-sourced turn; it is not text typed into the pane.
+      pi.sendUserMessage(directive);
+      return;
+    }
+
+    const shouldExit =
+      (autoExit && shouldAutoExitOnAgentEnd(userTookOver, latestAgentMessages)) ||
+      (wrapupInProgress && !latestAssistantWasAborted(latestAgentMessages));
 
     if (shouldExit) {
       // Surface stopReason: "error" turns (auto-retry exhausted, provider
       // overload, etc.) to the parent via the .exit sidecar so the watcher
       // can report a clear failure with the underlying error message.
-      const sessionFile = process.env.PI_SUBAGENT_SESSION;
       if (sessionFile) {
         try {
           writeFileSync(
             `${sessionFile}.exit`,
-            JSON.stringify(buildCompletionSidecar(latestAgentMessages)),
+            JSON.stringify(buildCompletionSidecar(latestAgentMessages, wrapupInProgress)),
           );
         } catch {
           // Best effort — the watcher can still detect the terminal sentinel
@@ -320,7 +344,10 @@ export default function (pi: ExtensionAPI) {
       const sessionFile = process.env.PI_SUBAGENT_SESSION;
       recorder.subagentDone();
       if (sessionFile) {
-        writeFileSync(`${sessionFile}.exit`, JSON.stringify({ type: "done" }));
+        writeFileSync(
+          `${sessionFile}.exit`,
+          JSON.stringify({ type: "done", ...(wrapupInProgress ? { wrapup: true } : {}) }),
+        );
       }
       ctx.shutdown();
       return {

--- a/pi-extension/subagents/subagent-done.ts
+++ b/pi-extension/subagents/subagent-done.ts
@@ -37,6 +37,40 @@ export function shouldAutoExitOnAgentEnd(
   return true;
 }
 
+export interface AutoExitDecisionState {
+  /** Sticky: set when the operator typed into the session or Escape-aborted a run. */
+  disarmed: boolean;
+  /** Set by /auto-exit: allows exactly one more settled completion to exit. */
+  oneShotReArm: boolean;
+}
+
+/**
+ * Pure auto-exit decision for a settled agent turn.
+ *
+ * - Armed and untouched: exits on terminal stops and errors exactly as
+ *   v0.2.0 did; Escape-aborted runs keep the session open.
+ * - Disarmed (operator takeover): never exits, whatever the stop reason.
+ * - One-shot re-arm (/auto-exit): behaves like armed for a single further
+ *   completion; the caller consumes the flag once that exit happens.
+ */
+export function resolveAutoExit(
+  state: AutoExitDecisionState,
+  stopReason: string | undefined,
+): boolean {
+  if (state.disarmed && !state.oneShotReArm) return false;
+  return stopReason !== "aborted";
+}
+
+function latestAssistantStopReason(messages: any[] | undefined): string | undefined {
+  if (messages) {
+    for (let i = messages.length - 1; i >= 0; i--) {
+      const msg = messages[i];
+      if (msg?.role === "assistant") return msg.stopReason as string | undefined;
+    }
+  }
+  return undefined;
+}
+
 export interface SubagentErrorInfo {
   errorMessage: string;
   stopReason: "error";
@@ -148,9 +182,25 @@ export default function (pi: ExtensionAPI) {
     );
   }
 
-  let userTookOver = false;
+  let disarmed = false;
+  let oneShotReArm = false;
+  let warnedOperatorTakeover = false;
   let agentStarted = false;
   let latestAgentMessages: any[] | undefined;
+
+  // Operator takeover (typed input or an Escape abort) permanently disarms
+  // auto-exit for this session. The warning is latched so it is emitted
+  // exactly once no matter how often the operator interacts afterwards.
+  function disarmAutoExit(cause: string, ctx: any): void {
+    disarmed = true;
+    if (!autoExit || warnedOperatorTakeover) return;
+    warnedOperatorTakeover = true;
+    ctx.ui.notify(
+      `Auto-exit disabled (${cause}). You are driving this session now — ` +
+        "/auto-exit closes it after its next completion.",
+      "warning",
+    );
+  }
 
   // Show widget + status bar on session start
   pi.on("session_start", (_event, ctx) => {
@@ -162,12 +212,12 @@ export default function (pi: ExtensionAPI) {
     renderWidget(ctx, null);
   });
 
-  pi.on("input", () => {
+  pi.on("input", (_event, ctx) => {
     recorder.input();
     // Ignore the initial task message that starts an autonomous subagent.
     // Only inputs after the first agent run has started count as user takeover.
     if (!shouldMarkUserTookOver(agentStarted)) return;
-    userTookOver = true;
+    disarmAutoExit("operator input", ctx);
   });
 
   pi.on("before_agent_start", () => {
@@ -188,8 +238,21 @@ export default function (pi: ExtensionAPI) {
   });
 
   pi.on("agent_settled", (_event, ctx) => {
+    const stopReason = latestAssistantStopReason(latestAgentMessages);
+
+    // An Escape-triggered abort is operator takeover too: permanently disarm
+    // (single warning above) and leave the session open for inspection.
+    if (stopReason === "aborted") {
+      disarmAutoExit("Escape", ctx);
+    }
+
     const shouldExit = autoExit
-      && shouldAutoExitOnAgentEnd(userTookOver, latestAgentMessages);
+      && resolveAutoExit({ disarmed, oneShotReArm }, stopReason);
+    if (shouldExit && oneShotReArm) {
+      // Consume the one-shot re-arm: after this exit auto-exit is disarmed
+      // again until the operator runs /auto-exit once more.
+      oneShotReArm = false;
+    }
 
     if (shouldExit) {
       // Surface stopReason: "error" turns (auto-retry exhausted, provider
@@ -211,12 +274,6 @@ export default function (pi: ExtensionAPI) {
       recorder.agentEndDone();
       ctx.shutdown();
       return;
-    }
-
-    if (autoExit) {
-      // Reset any recorded manual input marker. Auto-exit is decided by whether
-      // the latest settled agent run completed normally, not by who initiated it.
-      userTookOver = false;
     }
   });
 
@@ -265,6 +322,33 @@ export default function (pi: ExtensionAPI) {
   });
 
   // Toggle expand/collapse with Ctrl+J
+  // Re-arm auto-exit for exactly one completion after operator takeover.
+  pi.registerCommand("auto-exit", {
+    description: "Close this session automatically after its next completed turn",
+    handler: async (_args, ctx) => {
+      if (!autoExit) {
+        ctx.ui.notify("Auto-exit is not enabled for this session.", "info");
+        return;
+      }
+      if (!disarmed) {
+        ctx.ui.notify("Auto-exit is already armed.", "info");
+        return;
+      }
+      if (oneShotReArm) {
+        ctx.ui.notify(
+          "Auto-exit is already re-armed for the next completion.",
+          "info",
+        );
+        return;
+      }
+      oneShotReArm = true;
+      ctx.ui.notify(
+        "Auto-exit re-armed: this session will close after its next completion.",
+        "info",
+      );
+    },
+  });
+
   pi.registerShortcut("ctrl+j", {
     description: "Toggle subagent tools widget",
     handler: (ctx) => {

--- a/pi-extension/subagents/subagent-done.ts
+++ b/pi-extension/subagents/subagent-done.ts
@@ -14,28 +14,26 @@ export function shouldMarkUserTookOver(agentStarted: boolean): boolean {
   return agentStarted;
 }
 
+function isTerminalAutoExitStopReason(stopReason: string | undefined): boolean {
+  return stopReason === "stop" || stopReason === "error";
+}
+
 export function shouldAutoExitOnAgentEnd(
   _userTookOver: boolean,
   messages: any[] | undefined,
 ): boolean {
-  // Manual input should not strand an auto-exit subagent. If the latest agent
-  // turn completed normally, close the session. Escape/abort still leaves it
-  // open for inspection or another prompt.
-  //
-  // stopReason: "error" (e.g. exhausted retries on a provider overload) also
-  // returns true — we want to shut down so the parent is woken up — but we
-  // pair this with findLatestAssistantError() so the parent learns it was an
-  // error, not a clean completion.
+  // A tool-use response is an intermediate turn boundary. Keep the child
+  // alive so Pi can deliver the next assistant response or a tool failure.
   if (messages) {
     for (let i = messages.length - 1; i >= 0; i--) {
       const msg = messages[i];
       if (msg?.role === "assistant") {
-        return msg.stopReason !== "aborted";
+        return isTerminalAutoExitStopReason(msg.stopReason);
       }
     }
   }
 
-  return true;
+  return false;
 }
 
 export interface AutoExitDecisionState {
@@ -59,7 +57,7 @@ export function resolveAutoExit(
   stopReason: string | undefined,
 ): boolean {
   if (state.disarmed && !state.oneShotReArm) return false;
-  return stopReason !== "aborted";
+  return isTerminalAutoExitStopReason(stopReason);
 }
 
 function latestAssistantStopReason(messages: any[] | undefined): string | undefined {
@@ -275,7 +273,7 @@ export default function (pi: ExtensionAPI) {
     const autoExitShouldFire = autoExit
       && resolveAutoExit({ disarmed, oneShotReArm }, stopReason);
     const shouldExit = autoExitShouldFire
-      || (wrapupInProgress && stopReason !== "aborted");
+      || (wrapupInProgress && isTerminalAutoExitStopReason(stopReason));
     if (autoExitShouldFire && oneShotReArm) {
       // Consume the one-shot re-arm: after this exit auto-exit is disarmed
       // again until the operator runs /auto-exit once more.

--- a/pi-extension/subagents/time-limits.ts
+++ b/pi-extension/subagents/time-limits.ts
@@ -1,0 +1,134 @@
+import { existsSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+
+export interface TimeLimitConfig {
+  timeLimitSeconds?: number;
+  idleTimeoutSeconds?: number;
+  timeoutWarnThreshold?: number;
+}
+
+export type TimeLimitAction = "none" | "warn" | "hard-stop";
+
+export const REPORT_ONLY_WRAPUP_DIRECTIVE =
+  "Your time limit is nearly exhausted. Do not continue implementation or use tools. " +
+  "Provide a concise final partial report with completed work, remaining work, and blockers.";
+
+export interface WrapupFileOperations {
+  exists(file: string): boolean;
+  read(file: string): string;
+  write(file: string, content: string): void;
+  remove(file: string): void;
+}
+
+const DEFAULT_WRAPUP_FILE_OPERATIONS: WrapupFileOperations = {
+  exists: existsSync,
+  read: (file) => readFileSync(file, "utf8"),
+  write: (file, content) => writeFileSync(file, content, "utf8"),
+  remove: (file) => rmSync(file, { force: true }),
+};
+
+export function parsePositiveIntegerSeconds(value: string | undefined): number | undefined {
+  if (!value || !/^[1-9]\d*$/.test(value)) return undefined;
+  const seconds = Number(value);
+  return Number.isSafeInteger(seconds) ? seconds : undefined;
+}
+
+export function parseTimeoutWarnThreshold(value: string | undefined): number | undefined {
+  if (!value) return undefined;
+  const threshold = Number(value);
+  return Number.isFinite(threshold) && threshold > 0 && threshold < 1 ? threshold : undefined;
+}
+
+function deadlineAt(start: number, seconds: number | undefined): number | undefined {
+  if (!Number.isFinite(start) || !Number.isFinite(seconds) || seconds <= 0) return undefined;
+  const deadline = start + seconds * 1_000;
+  return Number.isFinite(deadline) ? deadline : undefined;
+}
+
+function earlierDeadline(...deadlines: Array<number | undefined>): number | undefined {
+  const valid = deadlines.filter((deadline): deadline is number => deadline != null);
+  return valid.length > 0 ? Math.min(...valid) : undefined;
+}
+
+/** The earliest hard deadline; idle limits require a child activity timestamp. */
+export function getTimeLimitDeadlineAt(
+  startTime: number,
+  lastActivityAt: number | undefined,
+  config: TimeLimitConfig,
+): number | undefined {
+  return earlierDeadline(
+    deadlineAt(startTime, config.timeLimitSeconds),
+    Number.isFinite(lastActivityAt) ? deadlineAt(lastActivityAt!, config.idleTimeoutSeconds) : undefined,
+  );
+}
+
+function getWarnDeadlineAt(
+  startTime: number,
+  lastActivityAt: number | undefined,
+  config: TimeLimitConfig,
+): number | undefined {
+  const threshold = config.timeoutWarnThreshold;
+  if (!Number.isFinite(threshold) || threshold! <= 0 || threshold! >= 1) return undefined;
+  return earlierDeadline(
+    deadlineAt(startTime, config.timeLimitSeconds == null ? undefined : config.timeLimitSeconds * threshold!),
+    Number.isFinite(lastActivityAt)
+      ? deadlineAt(lastActivityAt!, config.idleTimeoutSeconds == null ? undefined : config.idleTimeoutSeconds * threshold!)
+      : undefined,
+  );
+}
+
+/** Evaluate a single tick using only caller-supplied time and state. */
+export function evalTimeLimit(
+  now: number,
+  startTime: number,
+  lastActivityAt: number | undefined,
+  config: TimeLimitConfig,
+  warned = false,
+): TimeLimitAction {
+  const hardDeadline = getTimeLimitDeadlineAt(startTime, lastActivityAt, config);
+  if (hardDeadline != null && now >= hardDeadline) return "hard-stop";
+  if (warned) return "none";
+  const warnDeadline = getWarnDeadlineAt(startTime, lastActivityAt, config);
+  return warnDeadline != null && now >= warnDeadline ? "warn" : "none";
+}
+
+export function wrapupDirectiveFile(sessionFile: string): string {
+  return `${sessionFile}.wrapup`;
+}
+
+export function writeWrapupDirective(
+  sessionFile: string,
+  operations: WrapupFileOperations = DEFAULT_WRAPUP_FILE_OPERATIONS,
+): void {
+  operations.write(wrapupDirectiveFile(sessionFile), REPORT_ONLY_WRAPUP_DIRECTIVE);
+}
+
+/** Consume the one-shot parent directive before starting the report-only turn. */
+export function consumeWrapupDirective(
+  sessionFile: string | undefined,
+  operations: WrapupFileOperations = DEFAULT_WRAPUP_FILE_OPERATIONS,
+): string | null {
+  if (!sessionFile) return null;
+  const file = wrapupDirectiveFile(sessionFile);
+  if (!operations.exists(file)) return null;
+  try {
+    const directive = operations.read(file).trim();
+    operations.remove(file);
+    return directive || null;
+  } catch {
+    return null;
+  }
+}
+
+export function cleanupWrapupDirective(
+  sessionFile: string | undefined,
+  operations: Pick<WrapupFileOperations, "remove"> = DEFAULT_WRAPUP_FILE_OPERATIONS,
+): void {
+  if (!sessionFile) return;
+  try {
+    operations.remove(wrapupDirectiveFile(sessionFile));
+  } catch {}
+}
+
+export function formatTimeLimitError(elapsedMs: number): string {
+  return `Subagent timed out after ${Math.floor(Math.max(0, elapsedMs) / 1_000)}s.`;
+}

--- a/test/harness-drivers.test.ts
+++ b/test/harness-drivers.test.ts
@@ -134,6 +134,10 @@ describe("Pi Harness Driver", () => {
     assert.ok(built.command.includes("pi --session '/tmp/sessions/subagent.jsonl'"));
     assert.ok(built.command.includes("--model 'anthropic/claude-sonnet-4-5'"));
     assert.ok(built.command.includes("--thinking 'high'"));
+    assert.ok(
+      built.command.includes("PI_SUBAGENT_ACTIVITY_FILE='/tmp/artifacts/subagent-activity/abc12345.json'"),
+      "the child and parent must use the same activity file for idle-timeout supervision",
+    );
     assert.ok(built.command.includes("echo '__SUBAGENT_DONE_'$?'__'"));
   });
 });

--- a/test/recovery-ladder.test.ts
+++ b/test/recovery-ladder.test.ts
@@ -1,0 +1,211 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import * as subagentsModule from "../pi-extension/subagents/index.ts";
+import {
+  DEFAULT_RECOVERY_DELAYS,
+  advanceRecoveryLadder,
+  parseRecoveryDelays,
+  type RecoveryState,
+} from "../pi-extension/subagents/recovery.ts";
+import {
+  createLifecycle,
+  observeActivity,
+  observePaneInspection,
+  projectLifecycle,
+} from "../pi-extension/subagents/lifecycle.ts";
+
+const delays = [30_000, 60_000, 90_000] as const;
+
+function makeRunning(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "child-1",
+    name: "Worker",
+    task: "Recover the provider failure",
+    surface: "pane-1",
+    startTime: 0,
+    sessionFile: "/tmp/worker.jsonl",
+    interactive: false,
+    lifecycle: createLifecycle(0),
+    ...overrides,
+  };
+}
+
+describe("recovery delay parsing", () => {
+  it("uses defaults for missing or malformed values and clamps short stages", () => {
+    for (const [raw, expected] of [
+      [undefined, DEFAULT_RECOVERY_DELAYS],
+      ["", DEFAULT_RECOVERY_DELAYS],
+      ["30000,60000", DEFAULT_RECOVERY_DELAYS],
+      ["30000,wat,90000", DEFAULT_RECOVERY_DELAYS],
+      ["30000,60000,90000,120000", DEFAULT_RECOVERY_DELAYS],
+      ["30000,60000,90000.5", DEFAULT_RECOVERY_DELAYS],
+      [" 12000, 22000, 32000 ", [12_000, 22_000, 32_000]],
+      ["1,9999,-2", [10_000, 10_000, 10_000]],
+    ] as const) {
+      assert.deepEqual(parseRecoveryDelays(raw), expected, String(raw));
+    }
+  });
+});
+
+describe("recovery ladder", () => {
+  it("advances wait, nudge, escalation, and kill from injected fake-clock ticks", () => {
+    let now = 0;
+    let state: RecoveryState | undefined;
+    const tick = (nextNow: number, stalled = true, exempt = false) => {
+      now = nextNow;
+      const advance = advanceRecoveryLadder(state, { now, stalled, exempt, delays });
+      state = advance.state;
+      return advance;
+    };
+
+    assert.deepEqual(tick(0), { state: { stage: "waiting", stageSince: 0 }, action: null });
+    assert.equal(tick(29_999).action, null);
+    assert.deepEqual(tick(30_000), { state: { stage: "nudged", stageSince: 30_000 }, action: "nudge" });
+    assert.equal(tick(30_001).action, null);
+    assert.equal(tick(89_999).action, null);
+    assert.deepEqual(tick(90_000), { state: { stage: "escalated", stageSince: 90_000 }, action: "escalate" });
+    assert.equal(tick(179_999).action, null);
+    assert.deepEqual(tick(180_000), { state: { stage: "killed", stageSince: 180_000 }, action: "kill" });
+    assert.equal(tick(999_999).action, null, "terminal recovery state must be a no-op");
+  });
+
+  it("uses injected pane operations, tears down once, and reports recovery-kill as a failure", () => {
+    const testApi = (subagentsModule as any).__test__;
+    const running = makeRunning({
+      abortController: {
+        abort() {
+          aborts += 1;
+        },
+      },
+    });
+    let nudges = 0;
+    let closes = 0;
+    let aborts = 0;
+    const operations = {
+      interruptPane(surface: string) {
+        assert.equal(surface, "pane-1");
+        nudges += 1;
+      },
+      closePane(surface: string) {
+        assert.equal(surface, "pane-1");
+        closes += 1;
+      },
+      abortWatcher() {
+        assert.match(running.recoveryKilled?.errorMessage ?? "", /recovery-kill after 180s/);
+        running.abortController.abort();
+      },
+    };
+
+    for (const now of [0, 30_000, 90_000, 180_000]) {
+      testApi.advanceRunningRecovery(running, { kind: "stalled" }, now, delays, operations);
+    }
+
+    assert.equal(nudges, 1);
+    assert.equal(closes, 1);
+    assert.equal(aborts, 1);
+    assert.equal(running.recovery.stage, "killed");
+    assert.equal(running.lifecycle.process.kind, "failed");
+    assert.match(running.lifecycle.process.error, /recovery-kill after 180s/);
+
+    const result = testApi.buildRecoveryKilledResult(running, 180_001);
+    assert.equal(result.exitCode, 1);
+    assert.equal(result.error, running.lifecycle.process.error);
+    assert.match(result.errorMessage, /recovery-kill after 180s/);
+    assert.match(result.summary, /recovery-kill/);
+    assert.doesNotMatch(result.summary, /cancelled|wrap-up|completed/i);
+
+    const presentation = testApi.resolveResultPresentation(result, running.name);
+    assert.match(presentation, /failed/);
+    assert.doesNotMatch(presentation, /completed/);
+
+    const repeated = testApi.advanceRunningRecovery(running, { kind: "stalled" }, 999_999, delays, operations);
+    assert.equal(repeated.action, null, "terminal recovery state must not produce a duplicate result");
+    assert.equal(closes, 1, "repeated ticks must not close a pane twice");
+    assert.equal(aborts, 1, "repeated ticks must not abort twice");
+    running.lifecycle = { ...running.lifecycle, delivery: "delivered" };
+    assert.equal(subagentsModule.shouldDeliverSubagentCompletion(running), false);
+  });
+
+  it("does not arm interactive or wrap-up children", () => {
+    const testApi = (subagentsModule as any).__test__;
+    for (const overrides of [{ interactive: true }, { wrapupPending: true }]) {
+      const running = makeRunning(overrides);
+      let paneCalls = 0;
+      const advance = testApi.advanceRunningRecovery(
+        running,
+        { kind: "stalled" },
+        1_000_000,
+        delays,
+        {
+          interruptPane() {
+            paneCalls += 1;
+          },
+          closePane() {
+            paneCalls += 1;
+          },
+          abortWatcher() {
+            paneCalls += 1;
+          },
+        },
+      );
+      assert.equal(advance.action, null);
+      assert.equal(running.recovery, undefined);
+      assert.equal(paneCalls, 0);
+    }
+  });
+
+  it("never advances healthy tool, streaming, or provider activity despite long runtime", () => {
+    const testApi = (subagentsModule as any).__test__;
+    for (const scope of ["tool", "streaming", "provider"] as const) {
+      const now = 1_000_000;
+      let lifecycle = createLifecycle(0);
+      lifecycle = observePaneInspection(lifecycle, {
+        kind: "present",
+        observedAt: now,
+        agentStatus: "working",
+      }, now);
+      lifecycle = observeActivity(lifecycle, {
+        ok: true,
+        activity: {
+          version: 1,
+          runningChildId: "child-1",
+          createdAt: 0,
+          updatedAt: now,
+          sequence: 1,
+          latestEvent: "agent_start",
+          phase: "active",
+          agentActive: true,
+          turnActive: true,
+          providerActive: scope === "provider",
+          toolActive: scope === "tool",
+          activeScope: scope,
+          activeSince: now,
+          ...(scope === "tool" ? { toolName: "bash", toolStartedAt: now } : {}),
+        },
+      }, now);
+      const projection = projectLifecycle(lifecycle, now + 1);
+      assert.equal(projection.kind, "active", scope);
+
+      const running = makeRunning({ lifecycle });
+      const advance = testApi.advanceRunningRecovery(
+        running,
+        projection,
+        now + delays[0] + delays[1] + delays[2] + 1,
+        delays,
+        {
+          interruptPane() {
+            throw new Error("healthy activity must not be nudged");
+          },
+          closePane() {
+            throw new Error("healthy activity must not be killed");
+          },
+          abortWatcher() {
+            throw new Error("healthy activity must not be aborted");
+          },
+        },
+      );
+      assert.equal(advance.action, null, scope);
+      assert.equal(running.recovery, undefined, scope);
+    }
+  });
+});

--- a/test/spawn-grants.test.ts
+++ b/test/spawn-grants.test.ts
@@ -6,6 +6,7 @@ import { tmpdir } from "node:os";
 import { PiHarnessDriver } from "../pi-extension/subagents/harness/index.ts";
 import type { SubagentLaunchContext } from "../pi-extension/subagents/harness/types.ts";
 import * as subagentsModule from "../pi-extension/subagents/index.ts";
+import subagentsExtension from "../pi-extension/subagents/index.ts";
 
 const testApi = (subagentsModule as any).__test__;
 const SPAWNING_TOOLS = [...testApi.SPAWNING_TOOLS as Set<string>].sort();
@@ -208,5 +209,83 @@ describe("termination regression", () => {
     assert.equal(testApi.blockedSelfSpawn("planner", "scout"), false);
     assert.equal(testApi.blockedSelfSpawn(undefined, "scout"), false);
     assert.equal(testApi.blockedSelfSpawn("scout", undefined), false);
+  });
+});
+
+describe("self-spawn guard via the real registered tool execute()", () => {
+  function registerExtensionAndGetTools() {
+    const tools = new Map<string, any>();
+    // Registration-time calls only; handler bodies never run in these tests.
+    const mockPi = {
+      on: () => {},
+      registerTool: (tool: any) => tools.set(tool.name, tool),
+      registerCommand: () => {},
+      registerMessageRenderer: () => {},
+      sendMessage: () => {},
+      sendUserMessage: () => {},
+      getThinkingLevel: () => "off",
+    };
+    // Strip child-agent env so no spawning tools look denied during registration.
+    const savedId = process.env.PI_SUBAGENT_ID;
+    const savedDeny = process.env.PI_DENY_TOOLS;
+    delete process.env.PI_SUBAGENT_ID;
+    delete process.env.PI_DENY_TOOLS;
+    try {
+      subagentsExtension(mockPi as any);
+    } finally {
+      if (savedId === undefined) delete process.env.PI_SUBAGENT_ID;
+      else process.env.PI_SUBAGENT_ID = savedId;
+      if (savedDeny === undefined) delete process.env.PI_DENY_TOOLS;
+      else process.env.PI_DENY_TOOLS = savedDeny;
+    }
+    return tools;
+  }
+
+  it("returns guidance text instead of throwing when an agent spawns itself", async () => {
+    const previousAgent = process.env.PI_SUBAGENT_AGENT;
+    process.env.PI_SUBAGENT_AGENT = "planner";
+    try {
+      const tool = registerExtensionAndGetTools().get("subagent");
+      assert.ok(tool, "subagent tool must be registered");
+
+      const result = await tool.execute(
+        "test-call",
+        { name: "dup", task: "do work", agent: "planner" },
+        undefined,
+        undefined,
+        {},
+      );
+
+      const text = result.content[0].text as string;
+      assert.match(text, /You are the planner agent/);
+      assert.match(text, /do not start another planner/);
+      assert.deepEqual(result.details, { error: "self-spawn blocked" });
+    } finally {
+      if (previousAgent === undefined) delete process.env.PI_SUBAGENT_AGENT;
+      else process.env.PI_SUBAGENT_AGENT = previousAgent;
+    }
+  });
+
+  it("does not block spawning a different agent", async () => {
+    process.env.PI_SUBAGENT_AGENT = "planner";
+    try {
+      const tool = registerExtensionAndGetTools().get("subagent");
+      assert.ok(tool);
+
+      await assert.rejects(
+        () =>
+          tool.execute(
+            "test-call",
+            { name: "s", task: "t", agent: "scout" },
+            undefined,
+            undefined,
+            {},
+          ),
+        // Guard passes; execution then fails later on missing prerequisites.
+        // Any throw proves it got past the self-spawn guard without one.
+      );
+    } finally {
+      delete process.env.PI_SUBAGENT_AGENT;
+    }
   });
 });

--- a/test/spawn-grants.test.ts
+++ b/test/spawn-grants.test.ts
@@ -1,6 +1,7 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
-import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
+import { createHash } from "node:crypto";
+import { mkdtempSync, readFileSync, writeFileSync, rmSync, mkdirSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { PiHarnessDriver } from "../pi-extension/subagents/harness/index.ts";
@@ -209,6 +210,83 @@ describe("termination regression", () => {
     assert.equal(testApi.blockedSelfSpawn("planner", "scout"), false);
     assert.equal(testApi.blockedSelfSpawn(undefined, "scout"), false);
     assert.equal(testApi.blockedSelfSpawn("scout", undefined), false);
+  });
+});
+
+describe("resume session cwd preflight", () => {
+  it("heals a missing cwd and preserves every byte after the header", () => {
+    const dir = mkdtempSync(join(tmpdir(), "resume-cwd-test-"));
+    try {
+      const sessionFile = join(dir, "session.jsonl");
+      const resumeCwd = join(dir, "resuming");
+      mkdirSync(resumeCwd);
+      const header = {
+        type: "session",
+        version: 3,
+        id: "session-id",
+        timestamp: "2026-08-26T00:00:00.000Z",
+        cwd: join(dir, "pruned-worktree"),
+      };
+      const tail = `{"type":"message","id":"message-id","payload":"preserve me"}\n{"type":"turn_end","id":"turn-end-id"}\n`;
+      writeFileSync(sessionFile, JSON.stringify(header) + "\n" + tail, "utf8");
+      const before = readFileSync(sessionFile);
+      const firstNewline = before.indexOf(0x0a);
+      const tailHash = createHash("sha256").update(before.subarray(firstNewline + 1)).digest("hex");
+
+      const result = testApi.ensureResumeSessionCwd(sessionFile, resumeCwd);
+
+      assert.deepEqual(result, { ok: true, healed: true });
+      const after = readFileSync(sessionFile);
+      assert.equal(
+        createHash("sha256").update(after.subarray(after.indexOf(0x0a) + 1)).digest("hex"),
+        tailHash,
+      );
+      const healedHeader = JSON.parse(after.subarray(0, after.indexOf(0x0a)).toString("utf8"));
+      assert.equal(healedHeader.cwd, resumeCwd);
+      assert.equal(healedHeader.type, header.type);
+      assert.equal(healedHeader.id, header.id);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("leaves a session with an existing cwd byte-identical", () => {
+    const dir = mkdtempSync(join(tmpdir(), "resume-cwd-test-"));
+    try {
+      const sessionFile = join(dir, "session.jsonl");
+      const header = {
+        type: "session",
+        cwd: dir,
+        id: "existing-cwd",
+      };
+      const original = Buffer.from(JSON.stringify(header) + "\r\nsecond line\n", "utf8");
+      writeFileSync(sessionFile, original);
+
+      const result = testApi.ensureResumeSessionCwd(sessionFile, join(dir, "other"));
+
+      assert.deepEqual(result, { ok: true, healed: false });
+      assert.deepEqual(readFileSync(sessionFile), original);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("blocks a corrupt header before resume can launch", () => {
+    const dir = mkdtempSync(join(tmpdir(), "resume-cwd-test-"));
+    try {
+      const sessionFile = join(dir, "session.jsonl");
+      const original = Buffer.from("{not valid json\n{\"type\":\"message\"}\n", "utf8");
+      writeFileSync(sessionFile, original);
+
+      const result = testApi.ensureResumeSessionCwd(sessionFile, dir);
+
+      assert.equal(result.ok, false);
+      if (result.ok) assert.fail("corrupt headers must block resume");
+      assert.match(result.error, /parse.*header|header.*parse/i);
+      assert.deepEqual(readFileSync(sessionFile), original);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
   });
 });
 

--- a/test/spawn-grants.test.ts
+++ b/test/spawn-grants.test.ts
@@ -1,0 +1,212 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { PiHarnessDriver } from "../pi-extension/subagents/harness/index.ts";
+import type { SubagentLaunchContext } from "../pi-extension/subagents/harness/types.ts";
+import * as subagentsModule from "../pi-extension/subagents/index.ts";
+
+const testApi = (subagentsModule as any).__test__;
+const SPAWNING_TOOLS = [...testApi.SPAWNING_TOOLS as Set<string>].sort();
+
+function createMockLaunchContext(overrides?: Partial<SubagentLaunchContext>): SubagentLaunchContext {
+  return {
+    params: {
+      id: "abc12345",
+      name: "worker",
+      task: "Analyze the repository structure",
+    },
+    runtimePlan: {
+      provider: "anthropic",
+      modelId: "claude-sonnet-4-5",
+      model: "anthropic/claude-sonnet-4-5",
+      thinking: "medium",
+      modelSource: "request",
+      thinkingSource: "request",
+    },
+    effectiveModel: "anthropic/claude-sonnet-4-5",
+    effectiveThinking: "medium",
+    parentThinking: "medium",
+    surface: "pane-1",
+    artifactDir: "/tmp/artifacts",
+    sessionDir: "/tmp/sessions",
+    subagentSessionFile: "/tmp/sessions/subagent.jsonl",
+    effectiveCwd: "/tmp/project",
+    effectiveAutoExit: true,
+    effectiveInteractive: false,
+    inheritsConversationContext: true,
+    taskDelivery: "direct",
+    subagentsDir: "/path/to/subagents",
+    shellQuote: (s: string) => `'${s.replace(/'/g, "'\\''")}'`,
+    ...overrides,
+  };
+}
+
+describe("resolveDenyTools — deny-by-default spawn grants", () => {
+  it("denies all spawning tools by default (no agent defs, bare spawn)", () => {
+    const denied = testApi.resolveDenyTools(null);
+    for (const tool of SPAWNING_TOOLS) assert.equal(denied.has(tool), true, `expected ${tool} denied`);
+  });
+
+  it("denies all spawning tools when frontmatter omits `spawning`", () => {
+    const denied = testApi.resolveDenyTools({ name: "worker" });
+    for (const tool of SPAWNING_TOOLS) assert.equal(denied.has(tool), true);
+  });
+
+  it("denies all spawning tools when frontmatter sets spawning:false", () => {
+    const denied = testApi.resolveDenyTools({ spawning: false });
+    for (const tool of SPAWNING_TOOLS) assert.equal(denied.has(tool), true);
+  });
+
+  it("grants spawning tools only with explicit spawning:true and remaining depth", () => {
+    const granted = testApi.resolveDenyTools({ spawning: true }, null);
+    for (const tool of SPAWNING_TOOLS) assert.equal(granted.has(tool), false);
+    assert.equal(testApi.resolveDenyTools({ spawning: true }, 3).size, 0);
+  });
+
+  it("remaining 0 denies spawning despite a frontmatter grant", () => {
+    const denied = testApi.resolveDenyTools({ spawning: true }, 0);
+    for (const tool of SPAWNING_TOOLS) assert.equal(denied.has(tool), true);
+  });
+
+  it("deny-tools additions stack on top of grants and denials", () => {
+    // Granted agent with extra denials
+    const grantedWithExtra = testApi.resolveDenyTools(
+      { spawning: true, denyTools: "bash, read" },
+      null,
+    );
+    assert.deepEqual([...grantedWithExtra].sort(), ["bash", "read"]);
+
+    // Denied-by-default agent stacking an unrelated denial
+    const deniedWithExtra = testApi.resolveDenyTools({ denyTools: "write" });
+    for (const tool of SPAWNING_TOOLS) assert.equal(deniedWithExtra.has(tool), true);
+    assert.equal(deniedWithExtra.has("write"), true);
+
+    // Redundant listing of a spawning tool changes nothing
+    assert.equal(testApi.resolveDenyTools({ spawning: true, denyTools: "subagent" }, 2).has("subagent"), true);
+
+    // Empty / junk entries are ignored
+    assert.equal(testApi.resolveDenyTools({ spawning: true, denyTools: " , ," }, 1).size, 0);
+  });
+});
+
+describe("spawn depth math", () => {
+  it("parseSpawnDepth reads PI_SUBAGENT_SPAWN_DEPTH conservatively", () => {
+    assert.equal(testApi.parseSpawnDepth(undefined), null); // unset → unlimited (grant still required)
+    assert.equal(testApi.parseSpawnDepth(""), null);
+    assert.equal(testApi.parseSpawnDepth("  "), null);
+    assert.equal(testApi.parseSpawnDepth("junk"), null);
+    assert.equal(testApi.parseSpawnDepth("-1"), null);
+    assert.equal(testApi.parseSpawnDepth("0"), 0);
+    assert.equal(testApi.parseSpawnDepth("7"), 7);
+    assert.equal(testApi.parseSpawnDepth(" 3 "), 3);
+  });
+
+  it("decrementSpawnDepth never rises and clamps at zero", () => {
+    assert.equal(testApi.decrementSpawnDepth(null), null); // unlimited stays unlimited
+    assert.equal(testApi.decrementSpawnDepth(5), 4);
+    assert.equal(testApi.decrementSpawnDepth(1), 0);
+    assert.equal(testApi.decrementSpawnDepth(0), 0);
+  });
+});
+
+describe("Pi harness driver emits depth + deny env", () => {
+  const driver = new PiHarnessDriver();
+
+  it("emits PI_DENY_TOOLS including spawning tools and PI_SUBAGENT_SPAWN_DEPTH=<remaining>", () => {
+    const denySet = new Set<string>(SPAWNING_TOOLS);
+    const built = driver.buildCommand(createMockLaunchContext({ denySet, childSpawnDepth: 2 }));
+
+    assert.match(built.command, /PI_DENY_TOOLS='[^']*subagent[^']*'/);
+    for (const tool of SPAWNING_TOOLS) {
+      assert.ok(built.command.includes(`'${tool}'`) || built.command.includes(tool),
+        `expected ${tool} in PI_DENY_TOOLS`);
+    }
+    assert.ok(built.command.includes("PI_SUBAGENT_SPAWN_DEPTH=2"));
+  });
+
+  it("emits PI_SUBAGENT_SPAWN_DEPTH=0 at exhaustion (explicit, not absent)", () => {
+    const built = driver.buildCommand(createMockLaunchContext({ childSpawnDepth: 0 }));
+    assert.ok(built.command.includes("PI_SUBAGENT_SPAWN_DEPTH=0"));
+  });
+
+  it("omits PI_SUBAGENT_SPAWN_DEPTH when unlimited (no ceiling configured)", () => {
+    const built = driver.buildCommand(createMockLaunchContext({ childSpawnDepth: null }));
+    assert.equal(built.command.includes("PI_SUBAGENT_SPAWN_DEPTH="), false);
+
+    const legacyBuilt = driver.buildCommand(createMockLaunchContext());
+    assert.equal(legacyBuilt.command.includes("PI_SUBAGENT_SPAWN_DEPTH="), false);
+  });
+});
+
+describe("resume clamp — first-launch metadata wins", () => {
+  it("missing/corrupt metadata resolves to 0 (deny)", () => {
+    assert.deepEqual(testApi.clampResumeSpawn(undefined, 9), { maySpawn: false, childEnvDepth: 0 });
+    assert.deepEqual(testApi.clampResumeSpawn(null, 9), { maySpawn: false, childEnvDepth: 0 });
+    assert.deepEqual(testApi.clampResumeSpawn({}, 9), { maySpawn: false, childEnvDepth: 0 });
+    assert.deepEqual(testApi.clampResumeSpawn({ allowance: "3" }, 9), { maySpawn: false, childEnvDepth: 0 });
+    assert.deepEqual(testApi.clampResumeSpawn({ allowance: -2 }, 9), { maySpawn: false, childEnvDepth: 0 });
+  });
+
+  it("clamps to min(recorded allowance, requested)", () => {
+    // recorded 3, environment would allow 5 → 3, child gets 2
+    assert.deepEqual(testApi.clampResumeSpawn({ allowance: 3 }, 5), { maySpawn: true, childEnvDepth: 2 });
+    // recorded 3, environment allows 1 → 1, child gets 0
+    assert.deepEqual(testApi.clampResumeSpawn({ allowance: 3 }, 1), { maySpawn: true, childEnvDepth: 0 });
+    // recorded 3, no ceiling in environment → recorded 3 stands
+    assert.deepEqual(testApi.clampResumeSpawn({ allowance: 3 }, null), { maySpawn: true, childEnvDepth: 2 });
+    // exhausted at first launch → resume cannot revive
+    assert.deepEqual(testApi.clampResumeSpawn({ allowance: 0 }, 9), { maySpawn: false, childEnvDepth: 0 });
+  });
+
+  it("recorded unlimited stays bounded by the requesting environment only", () => {
+    assert.deepEqual(testApi.clampResumeSpawn({ allowance: null }, 4), { maySpawn: true, childEnvDepth: 3 });
+    assert.deepEqual(testApi.clampResumeSpawn({ allowance: null }, null), { maySpawn: true, childEnvDepth: null });
+  });
+
+  it("readSpawnMetadata returns null on missing or corrupt sidecar files", () => {
+    const dir = mkdtempSync(join(tmpdir(), "spawn-grants-test-"));
+    try {
+      assert.equal(testApi.readSpawnMetadata(join(dir, "missing.jsonl")), null);
+
+      const sessionFile = join(dir, "session.jsonl");
+      writeFileSync(`${sessionFile}.spawn.json`, JSON.stringify({ allowance: 4 }), "utf8");
+      assert.deepEqual(testApi.readSpawnMetadata(sessionFile), { allowance: 4 });
+
+      writeFileSync(`${sessionFile}.spawn.json`, "{not json", "utf8");
+      assert.equal(testApi.readSpawnMetadata(sessionFile), null);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("termination regression", () => {
+  it("A-spawns-B-spawns-A terminates: depth decrements every generation until denial", () => {
+    const grantedDefs = { spawning: true };
+    let allowance: number | null = 3;
+    let spawnerIsA = true;
+    let spawns = 0;
+
+    while (true) {
+      const denied = testApi.resolveDenyTools(grantedDefs, allowance);
+      if (denied.has("subagent")) break;
+      allowance = testApi.decrementSpawnDepth(allowance);
+      spawns++;
+      spawnerIsA = !spawnerIsA;
+      assert.ok(spawns <= 10, "mutual spawning must terminate");
+    }
+
+    // ceiling 3 → A, B, A each spawn once; B's fourth attempt is denied
+    assert.equal(spawns, 3);
+    assert.equal(spawnerIsA, false);
+  });
+
+  it("keeps the same-agent respawn guard working regardless of depth", () => {
+    assert.equal(testApi.blockedSelfSpawn("planner", "planner"), true);
+    assert.equal(testApi.blockedSelfSpawn("planner", "scout"), false);
+    assert.equal(testApi.blockedSelfSpawn(undefined, "scout"), false);
+    assert.equal(testApi.blockedSelfSpawn("scout", undefined), false);
+  });
+});

--- a/test/subagent-done-autoexit.test.ts
+++ b/test/subagent-done-autoexit.test.ts
@@ -218,6 +218,41 @@ describe("subagent-done auto-exit hardening (L-95)", () => {
     });
   });
 
+  it("keeps a policy-denied tool boundary open before reporting terminal failure", () => {
+    const child = boot();
+    child.settle([
+      {
+        role: "assistant",
+        stopReason: "toolUse",
+        content: [{ type: "toolCall", id: "call-policy", name: "read", arguments: {} }],
+      },
+      {
+        role: "toolResult",
+        toolCallId: "call-policy",
+        isError: true,
+        details: { error: "policy denied" },
+        content: [{ type: "text", text: "Tool execution blocked by policy" }],
+      },
+    ]);
+    assert.equal(child.ctx.shutdowns, 0, "policy tool-use boundary must not complete the child");
+    assert.equal(sidecarOf(child), null, "policy boundary is not a clean completion");
+
+    child.settle([
+      {
+        role: "assistant",
+        stopReason: "error",
+        errorMessage: "Tool execution blocked by policy",
+        content: [],
+      },
+    ]);
+    assert.equal(child.ctx.shutdowns, 1, "later terminal error wakes the parent");
+    assert.deepEqual(sidecarOf(child), {
+      type: "error",
+      errorMessage: "Tool execution blocked by policy",
+      stopReason: "error",
+    });
+  });
+
   it("does not treat a wrap-up tool-use boundary as the report", () => {
     const child = boot();
     writeFileSync(`${child.sessionFile}.wrapup`, "provide a final partial report");

--- a/test/subagent-done-autoexit.test.ts
+++ b/test/subagent-done-autoexit.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, beforeEach, afterEach } from "node:test";
 import assert from "node:assert/strict";
-import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import subagentDoneExtension, {
@@ -18,9 +18,11 @@ interface Notification {
 function createExtensionApi() {
   const eventHandlers = new Map<string, Array<Function>>();
   const registeredCommands: Array<{ name: string; handler: Function }> = [];
+  const sentUserMessages: string[] = [];
   return {
     eventHandlers,
     registeredCommands,
+    sentUserMessages,
     api: {
       on(event: string, handler: Function) {
         const handlers = eventHandlers.get(event) ?? [];
@@ -33,7 +35,9 @@ function createExtensionApi() {
       },
       registerMessageRenderer() {},
       registerShortcut() {},
-      sendUserMessage() {},
+      sendUserMessage(message: string) {
+        sentUserMessages.push(message);
+      },
       sendMessage() {},
       getAllTools() {
         return [];
@@ -77,7 +81,7 @@ describe("subagent-done auto-exit hardening (L-95)", () => {
       delete process.env.PI_SUBAGENT_SESSION;
     }
 
-    const { api, eventHandlers, registeredCommands } = createExtensionApi();
+    const { api, eventHandlers, registeredCommands, sentUserMessages } = createExtensionApi();
     subagentDoneExtension(api);
 
     const notifications: Notification[] = [];
@@ -99,6 +103,7 @@ describe("subagent-done auto-exit hardening (L-95)", () => {
       notifications,
       sessionFile,
       registeredCommands,
+      sentUserMessages,
       fire(event: string, payload: any = {}) {
         for (const handler of eventHandlers.get(event) ?? []) handler(payload, ctx);
       },
@@ -128,7 +133,8 @@ describe("subagent-done auto-exit hardening (L-95)", () => {
       [false, false, "stop", true],
       [false, false, "error", true],
       [false, false, "aborted", false],
-      [false, false, undefined, true],
+      [false, false, "toolUse", false],
+      [false, false, undefined, false],
       // Disarmed: never exits, whatever happened.
       [true, false, "stop", false],
       [true, false, "error", false],
@@ -139,6 +145,7 @@ describe("subagent-done auto-exit hardening (L-95)", () => {
       [true, true, "stop", true],
       [true, true, "error", true],
       [true, true, "aborted", false],
+      [true, true, "toolUse", false],
       // Re-arm while armed cannot occur via CLI but is harmless.
       [false, true, "stop", true],
     ];
@@ -157,6 +164,85 @@ describe("subagent-done auto-exit hardening (L-95)", () => {
     assert.equal(child.ctx.shutdowns, 1, "zero-real-input child still exits");
     assert.deepEqual(sidecarOf(child), { type: "done" });
     assert.equal(child.notifications.length, 0, "no warning for the injected task");
+  });
+
+  it("keeps the child alive after a tool-use turn until the final report", () => {
+    const child = boot();
+    child.fire("agent_start", {});
+    child.fire("tool_execution_start", { toolCallId: "call-1", toolName: "read" });
+    child.fire("tool_result", { toolCallId: "call-1", toolName: "read" });
+    child.fire("tool_execution_end", { toolCallId: "call-1", toolName: "read" });
+
+    child.settle([
+      {
+        role: "assistant",
+        stopReason: "toolUse",
+        content: [{ type: "toolCall", id: "call-1", name: "read", arguments: {} }],
+      },
+      {
+        role: "toolResult",
+        toolCallId: "call-1",
+        isError: false,
+        content: [{ type: "text", text: "successful tool result" }],
+      },
+    ]);
+    assert.equal(child.ctx.shutdowns, 0, "tool-use boundary must not auto-exit");
+    assert.equal(sidecarOf(child), null, "no completion sidecar at tool-use boundary");
+
+    child.settle([
+      {
+        role: "assistant",
+        stopReason: "stop",
+        content: [{ type: "text", text: "final report" }],
+      },
+    ]);
+    assert.equal(child.ctx.shutdowns, 1, "later final assistant turn exits");
+    assert.deepEqual(sidecarOf(child), { type: "done" });
+  });
+
+  it("publishes an injected tool or policy error as a failure", () => {
+    const child = boot();
+    child.settle([
+      {
+        role: "assistant",
+        stopReason: "error",
+        errorMessage: "Tool execution blocked by policy",
+        content: [],
+      },
+    ]);
+    assert.equal(child.ctx.shutdowns, 1, "terminal tool error wakes the parent");
+    assert.deepEqual(sidecarOf(child), {
+      type: "error",
+      errorMessage: "Tool execution blocked by policy",
+      stopReason: "error",
+    });
+  });
+
+  it("does not treat a wrap-up tool-use boundary as the report", () => {
+    const child = boot();
+    writeFileSync(`${child.sessionFile}.wrapup`, "provide a final partial report");
+    child.settle([{ role: "assistant", stopReason: "aborted" }]);
+    assert.equal(child.ctx.shutdowns, 0);
+    assert.deepEqual(child.sentUserMessages, ["provide a final partial report"]);
+
+    child.settle([
+      {
+        role: "assistant",
+        stopReason: "toolUse",
+        content: [{ type: "toolCall", id: "call-wrapup", name: "read", arguments: {} }],
+      },
+    ]);
+    assert.equal(child.ctx.shutdowns, 0, "wrap-up stays open through tool use");
+
+    child.settle([
+      {
+        role: "assistant",
+        stopReason: "stop",
+        content: [{ type: "text", text: "partial report" }],
+      },
+    ]);
+    assert.equal(child.ctx.shutdowns, 1, "wrap-up exits on its final report");
+    assert.deepEqual(sidecarOf(child), { type: "done", wrapup: true });
   });
 
   it("operator input disarms auto-exit persistently across settled turns", () => {

--- a/test/subagent-done-autoexit.test.ts
+++ b/test/subagent-done-autoexit.test.ts
@@ -1,0 +1,263 @@
+import { describe, it, beforeEach, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import subagentDoneExtension, {
+  resolveAutoExit,
+} from "../pi-extension/subagents/subagent-done.ts";
+
+// L-95 — auto-exit hardening: operator input / Escape permanently disarms,
+// /auto-exit re-arms for exactly one completion. Child-side only.
+
+interface Notification {
+  message: string;
+  type?: string;
+}
+
+function createExtensionApi() {
+  const eventHandlers = new Map<string, Array<Function>>();
+  const registeredCommands: Array<{ name: string; handler: Function }> = [];
+  return {
+    eventHandlers,
+    registeredCommands,
+    api: {
+      on(event: string, handler: Function) {
+        const handlers = eventHandlers.get(event) ?? [];
+        handlers.push(handler);
+        eventHandlers.set(event, handlers);
+      },
+      registerTool() {},
+      registerCommand(name: string, command: any) {
+        registeredCommands.push({ name, ...command });
+      },
+      registerMessageRenderer() {},
+      registerShortcut() {},
+      sendUserMessage() {},
+      sendMessage() {},
+      getAllTools() {
+        return [];
+      },
+    } as any,
+  };
+}
+
+const origAutoExit = process.env.PI_SUBAGENT_AUTO_EXIT;
+const origSession = process.env.PI_SUBAGENT_SESSION;
+
+function restoreEnv(name: string, value: string | undefined) {
+  if (value === undefined) delete process.env[name];
+  else process.env[name] = value;
+}
+
+describe("subagent-done auto-exit hardening (L-95)", () => {
+  let dir: string | undefined;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "l95-autoexit-"));
+  });
+
+  afterEach(() => {
+    restoreEnv("PI_SUBAGENT_AUTO_EXIT", origAutoExit);
+    restoreEnv("PI_SUBAGENT_SESSION", origSession);
+    if (dir) rmSync(dir, { recursive: true, force: true });
+    dir = undefined;
+  });
+
+  function boot(opts: { autoExit?: boolean; withSessionFile?: boolean } = {}) {
+    const autoExit = opts.autoExit ?? true;
+    if (autoExit) process.env.PI_SUBAGENT_AUTO_EXIT = "1";
+    else delete process.env.PI_SUBAGENT_AUTO_EXIT;
+
+    let sessionFile: string | undefined;
+    if (opts.withSessionFile !== false) {
+      sessionFile = join(dir!, "child.jsonl");
+      process.env.PI_SUBAGENT_SESSION = sessionFile;
+    } else {
+      delete process.env.PI_SUBAGENT_SESSION;
+    }
+
+    const { api, eventHandlers, registeredCommands } = createExtensionApi();
+    subagentDoneExtension(api);
+
+    const notifications: Notification[] = [];
+    const ctx: any = {
+      shutdowns: 0,
+      ui: {
+        notify(message: string, type?: string) {
+          notifications.push({ message, type });
+        },
+        setWidget() {},
+      },
+      shutdown() {
+        ctx.shutdowns += 1;
+      },
+    };
+
+    return {
+      ctx,
+      notifications,
+      sessionFile,
+      registeredCommands,
+      fire(event: string, payload: any = {}) {
+        for (const handler of eventHandlers.get(event) ?? []) handler(payload, ctx);
+      },
+      // agent_end + agent_settled: mirrors how Pi settles a finished turn.
+      settle(messages: any[]) {
+        this.fire("agent_end", { messages });
+        this.fire("agent_settled", { type: "agent_settled" });
+      },
+      async runCommand(name: string, args = "") {
+        const command = registeredCommands.find((c) => c.name === name);
+        assert.ok(command, `command /${name} must be registered`);
+        await command.handler(args, ctx);
+      },
+    };
+  }
+
+  function sidecarOf(child: ReturnType<typeof boot>): any | null {
+    if (!child.sessionFile || !existsSync(`${child.sessionFile}.exit`)) return null;
+    return JSON.parse(readFileSync(`${child.sessionFile}.exit`, "utf8"));
+  }
+
+  describe("resolveAutoExit decision table", () => {
+    // [disarmed, oneShotReArm, stopReason, expected]
+    const cases: Array<[boolean, boolean, string | undefined, boolean]> = [
+      // Armed (never disarmed): identical to v0.2.0 — terminal stop or error
+      // exits, aborted stays open.
+      [false, false, "stop", true],
+      [false, false, "error", true],
+      [false, false, "aborted", false],
+      [false, false, undefined, true],
+      // Disarmed: never exits, whatever happened.
+      [true, false, "stop", false],
+      [true, false, "error", false],
+      [true, false, "aborted", false],
+      [true, false, undefined, false],
+      // One-shot re-arm via /auto-exit: one more terminal stop or error may
+      // exit; an aborted turn still stays open.
+      [true, true, "stop", true],
+      [true, true, "error", true],
+      [true, true, "aborted", false],
+      // Re-arm while armed cannot occur via CLI but is harmless.
+      [false, true, "stop", true],
+    ];
+
+    for (const [disarmed, reArm, reason, expected] of cases) {
+      it(`disarmed=${disarmed} reArm=${reArm} stop=${reason} -> ${expected}`, () => {
+        assert.equal(resolveAutoExit({ disarmed, oneShotReArm: reArm }, reason), expected);
+      });
+    }
+  });
+
+  it("ignores the initial task input before the first agent run", () => {
+    const child = boot();
+    child.fire("input", { type: "input", text: "do the whole task" });
+    child.settle([{ role: "assistant", stopReason: "stop" }]);
+    assert.equal(child.ctx.shutdowns, 1, "zero-real-input child still exits");
+    assert.deepEqual(sidecarOf(child), { type: "done" });
+    assert.equal(child.notifications.length, 0, "no warning for the injected task");
+  });
+
+  it("operator input disarms auto-exit persistently across settled turns", () => {
+    const child = boot();
+    child.fire("agent_start", {});
+    child.fire("input", { type: "input", text: "hold on, steer this way" });
+    for (let i = 0; i < 3; i++) {
+      child.settle([{ role: "assistant", stopReason: "stop" }]);
+    }
+    assert.equal(child.ctx.shutdowns, 0, "disarm survives settled turns (no reset)");
+    assert.equal(sidecarOf(child), null, "no done sidecar after disarm");
+  });
+
+  it("warns exactly once when input first disarms auto-exit", () => {
+    const child = boot();
+    child.fire("agent_start", {});
+    child.fire("input", { type: "input", text: "first takeover" });
+    child.fire("input", { type: "input", text: "second takeover" });
+    child.fire("input", { type: "input", text: "third takeover" });
+    child.settle([{ role: "assistant", stopReason: "aborted" }]);
+    const warnings = child.notifications.filter((n) => n.type === "warning");
+    assert.equal(warnings.length, 1, "exactly one warning despite repeated inputs");
+    assert.match(warnings[0].message, /auto-exit/i);
+  });
+
+  it("Escape-triggered abort disarms auto-exit and keeps the session open", () => {
+    const child = boot();
+    child.settle([{ role: "assistant", stopReason: "aborted" }]);
+    assert.equal(child.ctx.shutdowns, 0, "aborted run does not exit");
+    assert.equal(
+      child.notifications.filter((n) => n.type === "warning").length,
+      1,
+      "one takeover warning for the Escape abort",
+    );
+    // Session stays open and disarmed: a later normal completion must not exit.
+    child.settle([{ role: "assistant", stopReason: "stop" }]);
+    assert.equal(child.ctx.shutdowns, 0);
+  });
+
+  it("/auto-exit re-arms for exactly one completion, then disarms again", async () => {
+    const child = boot();
+    child.fire("agent_start", {});
+    child.fire("input", { type: "input", text: "taking over" });
+    child.settle([{ role: "assistant", stopReason: "stop" }]);
+    assert.equal(child.ctx.shutdowns, 0);
+
+    // Double invocation must not stack two completions.
+    await child.runCommand("auto-exit");
+    await child.runCommand("auto-exit");
+
+    child.settle([{ role: "assistant", stopReason: "stop" }]);
+    assert.equal(child.ctx.shutdowns, 1, "re-armed child exits on next completion");
+    assert.deepEqual(sidecarOf(child), { type: "done" }, "done sidecar written");
+
+    // One-shot consumed: another settled completion does not exit again.
+    child.settle([{ role: "assistant", stopReason: "stop" }]);
+    assert.equal(child.ctx.shutdowns, 1, "auto-exit is disarmed again after one-shot exit");
+  });
+
+  it("/auto-exit is a no-op while auto-exit is still armed", async () => {
+    const child = boot();
+    await child.runCommand("auto-exit");
+    child.settle([{ role: "assistant", stopReason: "stop" }]);
+    assert.equal(child.ctx.shutdowns, 1, "plain armed behavior unchanged");
+  });
+
+  it("background regression: zero-input child behaves byte-for-byte like v0.2.0", () => {
+    const child = boot();
+    child.fire("session_start", {});
+    child.fire("agent_end", { messages: [{ role: "assistant", stopReason: "stop" }] });
+    assert.equal(child.ctx.shutdowns, 0, "no shutdown before agent_settled");
+    assert.equal(existsSync(`${child.sessionFile}.exit`), false);
+    child.fire("agent_settled", { type: "agent_settled" });
+    assert.equal(child.ctx.shutdowns, 1);
+    assert.deepEqual(sidecarOf(child), { type: "done" });
+    assert.equal(child.notifications.length, 0, "silent for background children");
+
+    const failing = boot();
+    failing.settle([
+      { role: "assistant", stopReason: "error", errorMessage: "529 overloaded" },
+    ]);
+    assert.equal(failing.ctx.shutdowns, 1, "error stopReason still wakes the parent");
+    assert.deepEqual(sidecarOf(failing), {
+      type: "error",
+      errorMessage: "529 overloaded",
+      stopReason: "error",
+    });
+  });
+
+  it("non-auto-exit sessions never warn and ignore /auto-exit state changes", async () => {
+    const child = boot({ autoExit: false });
+    child.fire("agent_start", {});
+    child.fire("input", { type: "input", text: "interactive use" });
+    child.settle([{ role: "assistant", stopReason: "stop" }]);
+    child.settle([{ role: "assistant", stopReason: "aborted" }]);
+    await child.runCommand("auto-exit");
+    assert.equal(child.ctx.shutdowns, 0, "interactive child never auto-exits");
+    assert.equal(
+      child.notifications.filter((n) => n.type === "warning").length,
+      0,
+      "nothing to disarm, so no takeover warning",
+    );
+  });
+});

--- a/test/test.ts
+++ b/test/test.ts
@@ -75,17 +75,22 @@ before(() => {
   delete process.env.PI_SUBAGENT_ID;
   delete process.env.PI_DENY_TOOLS;
 });
+const createdTestDirs: string[] = [];
+
 after(() => {
   if (inheritedSubagentId == null) delete process.env.PI_SUBAGENT_ID;
   else process.env.PI_SUBAGENT_ID = inheritedSubagentId;
   if (inheritedDenyTools == null) delete process.env.PI_DENY_TOOLS;
   else process.env.PI_DENY_TOOLS = inheritedDenyTools;
+  for (const dir of createdTestDirs) rmSync(dir, { recursive: true, force: true });
 });
 
 // --- Helpers ---
 
 function createTestDir(): string {
-  return mkdtempSync(join(tmpdir(), "subagents-test-"));
+  const dir = mkdtempSync(join(tmpdir(), "subagents-test-"));
+  createdTestDirs.push(dir);
+  return dir;
 }
 
 function createSessionFile(dir: string, entries: object[]): string {

--- a/test/test.ts
+++ b/test/test.ts
@@ -1494,6 +1494,11 @@ describe("subagent-done.ts", () => {
       assert.equal(shouldAutoExitOnAgentEnd(false, messages), false);
     });
 
+    it("stays open after a tool-use turn", () => {
+      const messages = [{ role: "assistant", stopReason: "toolUse" }];
+      assert.equal(shouldAutoExitOnAgentEnd(false, messages), false);
+    });
+
     it("still exits when the latest turn ended with stopReason=error", () => {
       // Auto-exit subagents must shut down on retry-exhaustion errors so the
       // parent is woken. The error sidecar (written separately) carries the

--- a/test/test.ts
+++ b/test/test.ts
@@ -1542,7 +1542,7 @@ describe("subagent-done.ts", () => {
         const { api, eventHandlers } = createMockExtensionApi();
         subagentDoneExtension(api);
         let shutdowns = 0;
-        const ctx = { shutdown: () => { shutdowns += 1; } };
+        const ctx = { shutdown: () => { shutdowns += 1; }, ui: { notify() {} } };
         eventHandlers.get("agent_end")![0]({
           messages: [{ role: "assistant", stopReason: "aborted" }],
         }, ctx);

--- a/test/time-limits.test.ts
+++ b/test/time-limits.test.ts
@@ -1,0 +1,435 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import * as subagentsModule from "../pi-extension/subagents/index.ts";
+import subagentDoneExtension from "../pi-extension/subagents/subagent-done.ts";
+import { interpretExitSidecar } from "../pi-extension/subagents/completion.ts";
+import {
+  REPORT_ONLY_WRAPUP_DIRECTIVE,
+  consumeWrapupDirective,
+  evalTimeLimit,
+  writeWrapupDirective,
+} from "../pi-extension/subagents/time-limits.ts";
+import { createLifecycle } from "../pi-extension/subagents/lifecycle.ts";
+
+function withTempDir(run: (dir: string) => void) {
+  const dir = mkdtempSync(join(tmpdir(), "subagent-time-limits-"));
+  try {
+    run(dir);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+function makeRunning(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "child-1",
+    name: "Worker",
+    task: "Implement the feature",
+    surface: "pane-1",
+    startTime: 0,
+    sessionFile: "/tmp/worker.jsonl",
+    interactive: false,
+    lifecycle: createLifecycle(0),
+    timeLimit: { timeLimitSeconds: 100, timeoutWarnThreshold: 0.8 },
+    ...overrides,
+  };
+}
+
+function createMockExtensionApi() {
+  const eventHandlers = new Map<string, Array<Function>>();
+  const sentUserMessages: string[] = [];
+  return {
+    eventHandlers,
+    sentUserMessages,
+    api: {
+      on(event: string, handler: Function) {
+        const handlers = eventHandlers.get(event) ?? [];
+        handlers.push(handler);
+        eventHandlers.set(event, handlers);
+      },
+      registerShortcut() {},
+      registerTool() {},
+      registerCommand() {},
+      registerMessageRenderer(name: string, renderer: Function) {
+        this.renderers.push({ name, renderer });
+      },
+      renderers: [] as Array<{ name: string; renderer: Function }>,
+      getAllTools() {
+        return [];
+      },
+      sendUserMessage(message: string) {
+        sentUserMessages.push(message);
+      },
+    } as any,
+  };
+}
+
+function createTheme(calls: string[]) {
+  return {
+    fg(color: string, text: string) {
+      calls.push(`fg:${color}`);
+      return text;
+    },
+    bg(color: string, text: string) {
+      calls.push(`bg:${color}`);
+      return text;
+    },
+    bold(text: string) {
+      return text;
+    },
+  };
+}
+
+describe("time-limit frontmatter", () => {
+  it("parses valid values and ignores invalid or absent values", () => {
+    const parse = (subagentsModule as any).__test__.parseAgentDefinition;
+    const parseFields = (frontmatter: string) =>
+      parse(`---\nname: worker\n${frontmatter}\n---\nWorker body`, "fallback");
+
+    assert.deepEqual(
+      {
+        timeLimitSeconds: parseFields("time-limit: 120\nidle-timeout: 15\ntimeout-warn-threshold: 0.8").timeLimitSeconds,
+        idleTimeoutSeconds: parseFields("time-limit: 120\nidle-timeout: 15\ntimeout-warn-threshold: 0.8").idleTimeoutSeconds,
+        timeoutWarnThreshold: parseFields("time-limit: 120\nidle-timeout: 15\ntimeout-warn-threshold: 0.8").timeoutWarnThreshold,
+      },
+      { timeLimitSeconds: 120, idleTimeoutSeconds: 15, timeoutWarnThreshold: 0.8 },
+    );
+
+    for (const frontmatter of [
+      "time-limit: 0",
+      "time-limit: -1",
+      "time-limit: 1.5",
+      "time-limit: 1e3",
+      "idle-timeout: nope",
+      "idle-timeout: 0",
+      "timeout-warn-threshold: 0",
+      "timeout-warn-threshold: 1",
+      "timeout-warn-threshold: 1.1",
+      "timeout-warn-threshold: nope",
+      "",
+    ]) {
+      const parsed = parseFields(frontmatter);
+      assert.equal(parsed.timeLimitSeconds, undefined, frontmatter);
+      assert.equal(parsed.idleTimeoutSeconds, undefined, frontmatter);
+      assert.equal(parsed.timeoutWarnThreshold, undefined, frontmatter);
+    }
+  });
+});
+
+describe("evalTimeLimit", () => {
+  it("uses an injected clock for no-limit, warn-only, hard-only, both, and idle cases", () => {
+    const cases: Array<[
+      string,
+      number,
+      number | undefined,
+      { timeLimitSeconds?: number; idleTimeoutSeconds?: number; timeoutWarnThreshold?: number },
+      boolean | undefined,
+      "none" | "warn" | "hard-stop",
+    ]> = [
+      ["no limit", 999_999, undefined, {}, undefined, "none"],
+      ["before whole-run warning", 79_999, undefined, { timeLimitSeconds: 100, timeoutWarnThreshold: 0.8 }, false, "none"],
+      ["whole-run warning", 80_000, undefined, { timeLimitSeconds: 100, timeoutWarnThreshold: 0.8 }, false, "warn"],
+      ["warning fires once", 81_000, undefined, { timeLimitSeconds: 100, timeoutWarnThreshold: 0.8 }, true, "none"],
+      ["whole-run hard stop", 100_000, undefined, { timeLimitSeconds: 100, timeoutWarnThreshold: 0.8 }, true, "hard-stop"],
+      ["hard-only before deadline", 99_999, undefined, { timeLimitSeconds: 100 }, false, "none"],
+      ["hard-only at deadline", 100_000, undefined, { timeLimitSeconds: 100 }, false, "hard-stop"],
+      ["idle warning uses activity timestamp", 57_999, 50_000, { idleTimeoutSeconds: 10, timeoutWarnThreshold: 0.8 }, false, "none"],
+      ["idle warning at fraction", 58_000, 50_000, { idleTimeoutSeconds: 10, timeoutWarnThreshold: 0.8 }, false, "warn"],
+      ["idle hard stop", 60_000, 50_000, { idleTimeoutSeconds: 10, timeoutWarnThreshold: 0.8 }, true, "hard-stop"],
+      ["idle does not use wall clock without an activity snapshot", 100_000, undefined, { idleTimeoutSeconds: 10, timeoutWarnThreshold: 0.8 }, false, "none"],
+      ["the earliest configured deadline wins", 60_000, 55_000, { timeLimitSeconds: 100, idleTimeoutSeconds: 5, timeoutWarnThreshold: 0.8 }, true, "hard-stop"],
+    ];
+
+    for (const [label, now, lastActivityAt, config, warned, expected] of cases) {
+      assert.equal(evalTimeLimit(now, 0, lastActivityAt, config, warned), expected, label);
+    }
+  });
+});
+
+describe("parent time-limit actions", () => {
+  it("writes one directive then only sends Escape for a warned wrap-up", () => {
+    const testApi = (subagentsModule as any).__test__;
+    const running = makeRunning();
+    const calls: string[] = [];
+    let typed = 0;
+    const operations = {
+      interruptPane(surface: string) {
+        calls.push(`escape:${surface}`);
+      },
+      closePane() {
+        calls.push("close");
+      },
+      abortWatcher() {
+        calls.push("abort");
+      },
+      writeWrapup(sessionFile: string) {
+        calls.push(`write:${sessionFile}.wrapup`);
+      },
+      removeWrapup(sessionFile: string) {
+        calls.push(`remove:${sessionFile}.wrapup`);
+      },
+    };
+
+    assert.equal(testApi.advanceRunningTimeLimit(running, 80_000, operations).action, "warn");
+    assert.equal(running.wrapupPending, true);
+    assert.equal(running.timeLimitWarned, true);
+    assert.deepEqual(calls, ["write:/tmp/worker.jsonl.wrapup", "escape:pane-1"]);
+
+    assert.equal(testApi.advanceRunningTimeLimit(running, 81_000, operations).action, null);
+    assert.deepEqual(calls, ["write:/tmp/worker.jsonl.wrapup", "escape:pane-1"]);
+    assert.equal(typed, 0, "the warning path must not type free text into the child pane");
+  });
+
+  it("pins the warned idle deadline, tears down once at hard stop, and reports a timed-out session tail", () => {
+    withTempDir((dir) => {
+      const testApi = (subagentsModule as any).__test__;
+      const sessionFile = join(dir, "worker.jsonl");
+      writeFileSync(sessionFile, `${JSON.stringify({
+        type: "message",
+        message: { role: "assistant", content: [{ type: "text", text: "Halfway through the migration." }] },
+      })}\n`);
+      const running = makeRunning({
+        sessionFile,
+        activity: { updatedAt: 50_000 },
+        timeLimit: { idleTimeoutSeconds: 10, timeoutWarnThreshold: 0.8 },
+      });
+      let closes = 0;
+      let aborts = 0;
+      let removes = 0;
+      const operations = {
+        interruptPane() {},
+        closePane() {
+          closes += 1;
+        },
+        abortWatcher() {
+          aborts += 1;
+        },
+        writeWrapup() {},
+        removeWrapup() {
+          removes += 1;
+        },
+      };
+
+      assert.equal(testApi.advanceRunningTimeLimit(running, 58_000, operations).action, "warn");
+      running.activity = { updatedAt: 59_999 };
+      assert.equal(
+        testApi.advanceRunningTimeLimit(running, 60_000, operations).action,
+        "hard-stop",
+        "the original idle deadline must stay pinned after the warning",
+      );
+      assert.equal(closes, 1);
+      assert.equal(aborts, 1);
+      assert.equal(removes, 1);
+      assert.equal(running.wrapupPending, false);
+      assert.equal(running.lifecycle.process.kind, "failed");
+
+      const result = testApi.buildTimeLimitStoppedResult(running, 60_001);
+      assert.deepEqual(
+        { exitCode: result.exitCode, timeout: result.timeout, partial: result.partial },
+        { exitCode: 1, timeout: "hard-stop", partial: undefined },
+      );
+      assert.match(result.summary, /timed out after 60s/i);
+      assert.match(result.summary, /Halfway through the migration/);
+      assert.match(testApi.resolveResultPresentation(result, running.name), /failed/);
+      assert.doesNotMatch(testApi.resolveResultPresentation(result, running.name), /completed/);
+
+      assert.equal(testApi.advanceRunningTimeLimit(running, 61_000, operations).action, null);
+      assert.equal(closes, 1, "terminal hard-stop must not close twice");
+      assert.equal(aborts, 1, "terminal hard-stop must not abort twice");
+    });
+  });
+
+  it("keeps recovery, interactive, and resumed runs out of time-limit actions", () => {
+    const testApi = (subagentsModule as any).__test__;
+    const noPaneCalls = {
+      interruptPane() { throw new Error("must not interrupt"); },
+      closePane() { throw new Error("must not close"); },
+      abortWatcher() { throw new Error("must not abort"); },
+      writeWrapup() { throw new Error("must not write"); },
+      removeWrapup() { throw new Error("must not remove"); },
+    };
+
+    assert.equal(
+      testApi.advanceRunningTimeLimit(makeRunning({ interactive: true }), 100_000, noPaneCalls).action,
+      null,
+    );
+    assert.equal(
+      testApi.advanceRunningTimeLimit(makeRunning({ recoveryKilled: { errorMessage: "recovery-kill", killedAt: 1 } }), 100_000, noPaneCalls).action,
+      null,
+    );
+    assert.equal(
+      testApi.advanceRunningTimeLimit(makeRunning({ timeLimit: undefined }), 100_000, noPaneCalls).action,
+      null,
+      "a resume registration without re-specified frontmatter has no deadline",
+    );
+
+    assert.equal(
+      testApi.resolveTimeLimitConfig(
+        { timeLimitSeconds: 100, timeoutWarnThreshold: 0.8 },
+        false,
+        false,
+      ).timeoutWarnThreshold,
+      undefined,
+      "non-Pi children retain a hard deadline but cannot promise a file-based report continuation",
+    );
+
+    const hardStopped = makeRunning({ timeLimitStopped: { errorMessage: "timed out", stoppedAt: 1 } });
+    const recovery = testApi.advanceRunningRecovery(
+      hardStopped,
+      { kind: "stalled" },
+      100_000,
+      [1, 1, 1],
+      noPaneCalls,
+    );
+    assert.equal(recovery.action, null);
+    assert.equal(hardStopped.recovery, undefined);
+  });
+});
+
+describe("completion classification", () => {
+  it("keeps partial, timed-out, recovery-kill, and clean outcomes mutually exclusive", () => {
+    const testApi = (subagentsModule as any).__test__;
+    const partial = {
+      name: "Worker",
+      task: "Task",
+      summary: "Partial report",
+      exitCode: 0,
+      elapsed: 80,
+      partial: true,
+      timeout: "warned-wrapup" as const,
+    };
+    const timedOut = testApi.buildTimeLimitStoppedResult(
+      makeRunning({ timeLimitStopped: { errorMessage: "Subagent timed out after 100s.", stoppedAt: 100_000 } }),
+      100_000,
+    );
+    const recovery = testApi.buildRecoveryKilledResult(
+      makeRunning({ recoveryKilled: { errorMessage: "Subagent recovery-kill after 100s.", killedAt: 100_000 } }),
+      100_000,
+    );
+    const clean = {
+      name: "Worker",
+      task: "Task",
+      summary: "Completed",
+      exitCode: 0,
+      elapsed: 10,
+    };
+
+    const classify = (result: any) =>
+      result.partial ? "partial" : result.timeout === "hard-stop" ? "timed-out" : result.errorMessage ? "recovery-kill" : "clean";
+    assert.deepEqual(
+      [partial, timedOut, recovery, clean].map(classify),
+      ["partial", "timed-out", "recovery-kill", "clean"],
+    );
+    assert.match(testApi.resolveResultPresentation(partial, partial.name), /partial report/i);
+    assert.match(testApi.resolveResultPresentation(timedOut, timedOut.name), /failed/i);
+    assert.match(testApi.resolveResultPresentation(recovery, recovery.name), /failed/i);
+    assert.match(testApi.resolveResultPresentation(clean, clean.name), /completed/i);
+  });
+});
+
+describe("wrap-up directive and completion delivery", () => {
+  it("is consumed once, starts a report-only continuation, and publishes a normal partial completion", () => {
+    withTempDir((dir) => {
+      const artifactDir = join(dir, "artifacts");
+      mkdirSync(artifactDir);
+      const sessionFile = join(artifactDir, "worker.jsonl");
+      writeFileSync(sessionFile, "");
+      writeWrapupDirective(sessionFile);
+      assert.equal(readFileSync(`${sessionFile}.wrapup`, "utf8"), REPORT_ONLY_WRAPUP_DIRECTIVE);
+      assert.equal(consumeWrapupDirective(sessionFile), REPORT_ONLY_WRAPUP_DIRECTIVE);
+      assert.equal(consumeWrapupDirective(sessionFile), null, "a directive is consumed once");
+      assert.equal(existsSync(`${sessionFile}.wrapup`), false);
+
+      writeWrapupDirective(sessionFile);
+      const previousAutoExit = process.env.PI_SUBAGENT_AUTO_EXIT;
+      const previousSession = process.env.PI_SUBAGENT_SESSION;
+      process.env.PI_SUBAGENT_AUTO_EXIT = "1";
+      process.env.PI_SUBAGENT_SESSION = sessionFile;
+      try {
+        const { api, eventHandlers, sentUserMessages } = createMockExtensionApi();
+        subagentDoneExtension(api);
+        let shutdowns = 0;
+        const ctx = { shutdown() { shutdowns += 1; } };
+        const agentEnd = eventHandlers.get("agent_end")![0];
+        const agentSettled = eventHandlers.get("agent_settled")![0];
+
+        agentEnd({ messages: [{ role: "assistant", stopReason: "aborted" }] }, ctx);
+        agentSettled({}, ctx);
+        assert.deepEqual(sentUserMessages, [REPORT_ONLY_WRAPUP_DIRECTIVE]);
+        assert.equal(shutdowns, 0);
+        assert.equal(existsSync(`${sessionFile}.wrapup`), false);
+
+        agentEnd({ messages: [{ role: "assistant", stopReason: "stop" }] }, ctx);
+        agentSettled({}, ctx);
+        assert.equal(shutdowns, 1);
+        assert.deepEqual(JSON.parse(readFileSync(`${sessionFile}.exit`, "utf8")), {
+          type: "done",
+          wrapup: true,
+        });
+        assert.deepEqual(interpretExitSidecar({ type: "done", wrapup: true }), {
+          reason: "done",
+          exitCode: 0,
+          wrapup: true,
+        });
+        assert.equal(existsSync(sessionFile), true, "the partial-report session remains resumable");
+        assert.deepEqual(
+          readdirSync(artifactDir).filter((file) => file.endsWith(".wrapup")),
+          [],
+          "cleanup leaves no stray wrap-up directives in the artifact directory",
+        );
+      } finally {
+        if (previousAutoExit == null) delete process.env.PI_SUBAGENT_AUTO_EXIT;
+        else process.env.PI_SUBAGENT_AUTO_EXIT = previousAutoExit;
+        if (previousSession == null) delete process.env.PI_SUBAGENT_SESSION;
+        else process.env.PI_SUBAGENT_SESSION = previousSession;
+      }
+    });
+  });
+
+  it("marks warned reports in details, presentation, and warning-styled rendering", () => {
+    const testApi = (subagentsModule as any).__test__;
+    const result = {
+      name: "Worker",
+      task: "Implement the feature",
+      summary: "Implemented the parser; remaining tests need review.",
+      sessionFile: "/tmp/worker.jsonl",
+      exitCode: 0,
+      elapsed: 80,
+      partial: true,
+      timeout: "warned-wrapup" as const,
+    };
+    assert.deepEqual(testApi.buildResultTimeoutDetails(result), {
+      partial: true,
+      timeout: "warned-wrapup",
+    });
+
+    const presentation = testApi.resolveResultPresentation(result, result.name);
+    assert.match(presentation, /partial report under .*time limit/i);
+    assert.doesNotMatch(presentation, /failed/);
+
+    const { api } = createMockExtensionApi();
+    (subagentsModule as any).default(api);
+    const renderer = api.renderers.find((entry: any) => entry.name === "subagent_result")!.renderer;
+    const calls: string[] = [];
+    const rendered = renderer(
+      {
+        customType: "subagent_result",
+        content: presentation,
+        details: {
+          name: result.name,
+          exitCode: 0,
+          elapsed: result.elapsed,
+          partial: true,
+          timeout: "warned-wrapup",
+        },
+      },
+      { expanded: true },
+      createTheme(calls),
+    );
+    assert.match(rendered.render(100).join("\n"), /partial report \(time limit\)/i);
+    assert.ok(calls.includes("fg:warning"), "partial completion uses warning styling");
+  });
+});


### PR DESCRIPTION
Fix for L-84: Prevent subagent auto-exit after a tool-use turn.

- af4c2de: fix(subagents): keep tool-use turns alive before auto-exit
- c52e214: test(subagents): cover policy failure after tool use

Testing: focused 26/26, full 278/278, lint clean, Baldr 197/197, live smoke passed.