### PR TITLE
fix(subagents): make spawn artifacts unique per spawn

### DIFF
--- a/README.md
+++ b/README.md
@@ -369,8 +369,13 @@ You are a specialized agent that does X...
 | `deny-tools`  | string  | Comma-separated extension tool names to deny                                                                                                                                                                                                                                |
 | `auto-exit`   | boolean | Auto-shutdown when the agent finishes its turn — no `subagent_done` call needed. If the user sends any input, auto-exit is permanently disabled and the user takes over the session. Recommended for autonomous agents (scout, worker); not for interactive ones (planner). Also determines the default value of `interactive` (see below). |
 | `interactive` | boolean | derived        | Override whether stall/recovery transitions wake the parent session. Defaults to the inverse of `auto-exit`: autonomous agents (`auto-exit: true`) are non-interactive and get stall pings; agents without `auto-exit` are interactive and stay quiet. Explicit values take precedence. |
+| `time-limit` | positive integer seconds | — | Whole-run deadline for a non-interactive agent. At the deadline the pane closes and the parent receives a timed-out failure with the session still resumable. |
+| `idle-timeout` | positive integer seconds | — | Deadline measured from the latest Pi activity snapshot; it is ignored when no activity snapshots are available. |
+| `timeout-warn-threshold` | fraction `0 < n < 1` | — | Optional warning fraction for either limit on Pi-backed children. At the threshold the child receives one report-only continuation; omit it for hard-stop only. Other CLIs retain the hard deadline only. |
 | `cwd`         | string  | Default working directory (absolute or relative to project root)                                                                                                                                                                                                            |
 | `disable-model-invocation` | boolean | Hide this agent from discovery surfaces like `subagents_list`. The agent still remains directly invokable by explicit name via `subagent({ agent: "name", ... })`. |
+
+A warning writes a directive beside the child session, sends Escape only to interrupt the active turn, and reserves the original deadline for one final report-only turn. That normal completion is delivered as a **partial report under time limit** (not a full completion); the directive never types text into the child pane and fresh report activity cannot extend an idle deadline.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -268,9 +268,11 @@ subagent_interrupt({ id: "abcd1234" });
 subagent_interrupt({ name: "Scout" });
 ```
 
-This sends Escape to the child pane, cancelling the in-progress model turn. The subagent session stays alive — the pane, session file, and background polling all remain intact. After the interrupt, the widget immediately labels the child as `interrupted` (counted as **open**, not active processing). Stale pre-interrupt activity snapshots are ignored so a lagging Herdr/`active` reading cannot overwrite the interrupt. The process elapsed timer keeps running because the pane is still open; only the interrupted-state duration freezes relative to the interrupt request. If the child starts work later, newer observations return it to `active`; completion, failure, and `caller_ping` still flow through normally.
+This sends Escape to the child pane, cancelling the in-progress model turn. Interactive subagents keep their pane and session open for operator takeover. Autonomous one-shot subagents keep the session JSONL but, after a bounded grace period, the parent marks the delegation failed, closes the pane, and delivers an interrupt result with a resume reference. Configure that grace with `PI_SUBAGENT_INTERRUPT_GRACE_MS` (default `5000`). Stale pre-interrupt activity snapshots are ignored so a lagging Herdr/`active` reading cannot overwrite the interrupt.
 
-This is a turn-level interrupt, not a method for forcibly terminating a subagent session.
+A delegated resume is a fresh autonomous run when `autoExit` is enabled: it explicitly re-arms one completion, ignores its machine-delivered resume prompt as operator input, writes a fresh `.exit` sidecar, and lets the parent consume it. `clearResumeExitSidecar` still removes only stale evidence before launch.
+
+Startup does not sweep historical watcher-less panes. Herdr has no durable ownership marker for old panes, so guessing from agent/session labels could close persistent Nova, Halo, or Echo crew panes. Crash orphan discovery and recovery are reserved for the follow-up restore flow; this package never sweeps those orchestrator panes.
 
 > **Note:** Only Pi-backed subagents are supported. Claude-backed runs will return an error.
 

--- a/README.md
+++ b/README.md
@@ -175,6 +175,14 @@ export PI_SUBAGENT_RECOVERY_DELAYS_MS=30000,60000,90000
 
 Missing or malformed values use those defaults; each value below `10000` ms is clamped to `10000` ms. The ladder runs only from the stalled pane projection, so active/streaming/provider work is not timed out by wall clock. Interactive children and report-only wrap-up stages are exempt.
 
+A child wedged inside a single long-running tool call never leaves the `tool` activity scope, so by default it also projects `stalled` after `600000` ms (10 minutes) of tool-scope silence — the last tool-scope activity snapshot aging past the window — and drives the same wait→nudge→kill ladder automatically. Hung tool calls therefore recover without extra configuration; set to `0` to disable:
+
+```bash
+export PI_SUBAGENT_ACTIVE_TOOL_STALL_MS=600000
+```
+
+Missing or malformed values use that default. Only `tool`-scope staleness counts: provider/streaming/agent scopes are never stale-stalled because LLM calls may legitimately think silently. When fresh tool activity arrives, the child emits a `recovered` transition like any other stall recovery.
+
 **Interactive subagents stay silent.** Long-running user-driven subagents (e.g. `planner`, or any `/iterate` fork) do not wake the parent session on `stalled`/`recovered` transitions — the user is working directly in the subagent's pane, and a steer message there would just burn an orchestrator turn on a no-op "still waiting" ping. The widget still updates normally, and activity snapshots are still recorded/classified regardless of the `interactive` setting. By default, agents with `auto-exit: true` are treated as autonomous and get stall pings; agents without it are treated as interactive and stay quiet. Override per-agent with `interactive: true|false` in frontmatter, or per-spawn with `interactive: true|false` on the tool call.
 
 #### Configuration

--- a/README.md
+++ b/README.md
@@ -357,7 +357,7 @@ You are a specialized agent that does X...
 | `tools`       | string  | Comma-separated **native pi tools only**: `read`, `bash`, `edit`, `write`, `grep`, `find`, `ls`                                                                                                                                                                             |
 | `skills`      | string  | Comma-separated skill names to auto-load                                                                                                                                                                                                                                    |
 | `session-mode` | string | Default child-session mode: `standalone`, `lineage-only`, or `fork` |
-| `spawning`    | boolean | Set `false` to deny all subagent-spawning tools                                                                                                                                                                                                                             |
+| `spawning`    | boolean | **Spawn grant.** Subagent-spawning tools are denied for every child by default; set `true` to grant them (still bounded by `PI_SUBAGENT_SPAWN_DEPTH`, see below).                                                                                                              |
 | `deny-tools`  | string  | Comma-separated extension tool names to deny                                                                                                                                                                                                                                |
 | `auto-exit`   | boolean | Auto-shutdown when the agent finishes its turn — no `subagent_done` call needed. If the user sends any input, auto-exit is permanently disabled and the user takes over the session. Recommended for autonomous agents (scout, worker); not for interactive ones (planner). Also determines the default value of `interactive` (see below). |
 | `interactive` | boolean | derived        | Override whether stall/recovery transitions wake the parent session. Defaults to the inverse of `auto-exit`: autonomous agents (`auto-exit: true`) are non-interactive and get stall pings; agents without `auto-exit` are interactive and stay quiet. Explicit values take precedence. |
@@ -439,18 +439,32 @@ subagent({ name: "Scout", agent: "scout", interactive: true, task: "..." });
 
 ## Tool Access Control
 
-By default, every sub-agent can spawn further sub-agents. Control this with frontmatter:
+By default, every sub-agent is launched **without** the subagent lifecycle tools (`subagent`, `subagent_interrupt`, `subagents_list`, `subagent_resume`) — spawning is a granted capability, not a given.
 
-### `spawning: false`
+### `spawning: true`
 
-Denies all subagent lifecycle tools (`subagent`, `subagent_interrupt`, `subagents_list`, `subagent_resume`):
+Grants the full subagent lifecycle tools to this agent:
 
 ```yaml
 ---
-name: worker
-spawning: false
+name: planner
+spawning: true
 ---
 ```
+
+Without this grant (the default), a child cannot spawn further sub-agents even if it tries. Any `deny-tools` entries still stack on top of a grant.
+
+### Recursion depth: `PI_SUBAGENT_SPAWN_DEPTH`
+
+Spawning agents can be bounded by setting `PI_SUBAGENT_SPAWN_DEPTH` in the top-level session's environment. The value is a generation ceiling for direct children:
+
+- Generation-1 children receive an allowance equal to the env value; each granted agent passes `remaining − 1` down to its own children, so the allowance decrements every generation and never rises.
+- A granted agent with `remaining = 0` cannot spawn — exhaustion overrides the frontmatter grant.
+- When the variable is unset, depth is unlimited but the `spawning: true` grant is still required.
+
+Example: `PI_SUBAGENT_SPAWN_DEPTH=2` allows children to spawn grandchildren, but great-grandchildren are denied. Mutually-spawning agents (`A` spawns `B`, `B` spawns `A`) therefore always terminate.
+
+Resumed sessions (`subagent_resume`) never receive more allowance than their first launch recorded in `<session-file>.spawn.json`; if that metadata is missing, resume denies spawning entirely.
 
 ### `deny-tools`
 
@@ -467,11 +481,11 @@ deny-tools: subagent
 
 | Agent      | `spawning`  | Rationale                                    |
 | ---------- | ----------- | -------------------------------------------- |
-| planner    | _(default)_ | Legitimately spawns scouts for investigation |
-| worker     | `false`     | Should implement tasks, not delegate         |
-| researcher | `false`     | Should research, not spawn                   |
-| reviewer   | `false`     | Should review, not spawn                     |
-| scout      | `false`     | Should gather context, not spawn             |
+| planner    | `true`      | Legitimately spawns scouts for investigation |
+| worker     | _(default)_ | Should implement tasks, not delegate         |
+| researcher | _(default)_ | Should research, not spawn                   |
+| reviewer   | _(default)_ | Should review, not spawn                     |
+| scout      | _(default)_ | Should gather context, not spawn             |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -359,7 +359,7 @@ You are a specialized agent that does X...
 | `session-mode` | string | Default child-session mode: `standalone`, `lineage-only`, or `fork` |
 | `spawning`    | boolean | Set `false` to deny all subagent-spawning tools                                                                                                                                                                                                                             |
 | `deny-tools`  | string  | Comma-separated extension tool names to deny                                                                                                                                                                                                                                |
-| `auto-exit`   | boolean | Auto-shutdown when the agent finishes its turn — no `subagent_done` call needed. If the user sends any input, auto-exit is permanently disabled and the user takes over the session. Recommended for autonomous agents (scout, worker); not for interactive ones (planner). Also determines the default value of `interactive` (see below). |
+| `auto-exit`   | boolean | Auto-shutdown when the agent finishes its turn — no `subagent_done` call needed. Operator input or an Escape abort permanently disarms it for that session (with a one-time warning); the `/auto-exit` slash command re-arms it for exactly one completion. Recommended for autonomous agents (scout, worker); not for interactive ones (planner). Also determines the default value of `interactive` (see below). |
 | `interactive` | boolean | derived        | Override whether stall/recovery transitions wake the parent session. Defaults to the inverse of `auto-exit`: autonomous agents (`auto-exit: true`) are non-interactive and get stall pings; agents without `auto-exit` are interactive and stay quiet. Explicit values take precedence. |
 | `cwd`         | string  | Default working directory (absolute or relative to project root)                                                                                                                                                                                                            |
 | `disable-model-invocation` | boolean | Hide this agent from discovery surfaces like `subagents_list`. The agent still remains directly invokable by explicit name via `subagent({ agent: "name", ... })`. |
@@ -393,8 +393,10 @@ When set to `true`, the agent session shuts down automatically as soon as the ag
 
 **Behavior:**
 
-- The session closes after the agent's final message (on the `agent_end` event)
-- If the user sends **any input** before the agent finishes, auto-exit is permanently disabled for that session — the user takes over interactively
+- The session closes after the agent's settled final message
+- **Operator takeover disarms auto-exit permanently:** any input sent after the first agent run starts, or an Escape-triggered abort, disables auto-exit for the rest of the session and emits a one-time warning in the child pane. The session then behaves like a normal interactive session
+- **`/auto-exit` re-arms once:** run this slash command inside the child pane after taking over; auto-exit closes the session after its next completed turn (writing the usual done/error sidecar) and is disarmed again until the command is run once more. It is a no-op while auto-exit is already armed or already re-armed
+- Background children that never receive operator input keep exiting on their first normal completion — behavior is unchanged from previous releases
 - The modeHint injected into the agent's task is adjusted accordingly: autonomous agents see "Complete your task autonomously." rather than instructions to call `subagent_done`
 
 **When to use:**

--- a/README.md
+++ b/README.md
@@ -167,6 +167,14 @@ When `activeCount === 0` (every tracked row is open), the border uses an amber a
 
 A fixed internal watchdog marks a run as `stalled` when pane inspection fails or the pane disappears without a completion sidecar; valid long-running `active` or `waiting` states do not become `stalled` just because time passes. When a run enters `stalled` or recovers from it, the parent agent receives a steer message so it can react. All other status transitions stay in the widget only.
 
+For a non-interactive child that remains genuinely `stalled`, the recovery ladder waits 30 seconds, sends one Escape nudge, waits another 60 seconds to escalate, then waits 90 seconds before closing the pane and aborting the watcher. The delivered result is a `recovery-kill` failure, never a completion. Configure the three consecutive delays (stall→nudge, nudge→escalation, escalation→kill) with comma-separated milliseconds:
+
+```bash
+export PI_SUBAGENT_RECOVERY_DELAYS_MS=30000,60000,90000
+```
+
+Missing or malformed values use those defaults; each value below `10000` ms is clamped to `10000` ms. The ladder runs only from the stalled pane projection, so active/streaming/provider work is not timed out by wall clock. Interactive children and report-only wrap-up stages are exempt.
+
 **Interactive subagents stay silent.** Long-running user-driven subagents (e.g. `planner`, or any `/iterate` fork) do not wake the parent session on `stalled`/`recovered` transitions — the user is working directly in the subagent's pane, and a steer message there would just burn an orchestrator turn on a no-op "still waiting" ping. The widget still updates normally, and activity snapshots are still recorded/classified regardless of the `interactive` setting. By default, agents with `auto-exit: true` are treated as autonomous and get stall pings; agents without it are treated as interactive and stay quiet. Override per-agent with `interactive: true|false` in frontmatter, or per-spawn with `interactive: true|false` on the tool call.
 
 #### Configuration

--- a/agents/planner.md
+++ b/agents/planner.md
@@ -1,6 +1,7 @@
 ---
 name: planner
 description: Interactive planning agent - clarifies WHAT to build and figures out HOW. Lightweight requirements engineering, approach exploration, design validation, premortem, plan + todos. Can spawn scouts/researchers mid-session when it needs facts.
+spawning: true
 system-prompt: append
 ---
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pi-herdr-subagents",
-  "version": "0.1.7",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pi-herdr-subagents",
-      "version": "0.1.7",
+      "version": "0.2.0",
       "license": "MIT",
       "devDependencies": {
         "@earendil-works/pi-ai": "^0.80.6",
@@ -543,7 +543,6 @@
       "resolved": "https://registry.npmjs.org/@earendil-works/pi-coding-agent/-/pi-coding-agent-0.80.6.tgz",
       "integrity": "sha512-vcfD6tOk402isLl3Cm/qbn2O10TvgroMp1+/fEGM24ZdvETFCdOYv5VZ7m59EI5fPsjfSJh+CpQ5bhBrhfOg7g==",
       "dev": true,
-      "hasShrinkwrap": true,
       "license": "MIT",
       "dependencies": {
         "@earendil-works/pi-agent-core": "^0.80.6",
@@ -1071,7 +1070,7 @@
         "typebox": "1.1.38"
       },
       "bin": {
-        "pi-ai": "./dist/cli.js"
+        "pi-ai": "dist/cli.js"
       },
       "engines": {
         "node": ">=22.19.0"

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "type": "module",
   "scripts": {
     "lint": "oxlint pi-extension test",
-    "test": "node --test test/test.ts test/runtime-routing.test.ts test/release-workflow.test.ts test/harness-drivers.test.ts",
+    "test": "node --test test/test.ts test/runtime-routing.test.ts test/release-workflow.test.ts test/harness-drivers.test.ts test/spawn-grants.test.ts",
     "test:integration": "node --test --test-concurrency=1 test/integration/*.test.ts"
   },
   "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "type": "module",
   "scripts": {
     "lint": "oxlint pi-extension test",
-    "test": "node --test test/test.ts test/subagent-done-autoexit.test.ts test/runtime-routing.test.ts test/release-workflow.test.ts test/harness-drivers.test.ts test/spawn-grants.test.ts",
+    "test": "node --test test/test.ts test/subagent-done-autoexit.test.ts test/runtime-routing.test.ts test/release-workflow.test.ts test/harness-drivers.test.ts test/spawn-grants.test.ts test/recovery-ladder.test.ts",
     "test:integration": "node --test --test-concurrency=1 test/integration/*.test.ts"
   },
   "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "type": "module",
   "scripts": {
     "lint": "oxlint pi-extension test",
-    "test": "node --test test/test.ts test/runtime-routing.test.ts test/release-workflow.test.ts test/harness-drivers.test.ts",
+    "test": "node --test test/test.ts test/subagent-done-autoexit.test.ts test/runtime-routing.test.ts test/release-workflow.test.ts test/harness-drivers.test.ts",
     "test:integration": "node --test --test-concurrency=1 test/integration/*.test.ts"
   },
   "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "type": "module",
   "scripts": {
     "lint": "oxlint pi-extension test",
-    "test": "node --test test/test.ts test/subagent-done-autoexit.test.ts test/f108-interrupted-resume.test.ts test/runtime-routing.test.ts test/release-workflow.test.ts test/harness-drivers.test.ts test/spawn-grants.test.ts test/recovery-ladder.test.ts test/time-limits.test.ts test/stale-active-stall.test.ts",
+    "test": "node --test test/test.ts test/subagent-done-autoexit.test.ts test/f108-interrupted-resume.test.ts test/runtime-routing.test.ts test/release-workflow.test.ts test/harness-drivers.test.ts test/spawn-grants.test.ts test/recovery-ladder.test.ts test/time-limits.test.ts test/stale-active-stall.test.ts test/orphan-discovery.test.ts",
     "test:integration": "node --test --test-concurrency=1 test/integration/*.test.ts"
   },
   "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "type": "module",
   "scripts": {
     "lint": "oxlint pi-extension test",
-    "test": "node --test test/test.ts test/runtime-routing.test.ts test/release-workflow.test.ts test/harness-drivers.test.ts",
+    "test": "node --test test/test.ts test/runtime-routing.test.ts test/release-workflow.test.ts test/harness-drivers.test.ts test/time-limits.test.ts",
     "test:integration": "node --test --test-concurrency=1 test/integration/*.test.ts"
   },
   "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "type": "module",
   "scripts": {
     "lint": "oxlint pi-extension test",
-    "test": "node --test test/test.ts test/subagent-done-autoexit.test.ts test/f108-interrupted-resume.test.ts test/runtime-routing.test.ts test/release-workflow.test.ts test/harness-drivers.test.ts test/spawn-grants.test.ts test/recovery-ladder.test.ts test/time-limits.test.ts test/stale-active-stall.test.ts test/orphan-discovery.test.ts",
+    "test": "node --test test/test.ts test/subagent-done-autoexit.test.ts test/f108-interrupted-resume.test.ts test/runtime-routing.test.ts test/release-workflow.test.ts test/harness-drivers.test.ts test/spawn-grants.test.ts test/recovery-ladder.test.ts test/time-limits.test.ts test/stale-active-stall.test.ts test/orphan-discovery.test.ts test/f111-restore-flow.test.ts",
     "test:integration": "node --test --test-concurrency=1 test/integration/*.test.ts"
   },
   "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "type": "module",
   "scripts": {
     "lint": "oxlint pi-extension test",
-    "test": "node --test test/test.ts test/runtime-routing.test.ts test/release-workflow.test.ts test/harness-drivers.test.ts",
+    "test": "node --test test/test.ts test/runtime-routing.test.ts test/release-workflow.test.ts test/harness-drivers.test.ts test/recovery-ladder.test.ts test/stale-active-stall.test.ts",
     "test:integration": "node --test --test-concurrency=1 test/integration/*.test.ts"
   },
   "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "type": "module",
   "scripts": {
     "lint": "oxlint pi-extension test",
-    "test": "node --test test/test.ts test/subagent-done-autoexit.test.ts test/runtime-routing.test.ts test/release-workflow.test.ts test/harness-drivers.test.ts test/spawn-grants.test.ts test/recovery-ladder.test.ts test/time-limits.test.ts test/stale-active-stall.test.ts",
+    "test": "node --test test/test.ts test/subagent-done-autoexit.test.ts test/f108-interrupted-resume.test.ts test/runtime-routing.test.ts test/release-workflow.test.ts test/harness-drivers.test.ts test/spawn-grants.test.ts test/recovery-ladder.test.ts test/time-limits.test.ts test/stale-active-stall.test.ts",
     "test:integration": "node --test --test-concurrency=1 test/integration/*.test.ts"
   },
   "peerDependencies": {

--- a/pi-extension/subagents/completion.ts
+++ b/pi-extension/subagents/completion.ts
@@ -6,6 +6,8 @@ const TERMINAL_SENTINEL = /__SUBAGENT_DONE_(\d+)__/;
 export interface CompletionResult {
   reason: "done" | "ping" | "sentinel" | "error";
   exitCode: number;
+  /** The child completed its one-shot report-only continuation after a time warning. */
+  wrapup?: boolean;
   ping?: { name: string; message: string };
   errorMessage?: string;
 }
@@ -31,6 +33,7 @@ export function interpretExitSidecar(data: unknown): CompletionResult {
     name?: unknown;
     message?: unknown;
     errorMessage?: unknown;
+    wrapup?: unknown;
   };
 
   if (payload?.type === "ping") {
@@ -52,7 +55,9 @@ export function interpretExitSidecar(data: unknown): CompletionResult {
     return { reason: "error", exitCode: 1, errorMessage };
   }
 
-  if (payload?.type === "done") return { reason: "done", exitCode: 0 };
+  if (payload?.type === "done") {
+    return { reason: "done", exitCode: 0, ...(payload.wrapup === true ? { wrapup: true } : {}) };
+  }
 
   return {
     reason: "error",

--- a/pi-extension/subagents/completion.ts
+++ b/pi-extension/subagents/completion.ts
@@ -1,4 +1,5 @@
 import { existsSync, readFileSync, rmSync } from "node:fs";
+import { MISSING_PANE_DEBOUNCE_MS, MISSING_PANE_ERROR } from "./lifecycle.ts";
 
 const ABORT_MESSAGE = "Aborted while waiting for subagent to finish";
 const TERMINAL_SENTINEL = /__SUBAGENT_DONE_(\d+)__/;
@@ -135,6 +136,7 @@ export async function waitForCompletion(
   options: CompletionOptions,
 ): Promise<CompletionResult> {
   const startedAt = Date.now();
+  let missingPaneDetectedAt: number | undefined;
 
   for (;;) {
     if (signal.aborted) throw new Error(ABORT_MESSAGE);
@@ -164,16 +166,28 @@ export async function waitForCompletion(
       const observedAt = Date.now();
       options.onPaneInspection?.(inspection, observedAt);
       if (inspection.kind === "missing") {
+        // A single pane_not_found can race Herdr's pane publication/update.
+        // Require the miss to persist briefly before declaring evidence lost.
+        missingPaneDetectedAt ??= observedAt;
+        const racedCompletion = completionArtifact(options);
+        if (racedCompletion) return racedCompletion;
+        if (observedAt - missingPaneDetectedAt < MISSING_PANE_DEBOUNCE_MS) {
+          options.onTick?.(Math.floor((Date.now() - startedAt) / 1000));
+          await abortableDelay(options.intervalMs, signal);
+          continue;
+        }
+
         // Pane closure and atomic artifact publication are separate operations.
         // Allow a short bounded grace window before declaring evidence lost.
-        const racedCompletion = await waitForDisappearanceArtifacts(signal, options);
-        if (racedCompletion) return racedCompletion;
+        const delayedCompletion = await waitForDisappearanceArtifacts(signal, options);
+        if (delayedCompletion) return delayedCompletion;
         return {
           reason: "error",
           exitCode: 1,
-          errorMessage: "Subagent pane disappeared before completion evidence was recorded.",
+          errorMessage: MISSING_PANE_ERROR,
         };
       }
+      missingPaneDetectedAt = undefined;
     }
 
     options.onTick?.(Math.floor((Date.now() - startedAt) / 1000));

--- a/pi-extension/subagents/harness/drivers/pi.ts
+++ b/pi-extension/subagents/harness/drivers/pi.ts
@@ -104,7 +104,7 @@ export class PiHarnessDriver implements HarnessDriver {
         .replace(/\s+/g, "-")
         .replace(/-+/g, "-")
         .replace(/^-|-$/g, "");
-      const syspromptPath = join(artifactDir, `context/${spSafeName || "subagent"}-sysprompt-${spTimestamp}.md`);
+      const syspromptPath = join(artifactDir, `context/${spSafeName || "subagent"}-sysprompt-${spTimestamp}-${params.id}.md`);
       mkdirSync(dirname(syspromptPath), { recursive: true });
       writeFileSync(syspromptPath, identity, "utf8");
       parts.push(flag, shellQuote(syspromptPath));
@@ -157,7 +157,7 @@ export class PiHarnessDriver implements HarnessDriver {
         .replace(/\s+/g, "-")
         .replace(/-+/g, "-")
         .replace(/^-|-$/g, "");
-      const artifactName = `context/${safeName || "subagent"}-${timestamp}.md`;
+      const artifactName = `context/${safeName || "subagent"}-${timestamp}-${params.id}.md`;
       const artifactPath = join(artifactDir, artifactName);
       mkdirSync(dirname(artifactPath), { recursive: true });
       writeFileSync(artifactPath, fullTask, "utf8");

--- a/pi-extension/subagents/harness/drivers/pi.ts
+++ b/pi-extension/subagents/harness/drivers/pi.ts
@@ -70,6 +70,7 @@ export class PiHarnessDriver implements HarnessDriver {
       effectiveAutoExit,
       taskDelivery,
       denySet,
+      childSpawnDepth,
       identity,
       identityInSystemPrompt,
       systemPromptMode,
@@ -123,6 +124,9 @@ export class PiHarnessDriver implements HarnessDriver {
 
     if (denySet && denySet.size > 0) {
       envParts.push(`PI_DENY_TOOLS=${shellQuote([...denySet].join(","))}`);
+    }
+    if (childSpawnDepth != null) {
+      envParts.push(`PI_SUBAGENT_SPAWN_DEPTH=${childSpawnDepth}`);
     }
     envParts.push(`PI_SUBAGENT_NAME=${shellQuote(params.name)}`);
     if (params.agent) {

--- a/pi-extension/subagents/harness/drivers/pi.ts
+++ b/pi-extension/subagents/harness/drivers/pi.ts
@@ -6,6 +6,7 @@ import type {
   BuiltHarnessCommand,
 } from "../types.ts";
 import type { ResolvedRuntimePlan } from "../../runtime-routing.ts";
+import { getSubagentActivityFile } from "../../activity.ts";
 
 const SUBAGENT_CONTROL_TOOLS = ["caller_ping", "subagent_done"] as const;
 
@@ -133,7 +134,7 @@ export class PiHarnessDriver implements HarnessDriver {
     }
     envParts.push(`PI_SUBAGENT_SESSION=${shellQuote(subagentSessionFile)}`);
     envParts.push(`PI_SUBAGENT_ID=${shellQuote(params.id)}`);
-    const activityFile = join(artifactDir, `subagent-activity-${params.id}.json`);
+    const activityFile = getSubagentActivityFile(artifactDir, params.id);
     envParts.push(`PI_SUBAGENT_ACTIVITY_FILE=${shellQuote(activityFile)}`);
     envParts.push(`PI_SUBAGENT_SURFACE=${shellQuote(surface)}`);
 

--- a/pi-extension/subagents/harness/types.ts
+++ b/pi-extension/subagents/harness/types.ts
@@ -48,6 +48,8 @@ export interface SubagentLaunchContext {
   inheritsConversationContext: boolean;
   taskDelivery: "direct" | "artifact";
   denySet?: Set<string>;
+  /** PI_SUBAGENT_SPAWN_DEPTH handed to this child (its children's ceiling); null = unlimited. */
+  childSpawnDepth?: number | null;
   identity?: string | null;
   identityInSystemPrompt?: boolean;
   systemPromptMode?: string;

--- a/pi-extension/subagents/herdr.ts
+++ b/pi-extension/subagents/herdr.ts
@@ -253,6 +253,47 @@ export function sendHerdrEscape(surface: string): void {
   herdrExec(["pane", "send-keys", surface, "Escape"]);
 }
 
+export interface HerdrPaneSessionReference {
+  paneId: string;
+  sessionPath: string;
+}
+
+/** Read persisted agent session paths without making them restore targets. */
+export function listHerdrPaneSessions(): HerdrPaneSessionReference[] {
+  try {
+    const output = execFileSync("herdr", ["pane", "list"], {
+      encoding: "utf8",
+      timeout: 2_000,
+    });
+    const parsed = parseHerdrJson(output) as {
+      result?: { panes?: unknown };
+    } | null;
+    if (!Array.isArray(parsed?.result?.panes)) return [];
+
+    return parsed.result.panes.flatMap((rawPane) => {
+      if (!rawPane || typeof rawPane !== "object") return [];
+      const pane = rawPane as {
+        pane_id?: unknown;
+        agent_session?: unknown;
+        agent_session_path?: unknown;
+      };
+      const paneId = typeof pane.pane_id === "string" && pane.pane_id ? pane.pane_id : undefined;
+      if (!paneId) return [];
+      const session = pane.agent_session;
+      const sessionPath = session && typeof session === "object"
+        ? (session as { kind?: unknown; value?: unknown }).kind === "path" &&
+          typeof (session as { value?: unknown }).value === "string"
+          ? (session as { value: string }).value
+          : undefined
+        : typeof pane.agent_session_path === "string" ? pane.agent_session_path : undefined;
+      return sessionPath ? [{ paneId, sessionPath }] : [];
+    });
+  } catch {
+    // Discovery is best-effort when herdr is unavailable or is restarting.
+    return [];
+  }
+}
+
 export function closeHerdrSurface(surface: string): void {
   herdrExec(["pane", "close", surface]);
 }
@@ -299,6 +340,7 @@ export function reportHerdrPaneTask(
 }
 
 export const __herdrTest__ = {
+  clearCommandAvailability: () => commandAvailability.clear(),
   buildTabCreateArgs,
   buildPaneReportTaskArgs,
   parseHerdrJson,
@@ -306,4 +348,5 @@ export const __herdrTest__ = {
   extractHerdrRootPaneId,
   parsePaneGetOutput,
   parsePaneGetError,
+  listHerdrPaneSessions,
 };

--- a/pi-extension/subagents/index.ts
+++ b/pi-extension/subagents/index.ts
@@ -2882,7 +2882,7 @@ export default function subagentsExtension(pi: ExtensionAPI) {
               .replace(/[^a-z0-9\s-]/g, "")
               .replace(/\s+/g, "-")
               .replace(/-+/g, "-")
-              .replace(/^-|-$/g, "") || "resume"}-${msgTimestamp}.md`,
+              .replace(/^-|-$/g, "") || "resume"}-${msgTimestamp}-${id}.md`,
           );
           mkdirSync(dirname(resumeMsgFile), { recursive: true });
           writeFileSync(resumeMsgFile, params.message, "utf8");

--- a/pi-extension/subagents/index.ts
+++ b/pi-extension/subagents/index.ts
@@ -1473,6 +1473,14 @@ function startStatusRefresh(pi: ExtensionAPI) {
   (globalThis as any)[STATUS_INTERVAL_KEY] = statusInterval;
 }
 
+function clearResumeExitSidecar(sessionFile: string): void {
+  try {
+    unlinkSync(`${sessionFile}.exit`);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+  }
+}
+
 function resolveResumeLaunchBehavior(params: { autoExit?: boolean }): { autoExit: boolean; interactive: boolean } {
   const autoExit = params.autoExit ?? true;
   return { autoExit, interactive: !autoExit };
@@ -1513,6 +1521,7 @@ export const __test__ = {
   handleSubagentInterrupt,
   resolveResultPresentation,
   resolveResumeLaunchBehavior,
+  clearResumeExitSidecar,
   preflightSubagentDonePath,
   enrichNoSessionFailure,
   runningSubagents,
@@ -2433,6 +2442,10 @@ export default function subagentsExtension(pi: ExtensionAPI) {
             details: { error: resumeCwd.error },
           };
         }
+
+        // A prior run may have left completion evidence behind after its watcher
+        // consumed the original sidecar. It belongs to the old run, not this one.
+        clearResumeExitSidecar(params.sessionPath);
 
         // Record entry count before resuming so we can extract new messages
         const entryCountBefore = getNewEntries(params.sessionPath, 0).length;

--- a/pi-extension/subagents/index.ts
+++ b/pi-extension/subagents/index.ts
@@ -2,14 +2,17 @@ import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-a
 import { keyHint } from "@earendil-works/pi-coding-agent";
 import { Type, type Static } from "@sinclair/typebox";
 import { Box, Text, truncateToWidth, visibleWidth } from "@earendil-works/pi-tui";
-import { dirname, join } from "node:path";
+import { basename, dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
+import { randomUUID } from "node:crypto";
 import {
   readdirSync,
   readFileSync,
   writeFileSync,
   existsSync,
   mkdirSync,
+  renameSync,
+  unlinkSync,
 } from "node:fs";
 import { homedir } from "node:os";
 import {
@@ -330,6 +333,72 @@ function readSpawnMetadata(sessionFile: string): { allowance?: unknown } | null 
   } catch {
     return null;
   }
+}
+
+type ResumeSessionCwdResult =
+  | { ok: true; healed: boolean }
+  | { ok: false; error: string };
+
+/** Ensure a resumed session has a cwd that pi can open without prompting. */
+function ensureResumeSessionCwd(sessionFile: string, resumingCwd: string): ResumeSessionCwdResult {
+  let raw: Buffer;
+  try {
+    raw = readFileSync(sessionFile);
+  } catch (error) {
+    const reason = error instanceof Error ? error.message : String(error);
+    return { ok: false, error: `Unable to read session file: ${reason}` };
+  }
+
+  const firstLineEnd = raw.indexOf(0x0a);
+  const firstLine = raw
+    .subarray(0, firstLineEnd === -1 ? raw.length : firstLineEnd)
+    .toString("utf8");
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(firstLine);
+  } catch {
+    return { ok: false, error: "Unable to parse the session header JSON" };
+  }
+  if (
+    parsed === null ||
+    typeof parsed !== "object" ||
+    Array.isArray(parsed) ||
+    typeof (parsed as { cwd?: unknown }).cwd !== "string"
+  ) {
+    return { ok: false, error: "Session header has no valid cwd" };
+  }
+
+  const header = parsed as Record<string, unknown>;
+  if (existsSync(header.cwd as string)) return { ok: true, healed: false };
+
+  const lineEndingStart =
+    firstLineEnd !== -1 && firstLineEnd > 0 && raw[firstLineEnd - 1] === 0x0d
+      ? firstLineEnd - 1
+      : firstLineEnd === -1
+        ? raw.length
+        : firstLineEnd;
+  const rewritten = Buffer.concat([
+    Buffer.from(JSON.stringify({ ...header, cwd: resumingCwd }), "utf8"),
+    raw.subarray(lineEndingStart),
+  ]);
+  const tempFile = join(
+    dirname(sessionFile),
+    `.${basename(sessionFile)}.${process.pid}.${randomUUID()}.tmp`,
+  );
+  try {
+    writeFileSync(tempFile, rewritten, { flag: "wx", mode: 0o600 });
+    renameSync(tempFile, sessionFile);
+  } catch (error) {
+    try {
+      unlinkSync(tempFile);
+    } catch {
+      // Keep the original failure as the block reason.
+    }
+    const reason = error instanceof Error ? error.message : String(error);
+    return { ok: false, error: `Unable to repair missing session cwd: ${reason}` };
+  }
+
+  return { ok: true, healed: true };
 }
 
 /** Same-agent respawn guard: an agent never spawns another instance of itself. */
@@ -1408,6 +1477,7 @@ export const __test__ = {
   decrementSpawnDepth,
   clampResumeSpawn,
   readSpawnMetadata,
+  ensureResumeSessionCwd,
   blockedSelfSpawn,
   SPAWNING_TOOLS,
   resolveInterruptTarget,
@@ -2300,6 +2370,14 @@ export default function subagentsExtension(pi: ExtensionAPI) {
               { type: "text", text: `Error: session file not found: ${params.sessionPath}` },
             ],
             details: { error: "session not found" },
+          };
+        }
+
+        const resumeCwd = ensureResumeSessionCwd(params.sessionPath, ctx.cwd);
+        if (!resumeCwd.ok) {
+          return {
+            content: [{ type: "text", text: `Error: ${resumeCwd.error}` }],
+            details: { error: resumeCwd.error },
           };
         }
 

--- a/pi-extension/subagents/index.ts
+++ b/pi-extension/subagents/index.ts
@@ -103,6 +103,7 @@ import {
   writeWrapupDirective,
   type TimeLimitConfig,
 } from "./time-limits.ts";
+import type { SpawnMetadataRecord } from "./orphan-discovery.ts";
 
 /** Absolute path to `pi-extension/subagents`. https://github.com/nodejs/node/issues/37845 */
 const SUBAGENTS_DIR = dirname(fileURLToPath(import.meta.url));
@@ -345,11 +346,30 @@ function clampResumeSpawn(
  * session file. Any failure (missing file, corrupt JSON) → null, which the
  * clamp treats as zero allowance.
  */
-function readSpawnMetadata(sessionFile: string): { allowance?: unknown } | null {
+function readSpawnMetadata(sessionFile: string): SpawnMetadataRecord | null {
   try {
     return JSON.parse(readFileSync(`${sessionFile}.spawn.json`, "utf8"));
   } catch {
     return null;
+  }
+}
+
+/** Write one complete spawn record without exposing a partially-written JSON. */
+function writeSpawnMetadata(sessionFile: string, metadata: SpawnMetadataRecord): void {
+  const target = `${sessionFile}.spawn.json`;
+  const temporary = join(
+    dirname(target),
+    `.${basename(target)}.${process.pid}.${randomUUID()}.tmp`,
+  );
+  try {
+    writeFileSync(temporary, JSON.stringify(metadata), { flag: "wx", mode: 0o600 });
+    renameSync(temporary, target);
+  } finally {
+    try {
+      unlinkSync(temporary);
+    } catch {
+      // The rename succeeded, or the temporary file was never created.
+    }
   }
 }
 
@@ -1693,6 +1713,7 @@ export const __test__ = {
   clearResumeExitSidecar,
   preflightSubagentDonePath,
   enrichNoSessionFailure,
+  writeSpawnMetadata,
   runningSubagents,
   formatElapsed,
 };
@@ -1857,15 +1878,6 @@ async function launchSubagent(
     .replace(/^-|-$/g, "") || "subagent"}-${id}.sh`;
   const launchScriptFile = join(artifactDir, "subagent-scripts", launchScriptName);
 
-  runScriptInPane(surface, built.command, {
-    scriptPath: launchScriptFile,
-    scriptPreamble: (built.launchScriptPreamble ?? [
-      `# Subagent launch script for ${params.name}`,
-      `# Generated: ${new Date().toISOString()}`,
-      `# Surface: ${surface}`,
-    ]).join("\n"),
-  });
-
   const running: RunningSubagent = {
     id,
     name: params.name,
@@ -1886,17 +1898,33 @@ async function launchSubagent(
       : createLifecycle(startTime),
   };
 
-  // First-launch spawn metadata: authoritative cap for later subagent_resume.
-  // Non-granted agents record 0 so resume can never enlarge their rights.
+  // First-launch spawn metadata is durable lineage as well as the authoritative
+  // cap for later subagent_resume. Write it before the command enters the pane
+  // so a crash between pane creation and the first child message leaves a
+  // discoverable phantom rather than an invisible launch.
   try {
-    writeFileSync(
-      `${running.sessionFile}.spawn.json`,
-      JSON.stringify({ allowance: spawnGranted ? launcherAllowance ?? null : 0 }),
-      "utf8",
-    );
+    writeSpawnMetadata(running.sessionFile, {
+      allowance: spawnGranted ? launcherAllowance ?? null : 0,
+      parentSessionFile: sessionFile,
+      parentSessionId: sessionId,
+      childSessionFile: running.sessionFile,
+      name: params.name,
+      ...(params.agent ? { agent: params.agent } : {}),
+      task: params.task,
+      launchedAt: new Date(startTime).toISOString(),
+    });
   } catch {
-    // Unwritable sidecar ⇒ resume conservatively denies spawning.
+    // Unwritable sidecar ⇒ resume conservatively denies spawning, as before.
   }
+
+  runScriptInPane(surface, built.command, {
+    scriptPath: launchScriptFile,
+    scriptPreamble: (built.launchScriptPreamble ?? [
+      `# Subagent launch script for ${params.name}`,
+      `# Generated: ${new Date().toISOString()}`,
+      `# Surface: ${surface}`,
+    ]).join("\n"),
+  });
 
   runningSubagents.set(id, running);
   return running;

--- a/pi-extension/subagents/index.ts
+++ b/pi-extension/subagents/index.ts
@@ -81,6 +81,7 @@ import {
 import {
   advanceRecoveryLadder,
   formatRecoveryKillError,
+  parseActiveToolStallMs,
   parseRecoveryDelays,
   type RecoveryDelays,
   type RecoveryState,
@@ -783,7 +784,12 @@ function formatLifecycleWidgetLabel(
 
 function renderSubagentWidgetLines(agents: RunningSubagent[], width: number): string[] {
   const now = Date.now();
-  const rendered = agents.map((agent) => ({ agent, projection: projectLifecycle(ensureLifecycle(agent), now) }));
+  const rendered = agents.map((agent) => ({
+    agent,
+    projection: projectLifecycle(ensureLifecycle(agent), now, {
+      activeToolStallMs: parseActiveToolStallMs(process.env.PI_SUBAGENT_ACTIVE_TOOL_STALL_MS),
+    }),
+  }));
   const activeCount = rendered.filter(({ projection }) =>
     projection.kind === "active" ||
     projection.kind === "starting" ||
@@ -1090,6 +1096,7 @@ function handleSubagentInterrupt(
 function startStatusRefresh(pi: ExtensionAPI) {
   if (!statusConfig.enabled || statusInterval) return;
   const recoveryDelays = parseRecoveryDelays(process.env.PI_SUBAGENT_RECOVERY_DELAYS_MS);
+  const activeToolStallMs = parseActiveToolStallMs(process.env.PI_SUBAGENT_ACTIVE_TOOL_STALL_MS);
 
   statusInterval = setInterval(() => {
     if (runningSubagents.size === 0) {
@@ -1108,7 +1115,7 @@ function startStatusRefresh(pi: ExtensionAPI) {
     for (const running of runningSubagents.values()) {
       // Dual-writes lifecycle + statusState for reload hydration; steers use lifecycle only.
       observeRunningSubagent(running, now);
-      const projection = projectLifecycle(ensureLifecycle(running), now);
+      const projection = projectLifecycle(ensureLifecycle(running), now, { activeToolStallMs });
       const recovery = advanceRunningRecovery(running, projection, now, recoveryDelays);
       if (recovery.action) shouldRefreshWidget = true;
       const transition = lifecycleTransition(running.lastProjectedKind, projection.kind);

--- a/pi-extension/subagents/index.ts
+++ b/pi-extension/subagents/index.ts
@@ -69,6 +69,8 @@ import {
   markCompletionDetected,
   markDelivery,
   markFailed,
+  MISSING_PANE_DEBOUNCE_MS,
+  MISSING_PANE_ERROR,
   markInterruptRequested,
   markProcessRunning,
   observeActivity,
@@ -1116,6 +1118,37 @@ function isTerminalLifecycle(lifecycle: SubagentLifecycle): boolean {
   return lifecycle.process.kind === "completed" || lifecycle.process.kind === "failed";
 }
 
+/** Ignore a race where the pane disappeared before normal cleanup ran. */
+function closePaneQuietly(
+  surface: string,
+  closePaneKey: (surface: string) => void = closePane,
+): void {
+  try {
+    closePaneKey(surface);
+  } catch {}
+}
+
+/** Persist a terminal projection so result delivery can remove its widget row. */
+function reconcileProjectedFailure(running: RunningSubagent, projection: LifecycleProjection): LifecycleProjection {
+  const lifecycle = ensureLifecycle(running);
+  if (
+    projection.kind !== "failed" ||
+    lifecycle.pane.kind !== "missing" ||
+    isTerminalLifecycle(lifecycle)
+  ) {
+    return projection;
+  }
+
+  const terminalAt = lifecycle.pane.detectedAt + MISSING_PANE_DEBOUNCE_MS;
+  running.lifecycle = markFailed(
+    lifecycle,
+    projection.label ?? MISSING_PANE_ERROR,
+    terminalAt,
+    1,
+  );
+  return projectLifecycle(running.lifecycle, terminalAt);
+}
+
 /** Idempotent failure teardown shared with future hard-stop paths. */
 function failAndTeardownSubagent(
   running: RunningSubagent,
@@ -1343,7 +1376,10 @@ function startStatusRefresh(pi: ExtensionAPI) {
     for (const running of runningSubagents.values()) {
       // Dual-writes lifecycle + statusState for reload hydration; steers use lifecycle only.
       observeRunningSubagent(running, now);
-      const projection = projectLifecycle(ensureLifecycle(running), now, { activeToolStallMs });
+      const projection = reconcileProjectedFailure(
+        running,
+        projectLifecycle(ensureLifecycle(running), now, { activeToolStallMs }),
+      );
       const recovery = advanceRunningRecovery(running, projection, now, recoveryDelays);
       if (recovery.action) shouldRefreshWidget = true;
       const transition = lifecycleTransition(running.lastProjectedKind, projection.kind);
@@ -1419,6 +1455,8 @@ export const __test__ = {
   SPAWNING_TOOLS,
   resolveInterruptTarget,
   requestSubagentInterrupt,
+  reconcileProjectedFailure,
+  closePaneQuietly,
   failAndTeardownSubagent,
   advanceRunningRecovery,
   buildRecoveryKilledResult,
@@ -1693,7 +1731,7 @@ async function watchSubagent(
       });
 
       if (extracted) {
-        closePane(surface);
+        closePaneQuietly(surface);
         running.lifecycle = result.exitCode === 0
           ? markCompleted(running.lifecycle, Date.now())
           : markFailed(running.lifecycle, result.errorMessage ?? extracted.summary, Date.now(), result.exitCode);
@@ -1756,7 +1794,7 @@ async function watchSubagent(
           : "Sub-agent exited without output";
     }
 
-    closePane(surface);
+    closePaneQuietly(surface);
     running.lifecycle = result.exitCode === 0
       ? markCompleted(running.lifecycle, Date.now())
       : markFailed(running.lifecycle, result.errorMessage ?? summary, Date.now(), result.exitCode);

--- a/pi-extension/subagents/index.ts
+++ b/pi-extension/subagents/index.ts
@@ -210,7 +210,7 @@ interface ListedAgentDefinition extends AgentDefinition {
   source: AgentSource;
 }
 
-/** Tools that are gated by `spawning: false` */
+/** Tools gated behind an explicit frontmatter spawn grant (`spawning: true`) */
 const SPAWNING_TOOLS = new Set([
   "subagent",
   "subagent_interrupt",
@@ -219,21 +219,51 @@ const SPAWNING_TOOLS = new Set([
 ]);
 
 /**
- * Resolve the effective set of denied tool names from agent defaults.
- * `spawning: false` expands to all SPAWNING_TOOLS.
- * `deny-tools` adds individual tool names on top.
+ * Parse PI_SUBAGENT_SPAWN_DEPTH into a child-spawning allowance.
+ * Unset/blank/unparsable/negative → null (unlimited; a frontmatter grant is
+ * still required). A non-negative integer is the generation ceiling granted
+ * to this process's direct children.
  */
-function resolveDenyTools(agentDefs: AgentDefaults | null): Set<string> {
-  const denied = new Set<string>();
-  if (!agentDefs) return denied;
+function parseSpawnDepth(raw: string | undefined | null): number | null {
+  if (raw == null) return null;
+  const trimmed = raw.trim();
+  if (!trimmed) return null;
+  const parsed = Number.parseInt(trimmed, 10);
+  if (!Number.isFinite(parsed) || parsed < 0) return null;
+  return parsed;
+}
 
-  // spawning: false → deny all spawning tools
-  if (agentDefs.spawning === false) {
+/**
+ * Depth handed down to the next generation: decrements by one per
+ * generation, never rises, clamps at zero. Unlimited stays unlimited.
+ */
+function decrementSpawnDepth(allowance: number | null): number | null {
+  return allowance === null ? null : Math.max(0, allowance - 1);
+}
+
+/**
+ * Resolve the effective set of denied tool names from agent defaults.
+ *
+ * Spawning is deny-by-default: all SPAWNING_TOOLS are denied unless the
+ * agent frontmatter explicitly grants `spawning: true` AND depth remains
+ * (`spawnAllowance > 0`, or null = unlimited).
+ * `deny-tools` additions stack on top either way.
+ */
+function resolveDenyTools(
+  agentDefs: AgentDefaults | null,
+  spawnAllowance: number | null = null,
+): Set<string> {
+  const denied = new Set<string>();
+
+  // Deny-by-default: only spawning:true + remaining depth keeps the tools.
+  const spawnGranted =
+    agentDefs?.spawning === true && (spawnAllowance === null || spawnAllowance > 0);
+  if (!spawnGranted) {
     for (const t of SPAWNING_TOOLS) denied.add(t);
   }
 
-  // deny-tools: explicit list
-  if (agentDefs.denyTools) {
+  // deny-tools: explicit list stacks on top of the default denial
+  if (agentDefs?.denyTools) {
     for (const t of agentDefs.denyTools
       .split(",")
       .map((s) => s.trim())
@@ -243,6 +273,48 @@ function resolveDenyTools(agentDefs: AgentDefaults | null): Set<string> {
   }
 
   return denied;
+}
+
+/**
+ * Resume clamp: first-launch metadata is authoritative. The resumed session
+ * never receives more spawning allowance than its first launch recorded —
+ * min(recorded, requested). Missing/corrupt metadata resolves to 0 (deny).
+ */
+function clampResumeSpawn(
+  recorded: { allowance?: unknown } | null | undefined,
+  requestedAllowance: number | null,
+): { maySpawn: boolean; childEnvDepth: number | null } {
+  const capRaw = recorded?.allowance;
+  if (capRaw !== null && (typeof capRaw !== "number" || !Number.isFinite(capRaw) || capRaw < 0)) {
+    return { maySpawn: false, childEnvDepth: 0 };
+  }
+  const cap = capRaw === null ? null : Math.floor(capRaw);
+  const effective =
+    cap === null
+      ? requestedAllowance
+      : requestedAllowance === null
+        ? cap
+        : Math.min(cap, requestedAllowance);
+  const maySpawn = effective === null || effective > 0;
+  return { maySpawn, childEnvDepth: decrementSpawnDepth(effective) };
+}
+
+/**
+ * Read the first-launch spawn metadata sidecar written next to a subagent
+ * session file. Any failure (missing file, corrupt JSON) → null, which the
+ * clamp treats as zero allowance.
+ */
+function readSpawnMetadata(sessionFile: string): { allowance?: unknown } | null {
+  try {
+    return JSON.parse(readFileSync(`${sessionFile}.spawn.json`, "utf8"));
+  } catch {
+    return null;
+  }
+}
+
+/** Same-agent respawn guard: an agent never spawns another instance of itself. */
+function blockedSelfSpawn(requestedAgent: string | undefined, currentAgent: string | undefined): boolean {
+  return !!requestedAgent && !!currentAgent && requestedAgent === currentAgent;
 }
 
 /** Resolve the global agent config directory, respecting PI_CODING_AGENT_DIR. */
@@ -1079,6 +1151,12 @@ export const __test__ = {
   buildPiPromptArgs,
   observeRunningSubagent,
   resolveDenyTools,
+  parseSpawnDepth,
+  decrementSpawnDepth,
+  clampResumeSpawn,
+  readSpawnMetadata,
+  blockedSelfSpawn,
+  SPAWNING_TOOLS,
   resolveInterruptTarget,
   requestSubagentInterrupt,
   handleSubagentInterrupt,
@@ -1197,7 +1275,12 @@ async function launchSubagent(
   const summaryInstruction = effectiveAutoExit
     ? "Your FINAL assistant message should summarize what you accomplished."
     : "Your FINAL assistant message (before calling subagent_done or before the user exits) should summarize what you accomplished.";
-  const denySet = resolveDenyTools(agentDefs);
+  // Spawn grant + depth: this process's PI_SUBAGENT_SPAWN_DEPTH is the
+  // generation ceiling for our direct children; they receive one less so
+  // mutual spawning terminates.
+  const launcherAllowance = parseSpawnDepth(process.env.PI_SUBAGENT_SPAWN_DEPTH);
+  const spawnGranted = agentDefs?.spawning === true;
+  const denySet = resolveDenyTools(agentDefs, launcherAllowance);
   const identity = agentDefs?.body ?? params.systemPrompt ?? null;
   const systemPromptMode = agentDefs?.systemPromptMode;
   const identityInSystemPrompt = systemPromptMode && identity;
@@ -1222,6 +1305,7 @@ async function launchSubagent(
     inheritsConversationContext,
     taskDelivery: launchBehavior.taskDelivery,
     denySet,
+    childSpawnDepth: decrementSpawnDepth(launcherAllowance),
     identity,
     identityInSystemPrompt: Boolean(identityInSystemPrompt),
     systemPromptMode,
@@ -1267,6 +1351,18 @@ async function launchSubagent(
       ? markProcessRunning(createLifecycle(startTime), Date.now())
       : createLifecycle(startTime),
   };
+
+  // First-launch spawn metadata: authoritative cap for later subagent_resume.
+  // Non-granted agents record 0 so resume can never enlarge their rights.
+  try {
+    writeFileSync(
+      `${running.sessionFile}.spawn.json`,
+      JSON.stringify({ allowance: spawnGranted ? launcherAllowance ?? null : 0 }),
+      "utf8",
+    );
+  } catch {
+    // Unwritable sidecar ⇒ resume conservatively denies spawning.
+  }
 
   runningSubagents.set(id, running);
   return running;
@@ -1501,8 +1597,7 @@ export default function subagentsExtension(pi: ExtensionAPI) {
 
       async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
         // Prevent self-spawning (e.g. planner spawning another planner)
-        const currentAgent = process.env.PI_SUBAGENT_AGENT;
-        if (params.agent && currentAgent && params.agent === currentAgent) {
+        if (blockedSelfSpawn(params.agent, process.env.PI_SUBAGENT_AGENT)) {
           return {
             content: [
               {
@@ -1964,6 +2059,18 @@ export default function subagentsExtension(pi: ExtensionAPI) {
         resumeEnvParts.push(`PI_SUBAGENT_ACTIVITY_FILE=${shellQuote(activityFile)}`);
         if (autoExit) {
           resumeEnvParts.push(`PI_SUBAGENT_AUTO_EXIT=1`);
+        }
+        // Spawn rights on resume are clamped to what the first launch recorded:
+        // missing metadata ⇒ 0 (deny); never larger than first launch.
+        const resumeSpawn = clampResumeSpawn(
+          readSpawnMetadata(params.sessionPath),
+          parseSpawnDepth(process.env.PI_SUBAGENT_SPAWN_DEPTH),
+        );
+        if (!resumeSpawn.maySpawn) {
+          resumeEnvParts.push(`PI_DENY_TOOLS=${shellQuote([...SPAWNING_TOOLS].join(","))}`);
+        }
+        if (resumeSpawn.childEnvDepth !== null) {
+          resumeEnvParts.push(`PI_SUBAGENT_SPAWN_DEPTH=${resumeSpawn.childEnvDepth}`);
         }
         const resumeEnvPrefix = resumeEnvParts.join(" ") + " ";
 

--- a/pi-extension/subagents/index.ts
+++ b/pi-extension/subagents/index.ts
@@ -13,6 +13,8 @@ import {
   mkdirSync,
   renameSync,
   unlinkSync,
+  accessSync,
+  constants as fsConstants,
 } from "node:fs";
 import { homedir } from "node:os";
 import {
@@ -102,6 +104,19 @@ import {
 
 /** Absolute path to `pi-extension/subagents`. https://github.com/nodejs/node/issues/37845 */
 const SUBAGENTS_DIR = dirname(fileURLToPath(import.meta.url));
+
+function preflightSubagentDonePath(subagentsDir = SUBAGENTS_DIR): string {
+  const subagentDonePath = join(subagentsDir, "subagent-done.ts");
+  try {
+    accessSync(subagentDonePath, fsConstants.R_OK);
+  } catch {
+    throw new Error(
+      `Cannot launch subagent: child extension "${subagentDonePath}" is missing or unreadable. ` +
+      "Likely cause: a live-package-swap (pi install/remove) while the parent session was running.",
+    );
+  }
+  return subagentDonePath;
+}
 
 // Survive /reload: replace presentation timers while keeping active completion
 // watchers and their registry alive. Old module closures continue watching the
@@ -1498,6 +1513,8 @@ export const __test__ = {
   handleSubagentInterrupt,
   resolveResultPresentation,
   resolveResumeLaunchBehavior,
+  preflightSubagentDonePath,
+  enrichNoSessionFailure,
   runningSubagents,
   formatElapsed,
 };
@@ -1533,6 +1550,7 @@ async function launchSubagent(
   parentThinking: ThinkingLevel,
   options?: { surface?: string },
 ): Promise<RunningSubagent> {
+  preflightSubagentDonePath();
   const startTime = Date.now();
   const id = Math.random().toString(16).slice(2, 10);
 
@@ -1706,6 +1724,30 @@ async function launchSubagent(
   return running;
 }
 
+const FAILURE_PANE_TAIL_LINES = 20;
+
+function enrichNoSessionFailure(
+  result: Pick<import("./completion.ts").CompletionResult, "exitCode">,
+  running: Pick<RunningSubagent, "sessionFile" | "surface">,
+  summary: string,
+  readPaneFn: typeof readPane = readPane,
+): { summary: string; error?: string } {
+  if (result.exitCode === 0 || existsSync(running.sessionFile)) return { summary };
+
+  let paneTail: string;
+  try {
+    paneTail = readPaneFn(running.surface, FAILURE_PANE_TAIL_LINES);
+  } catch {
+    return { summary };
+  }
+  if (!paneTail.trim()) return { summary };
+
+  return {
+    summary: `${summary}\n\nChild pane output:\n${paneTail}`,
+    error: paneTail,
+  };
+}
+
 /**
  * Watch a launched subagent until it exits. Polls for completion, extracts
  * the summary from the session file, cleans up the surface,
@@ -1763,17 +1805,19 @@ async function watchSubagent(
       });
 
       if (extracted) {
+        const enriched = enrichNoSessionFailure(result, running, extracted.summary);
         closePane(surface);
         running.lifecycle = result.exitCode === 0
           ? markCompleted(running.lifecycle, Date.now())
-          : markFailed(running.lifecycle, result.errorMessage ?? extracted.summary, Date.now(), result.exitCode);
+          : markFailed(running.lifecycle, result.errorMessage ?? enriched.summary, Date.now(), result.exitCode);
 
         return {
           name,
           task,
-          summary: extracted.summary,
+          summary: enriched.summary,
           exitCode: result.exitCode,
           elapsed,
+          ...(enriched.error ? { error: enriched.error } : {}),
           ...(extracted.sessionId ? { claudeSessionId: extracted.sessionId } : {}),
           ...(result.wrapup ? { partial: true, timeout: "warned-wrapup" as const } : {}),
           ...extracted.details,
@@ -1826,19 +1870,21 @@ async function watchSubagent(
           : "Sub-agent exited without output";
     }
 
+    const enriched = enrichNoSessionFailure(result, running, summary);
     closePane(surface);
     running.lifecycle = result.exitCode === 0
       ? markCompleted(running.lifecycle, Date.now())
-      : markFailed(running.lifecycle, result.errorMessage ?? summary, Date.now(), result.exitCode);
+      : markFailed(running.lifecycle, result.errorMessage ?? enriched.summary, Date.now(), result.exitCode);
 
     return {
       name,
       task,
-      summary,
+      summary: enriched.summary,
       sessionFile,
       exitCode: result.exitCode,
       elapsed,
       ping: result.ping,
+      ...(enriched.error ? { error: enriched.error } : {}),
       ...(result.wrapup ? { partial: true, timeout: "warned-wrapup" as const } : {}),
       ...(result.errorMessage ? { errorMessage: result.errorMessage } : {}),
     };
@@ -2391,6 +2437,7 @@ export default function subagentsExtension(pi: ExtensionAPI) {
         // Record entry count before resuming so we can extract new messages
         const entryCountBefore = getNewEntries(params.sessionPath, 0).length;
 
+        const subagentDonePath = preflightSubagentDonePath();
         const surface = createSubagentPane(name);
         if (params.message) {
           setPaneTask(surface, params.message);
@@ -2401,7 +2448,6 @@ export default function subagentsExtension(pi: ExtensionAPI) {
         const parts = ["pi", "--session", shellQuote(params.sessionPath)];
 
         // Load subagent-done extension so the agent can self-terminate if needed
-        const subagentDonePath = join(SUBAGENTS_DIR, "subagent-done.ts");
         parts.push("-e", shellQuote(subagentDonePath));
 
         const sessionId = ctx.sessionManager.getSessionId();

--- a/pi-extension/subagents/index.ts
+++ b/pi-extension/subagents/index.ts
@@ -78,6 +78,13 @@ import {
   type SubagentLifecycle,
   type PaneInspection,
 } from "./lifecycle.ts";
+import {
+  advanceRecoveryLadder,
+  formatRecoveryKillError,
+  parseRecoveryDelays,
+  type RecoveryDelays,
+  type RecoveryState,
+} from "./recovery.ts";
 
 /** Absolute path to `pi-extension/subagents`. https://github.com/nodejs/node/issues/37845 */
 const SUBAGENTS_DIR = dirname(fileURLToPath(import.meta.url));
@@ -584,6 +591,10 @@ interface RunningSubagent {
     error?: string;
   };
   abortController?: AbortController;
+  recovery?: RecoveryState;
+  recoveryKilled?: { errorMessage: string; killedAt: number };
+  /** Reserved for the L-96 report-only continuation. */
+  wrapupPending?: boolean;
   cli?: string;
   sentinelFile?: string;
   /**
@@ -604,6 +615,18 @@ interface RunningSubagent {
   /** Parent-resolved model/thinking selection and provenance. */
   runtimePlan: ResolvedRuntimePlan | undefined;
 }
+
+interface RecoveryPaneOperations {
+  interruptPane: (surface: string) => void;
+  closePane: (surface: string) => void;
+  abortWatcher: (controller: AbortController | undefined) => void;
+}
+
+const DEFAULT_RECOVERY_PANE_OPERATIONS: RecoveryPaneOperations = {
+  interruptPane,
+  closePane,
+  abortWatcher: (controller) => controller?.abort(),
+};
 
 interface SubagentRuntime {
   runningSubagents: Map<string, RunningSubagent>;
@@ -946,6 +969,75 @@ function requestSubagentInterrupt(
   }
 }
 
+function isTerminalLifecycle(lifecycle: SubagentLifecycle): boolean {
+  return lifecycle.process.kind === "completed" || lifecycle.process.kind === "failed";
+}
+
+/** Idempotent failure teardown shared with future hard-stop paths. */
+function failAndTeardownSubagent(
+  running: RunningSubagent,
+  error: string,
+  now: number,
+  operations: Pick<RecoveryPaneOperations, "closePane" | "abortWatcher"> = DEFAULT_RECOVERY_PANE_OPERATIONS,
+  beforeAbort?: () => void,
+): boolean {
+  const lifecycle = ensureLifecycle(running);
+  if (isTerminalLifecycle(lifecycle)) return false;
+
+  beforeAbort?.();
+  running.lifecycle = markFailed(lifecycle, error, now, 1);
+  try {
+    operations.closePane(running.surface);
+  } catch {}
+  try {
+    operations.abortWatcher(running.abortController);
+  } catch {}
+  return true;
+}
+
+function advanceRunningRecovery(
+  running: RunningSubagent,
+  projection: LifecycleProjection,
+  now: number,
+  delays: RecoveryDelays,
+  operations: RecoveryPaneOperations = DEFAULT_RECOVERY_PANE_OPERATIONS,
+) {
+  const advance = advanceRecoveryLadder(running.recovery, {
+    now,
+    stalled: projection.kind === "stalled",
+    exempt: running.interactive || running.wrapupPending === true,
+    delays,
+  });
+  running.recovery = advance.state;
+
+  if (advance.action === "nudge") {
+    requestSubagentInterrupt(running, operations.interruptPane);
+  } else if (advance.action === "kill") {
+    const error = formatRecoveryKillError(now - running.startTime);
+    failAndTeardownSubagent(running, error, now, operations, () => {
+      // The watcher observes its abort asynchronously, so set this first.
+      running.recoveryKilled = { errorMessage: error, killedAt: now };
+    });
+  }
+
+  return advance;
+}
+
+function buildRecoveryKilledResult(running: RunningSubagent, now: number): SubagentResult | null {
+  const recoveryKilled = running.recoveryKilled;
+  if (!recoveryKilled) return null;
+  return {
+    name: running.name,
+    task: running.task,
+    summary: `Subagent error: ${recoveryKilled.errorMessage}`,
+    sessionFile: running.sessionFile,
+    exitCode: 1,
+    elapsed: Math.floor(Math.max(0, now - running.startTime) / 1000),
+    error: recoveryKilled.errorMessage,
+    errorMessage: recoveryKilled.errorMessage,
+  };
+}
+
 function handleSubagentInterrupt(
   params: { id?: string; name?: string },
   interruptPaneKey: (surface: string) => void = interruptPane,
@@ -997,6 +1089,7 @@ function handleSubagentInterrupt(
 
 function startStatusRefresh(pi: ExtensionAPI) {
   if (!statusConfig.enabled || statusInterval) return;
+  const recoveryDelays = parseRecoveryDelays(process.env.PI_SUBAGENT_RECOVERY_DELAYS_MS);
 
   statusInterval = setInterval(() => {
     if (runningSubagents.size === 0) {
@@ -1016,6 +1109,8 @@ function startStatusRefresh(pi: ExtensionAPI) {
       // Dual-writes lifecycle + statusState for reload hydration; steers use lifecycle only.
       observeRunningSubagent(running, now);
       const projection = projectLifecycle(ensureLifecycle(running), now);
+      const recovery = advanceRunningRecovery(running, projection, now, recoveryDelays);
+      if (recovery.action) shouldRefreshWidget = true;
       const transition = lifecycleTransition(running.lastProjectedKind, projection.kind);
       if (running.lastProjectedKind !== projection.kind) {
         shouldRefreshWidget = true;
@@ -1081,6 +1176,9 @@ export const __test__ = {
   resolveDenyTools,
   resolveInterruptTarget,
   requestSubagentInterrupt,
+  failAndTeardownSubagent,
+  advanceRunningRecovery,
+  buildRecoveryKilledResult,
   handleSubagentInterrupt,
   resolveResultPresentation,
   resolveResumeLaunchBehavior,
@@ -1301,6 +1399,11 @@ async function watchSubagent(
     });
 
     const detectedAt = Date.now();
+    const recoveryResult = buildRecoveryKilledResult(running, detectedAt);
+    if (recoveryResult) {
+      updateWidget();
+      return recoveryResult;
+    }
     running.lifecycle = markCompletionDetected(running.lifecycle, result, detectedAt);
     updateWidget();
     const elapsed = Math.floor((detectedAt - startTime) / 1000);
@@ -1395,13 +1498,21 @@ async function watchSubagent(
       ...(result.errorMessage ? { errorMessage: result.errorMessage } : {}),
     };
   } catch (err: any) {
+    const now = Date.now();
+    const recoveryResult = buildRecoveryKilledResult(running, now);
+    if (recoveryResult) {
+      running.lifecycle = markFailed(running.lifecycle, recoveryResult.errorMessage!, now, 1);
+      updateWidget();
+      return recoveryResult;
+    }
+
     try {
       closePane(surface);
     } catch {}
     running.lifecycle = markFailed(
       running.lifecycle,
       signal.aborted ? "Subagent cancelled." : err?.message ?? String(err),
-      Date.now(),
+      now,
       1,
     );
     updateWidget();
@@ -1412,7 +1523,7 @@ async function watchSubagent(
         task,
         summary: "Subagent cancelled.",
         exitCode: 1,
-        elapsed: Math.floor((Date.now() - startTime) / 1000),
+        elapsed: Math.floor((now - startTime) / 1000),
         error: "cancelled",
         sessionFile,
       };
@@ -1422,7 +1533,7 @@ async function watchSubagent(
       task,
       summary: `Subagent error: ${err?.message ?? String(err)}`,
       exitCode: 1,
-      elapsed: Math.floor((Date.now() - startTime) / 1000),
+      elapsed: Math.floor((now - startTime) / 1000),
       error: err?.message ?? String(err),
     };
   }

--- a/pi-extension/subagents/index.ts
+++ b/pi-extension/subagents/index.ts
@@ -1597,7 +1597,10 @@ export default function subagentsExtension(pi: ExtensionAPI) {
 
       async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
         // Prevent self-spawning (e.g. planner spawning another planner)
-        if (blockedSelfSpawn(params.agent, process.env.PI_SUBAGENT_AGENT)) {
+        // Non-empty here is guaranteed by blockedSelfSpawn requiring both args
+        // truthy and equal, so the message always renders a real identity.
+        const currentAgent = process.env.PI_SUBAGENT_AGENT;
+        if (blockedSelfSpawn(params.agent, currentAgent)) {
           return {
             content: [
               {

--- a/pi-extension/subagents/index.ts
+++ b/pi-extension/subagents/index.ts
@@ -85,6 +85,16 @@ import {
   type RecoveryDelays,
   type RecoveryState,
 } from "./recovery.ts";
+import {
+  cleanupWrapupDirective,
+  evalTimeLimit,
+  formatTimeLimitError,
+  getTimeLimitDeadlineAt,
+  parsePositiveIntegerSeconds,
+  parseTimeoutWarnThreshold,
+  writeWrapupDirective,
+  type TimeLimitConfig,
+} from "./time-limits.ts";
 
 /** Absolute path to `pi-extension/subagents`. https://github.com/nodejs/node/issues/37845 */
 const SUBAGENTS_DIR = dirname(fileURLToPath(import.meta.url));
@@ -196,6 +206,9 @@ interface AgentDefaults {
   spawning?: boolean;
   autoExit?: boolean;
   interactive?: boolean;
+  timeLimitSeconds?: number;
+  idleTimeoutSeconds?: number;
+  timeoutWarnThreshold?: number;
   systemPromptMode?: "append" | "replace";
   sessionMode?: SubagentSessionMode;
   cwd?: string;
@@ -310,6 +323,11 @@ function parseAgentDefinition(content: string, fallbackName: string): AgentDefin
     spawning: parseOptionalBoolean(getFrontmatterValue(frontmatter, "spawning")),
     autoExit: parseOptionalBoolean(getFrontmatterValue(frontmatter, "auto-exit")),
     interactive: parseOptionalBoolean(getFrontmatterValue(frontmatter, "interactive")),
+    timeLimitSeconds: parsePositiveIntegerSeconds(getFrontmatterValue(frontmatter, "time-limit")),
+    idleTimeoutSeconds: parsePositiveIntegerSeconds(getFrontmatterValue(frontmatter, "idle-timeout")),
+    timeoutWarnThreshold: parseTimeoutWarnThreshold(
+      getFrontmatterValue(frontmatter, "timeout-warn-threshold"),
+    ),
     sessionMode: parseSessionMode(getFrontmatterValue(frontmatter, "session-mode")),
     cwd: getFrontmatterValue(frontmatter, "cwd"),
     cli: getFrontmatterValue(frontmatter, "cli"),
@@ -471,6 +489,20 @@ function resolveEffectiveInteractive(
   return !resolveEffectiveAutoExit(params, agentDefs);
 }
 
+function resolveTimeLimitConfig(
+  agentDefs: AgentDefaults | null,
+  interactive: boolean,
+  supportsWrapup = true,
+): TimeLimitConfig | undefined {
+  if (interactive || !agentDefs) return undefined;
+  const config: TimeLimitConfig = {
+    timeLimitSeconds: agentDefs.timeLimitSeconds,
+    idleTimeoutSeconds: agentDefs.idleTimeoutSeconds,
+    timeoutWarnThreshold: supportsWrapup ? agentDefs.timeoutWarnThreshold : undefined,
+  };
+  return config.timeLimitSeconds || config.idleTimeoutSeconds ? config : undefined;
+}
+
 function loadAgentDefaults(agentName: string): AgentDefaults | null {
   // Resolve through the same name-keyed map discoverAgentDefinitions() builds
   // for the tool-guidance catalog, so a name advertised there always resolves
@@ -527,7 +559,7 @@ const modelConfig = loadModelConfig();
 function resolveResultPresentation(
   result: Pick<
     SubagentResult,
-    "exitCode" | "elapsed" | "summary" | "sessionFile" | "errorMessage"
+    "exitCode" | "elapsed" | "summary" | "sessionFile" | "errorMessage" | "partial" | "timeout"
   >,
   name: string,
 ): string {
@@ -549,9 +581,23 @@ function resolveResultPresentation(
     );
   }
 
+  if (result.partial) {
+    return (
+      `Sub-agent "${name}" delivered a partial report under its time limit ` +
+      `(${formatElapsed(result.elapsed)}).\n\n${result.summary}${sessionRef}`
+    );
+  }
+
   return result.exitCode !== 0
     ? `Sub-agent "${name}" failed (exit code ${result.exitCode}).\n\n${result.summary}${sessionRef}`
     : `Sub-agent "${name}" completed (${formatElapsed(result.elapsed)}).\n\n${result.summary}${sessionRef}`;
+}
+
+function buildResultTimeoutDetails(result: Pick<SubagentResult, "partial" | "timeout">) {
+  return {
+    ...(result.partial ? { partial: true } : {}),
+    ...(result.timeout ? { timeout: result.timeout } : {}),
+  };
 }
 
 /**
@@ -568,6 +614,9 @@ interface SubagentResult {
   error?: string;
   /** Provider/agent error message when auto-retry exhausted (overload, rate limit, etc.). */
   errorMessage?: string;
+  /** A normal completion produced by the one-shot time-limit report continuation. */
+  partial?: boolean;
+  timeout?: "warned-wrapup" | "hard-stop";
   ping?: { name: string; message: string };
 }
 
@@ -593,7 +642,12 @@ interface RunningSubagent {
   abortController?: AbortController;
   recovery?: RecoveryState;
   recoveryKilled?: { errorMessage: string; killedAt: number };
-  /** Reserved for the L-96 report-only continuation. */
+  timeLimit?: TimeLimitConfig;
+  timeLimitWarned?: boolean;
+  /** The deadline fixed at warning time so fresh report activity cannot extend an idle limit. */
+  timeLimitDeadlineAt?: number;
+  timeLimitStopped?: { errorMessage: string; stoppedAt: number };
+  /** A report-only continuation has been requested and awaits its normal completion. */
   wrapupPending?: boolean;
   cli?: string;
   sentinelFile?: string;
@@ -626,6 +680,17 @@ const DEFAULT_RECOVERY_PANE_OPERATIONS: RecoveryPaneOperations = {
   interruptPane,
   closePane,
   abortWatcher: (controller) => controller?.abort(),
+};
+
+interface TimeLimitPaneOperations extends RecoveryPaneOperations {
+  writeWrapup: (sessionFile: string) => void;
+  removeWrapup: (sessionFile: string) => void;
+}
+
+const DEFAULT_TIME_LIMIT_PANE_OPERATIONS: TimeLimitPaneOperations = {
+  ...DEFAULT_RECOVERY_PANE_OPERATIONS,
+  writeWrapup: writeWrapupDirective,
+  removeWrapup: cleanupWrapupDirective,
 };
 
 interface SubagentRuntime {
@@ -1005,7 +1070,10 @@ function advanceRunningRecovery(
   const advance = advanceRecoveryLadder(running.recovery, {
     now,
     stalled: projection.kind === "stalled",
-    exempt: running.interactive || running.wrapupPending === true,
+    exempt:
+      running.interactive ||
+      running.wrapupPending === true ||
+      running.timeLimitStopped != null,
     delays,
   });
   running.recovery = advance.state;
@@ -1035,6 +1103,94 @@ function buildRecoveryKilledResult(running: RunningSubagent, now: number): Subag
     elapsed: Math.floor(Math.max(0, now - running.startTime) / 1000),
     error: recoveryKilled.errorMessage,
     errorMessage: recoveryKilled.errorMessage,
+  };
+}
+
+function advanceRunningTimeLimit(
+  running: RunningSubagent,
+  now: number,
+  operations: TimeLimitPaneOperations = DEFAULT_TIME_LIMIT_PANE_OPERATIONS,
+): { action: "warn" | "hard-stop" | null } {
+  if (
+    running.interactive ||
+    !running.timeLimit ||
+    running.recoveryKilled ||
+    running.timeLimitStopped
+  ) {
+    return { action: null };
+  }
+
+  const lastActivityAt = running.activity?.updatedAt;
+  const action = running.timeLimitDeadlineAt != null
+    ? now >= running.timeLimitDeadlineAt ? "hard-stop" : "none"
+    : evalTimeLimit(
+      now,
+      running.startTime,
+      lastActivityAt,
+      running.timeLimit,
+      running.timeLimitWarned === true,
+    );
+
+  if (action === "warn") {
+    try {
+      operations.writeWrapup(running.sessionFile);
+    } catch {
+      return { action: null };
+    }
+    const interruption = requestSubagentInterrupt(running, operations.interruptPane);
+    if ("error" in interruption) {
+      try {
+        operations.removeWrapup(running.sessionFile);
+      } catch {}
+      return { action: null };
+    }
+
+    running.timeLimitWarned = true;
+    running.wrapupPending = true;
+    running.timeLimitDeadlineAt = getTimeLimitDeadlineAt(
+      running.startTime,
+      lastActivityAt,
+      running.timeLimit,
+    );
+    running.lifecycle = markInterruptRequested(ensureLifecycle(running), now);
+    return { action: "warn" };
+  }
+
+  if (action === "hard-stop") {
+    const error = formatTimeLimitError(now - running.startTime);
+    const stopped = failAndTeardownSubagent(running, error, now, operations, () => {
+      running.timeLimitStopped = { errorMessage: error, stoppedAt: now };
+      running.wrapupPending = false;
+      try {
+        operations.removeWrapup(running.sessionFile);
+      } catch {}
+    });
+    return { action: stopped ? "hard-stop" : null };
+  }
+
+  return { action: null };
+}
+
+function buildTimeLimitStoppedResult(running: RunningSubagent, now: number): SubagentResult | null {
+  const stopped = running.timeLimitStopped;
+  if (!stopped) return null;
+
+  let tail: string | null = null;
+  try {
+    if (existsSync(running.sessionFile)) {
+      tail = findLastAssistantMessage(getNewEntries(running.sessionFile, 0));
+    }
+  } catch {}
+
+  return {
+    name: running.name,
+    task: running.task,
+    summary: `${stopped.errorMessage}${tail ? `\n\nLast session output:\n${tail}` : ""}`,
+    sessionFile: running.sessionFile,
+    exitCode: 1,
+    elapsed: Math.floor(Math.max(0, now - running.startTime) / 1_000),
+    error: stopped.errorMessage,
+    timeout: "hard-stop",
   };
 }
 
@@ -1170,6 +1326,8 @@ export const __test__ = {
   resolveLaunchBehavior,
   resolveEffectiveAutoExit,
   resolveEffectiveInteractive,
+  resolveTimeLimitConfig,
+  parseAgentDefinition,
   buildSubagentToolAllowlist,
   buildPiPromptArgs,
   observeRunningSubagent,
@@ -1179,6 +1337,9 @@ export const __test__ = {
   failAndTeardownSubagent,
   advanceRunningRecovery,
   buildRecoveryKilledResult,
+  advanceRunningTimeLimit,
+  buildTimeLimitStoppedResult,
+  buildResultTimeoutDetails,
   handleSubagentInterrupt,
   resolveResultPresentation,
   resolveResumeLaunchBehavior,
@@ -1234,6 +1395,9 @@ async function launchSubagent(
   const effectiveThinking = runtimePlan.thinking;
   const effectiveAutoExit = resolveEffectiveAutoExit(params, agentDefs);
   const effectiveInteractive = resolveEffectiveInteractive(params, agentDefs);
+  const cliId = agentDefs?.cli ?? "pi";
+  const driver = getHarnessDriver(cliId);
+  const timeLimit = resolveTimeLimitConfig(agentDefs, effectiveInteractive, driver.id === "pi");
 
   const sessionFile = ctx.sessionManager.getSessionFile();
   if (!sessionFile) throw new Error("No session file");
@@ -1256,8 +1420,6 @@ async function launchSubagent(
   ].join("-");
   const subagentSessionFile = join(sessionDir, `${timestamp}_${uuid}.jsonl`);
 
-  const cliId = agentDefs?.cli ?? "pi";
-  const driver = getHarnessDriver(cliId);
   driver.validateRuntimePlan?.(runtimePlan, parentThinking);
 
   const surfacePreCreated = !!options?.surface;
@@ -1361,6 +1523,7 @@ async function launchSubagent(
     interactive: effectiveInteractive,
     runtimePlan,
     activityFile: driver.hasActivitySnapshots ? activityFile : undefined,
+    timeLimit,
     lifecycle: !driver.hasActivitySnapshots
       ? markProcessRunning(createLifecycle(startTime), Date.now())
       : createLifecycle(startTime),
@@ -1394,11 +1557,18 @@ async function watchSubagent(
         updateWidget();
       },
       onTick() {
-        observeRunningSubagent(running);
+        const now = Date.now();
+        observeRunningSubagent(running, now);
+        if (advanceRunningTimeLimit(running, now).action) updateWidget();
       },
     });
 
     const detectedAt = Date.now();
+    const timeLimitResult = buildTimeLimitStoppedResult(running, detectedAt);
+    if (timeLimitResult) {
+      updateWidget();
+      return timeLimitResult;
+    }
     const recoveryResult = buildRecoveryKilledResult(running, detectedAt);
     if (recoveryResult) {
       updateWidget();
@@ -1432,6 +1602,7 @@ async function watchSubagent(
           exitCode: result.exitCode,
           elapsed,
           ...(extracted.sessionId ? { claudeSessionId: extracted.sessionId } : {}),
+          ...(result.wrapup ? { partial: true, timeout: "warned-wrapup" as const } : {}),
           ...extracted.details,
         };
       }
@@ -1495,10 +1666,16 @@ async function watchSubagent(
       exitCode: result.exitCode,
       elapsed,
       ping: result.ping,
+      ...(result.wrapup ? { partial: true, timeout: "warned-wrapup" as const } : {}),
       ...(result.errorMessage ? { errorMessage: result.errorMessage } : {}),
     };
   } catch (err: any) {
     const now = Date.now();
+    const timeLimitResult = buildTimeLimitStoppedResult(running, now);
+    if (timeLimitResult) {
+      updateWidget();
+      return timeLimitResult;
+    }
     const recoveryResult = buildRecoveryKilledResult(running, now);
     if (recoveryResult) {
       running.lifecycle = markFailed(running.lifecycle, recoveryResult.errorMessage!, now, 1);
@@ -1536,6 +1713,8 @@ async function watchSubagent(
       elapsed: Math.floor((now - startTime) / 1000),
       error: err?.message ?? String(err),
     };
+  } finally {
+    cleanupWrapupDirective(sessionFile);
   }
 }
 
@@ -1717,6 +1896,7 @@ export default function subagentsExtension(pi: ExtensionAPI) {
                   exitCode: result.exitCode,
                   elapsed: result.elapsed,
                   sessionFile: result.sessionFile,
+                  ...buildResultTimeoutDetails(result),
                   ...(result.errorMessage ? { errorMessage: result.errorMessage } : {}),
                   ...(result.claudeSessionId ? { claudeSessionId: result.claudeSessionId } : {}),
                   ...(running.runtimePlan ? { runtimePlan: running.runtimePlan } : {}),
@@ -2179,6 +2359,7 @@ export default function subagentsExtension(pi: ExtensionAPI) {
                   exitCode: result.exitCode,
                   elapsed: result.elapsed,
                   sessionFile: params.sessionPath,
+                  ...buildResultTimeoutDetails(result),
                   ...(result.errorMessage ? { errorMessage: result.errorMessage } : {}),
                   ...(running.runtimePlan ? { runtimePlan: running.runtimePlan } : {}),
                 },
@@ -2273,18 +2454,25 @@ export default function subagentsExtension(pi: ExtensionAPI) {
         const exitCode = details.exitCode ?? 0;
         const errorMessage = typeof details.errorMessage === "string" ? details.errorMessage : "";
         const failed = exitCode !== 0 || !!errorMessage;
+        const partial = !failed && (details.partial === true || details.timeout === "warned-wrapup");
         const elapsed = details.elapsed != null ? formatElapsed(details.elapsed) : "?";
         const bgFn = failed
           ? (text: string) => theme.bg("toolErrorBg", text)
-          : (text: string) => theme.bg("toolSuccessBg", text);
+          : partial
+            ? (text: string) => theme.bg("customMessageBg", text)
+            : (text: string) => theme.bg("toolSuccessBg", text);
         const icon = failed
           ? theme.fg("error", "✗")
-          : theme.fg("success", "✓");
+          : partial
+            ? theme.fg("warning", "⚠")
+            : theme.fg("success", "✓");
         const status = errorMessage
           ? "failed (provider/agent error)"
           : failed
             ? `failed (exit ${exitCode})`
-            : "completed";
+            : partial
+              ? "partial report (time limit)"
+              : "completed";
         const agentTag = details.agent ? theme.fg("dim", ` (${details.agent})`) : "";
 
         const header = `${icon} ${theme.fg("toolTitle", theme.bold(name))}${agentTag} ${theme.fg("dim", "—")} ${status} ${theme.fg("dim", `(${elapsed})`)}`;

--- a/pi-extension/subagents/index.ts
+++ b/pi-extension/subagents/index.ts
@@ -690,6 +690,22 @@ function getShellReadyDelayMs(): number {
   return Number.isFinite(parsed) && parsed >= 0 ? parsed : 500;
 }
 
+export const DEFAULT_INTERRUPT_GRACE_MS = 5_000;
+const INTERRUPTED_EXIT_CODE = 130;
+const INTERRUPTED_ERROR = "Subagent interrupted by parent after the grace period.";
+
+/** Parse PI_SUBAGENT_INTERRUPT_GRACE_MS; invalid values use five seconds. */
+function parseInterruptGraceMs(raw: string | undefined): number {
+  const trimmed = raw?.trim();
+  if (!trimmed) return DEFAULT_INTERRUPT_GRACE_MS;
+  const value = Number(trimmed);
+  return Number.isSafeInteger(value) && value >= 0 ? value : DEFAULT_INTERRUPT_GRACE_MS;
+}
+
+function getInterruptGraceMs(): number {
+  return parseInterruptGraceMs(process.env.PI_SUBAGENT_INTERRUPT_GRACE_MS);
+}
+
 function muxUnavailableResult() {
   return {
     content: [
@@ -799,6 +815,10 @@ interface RunningSubagent {
     error?: string;
   };
   abortController?: AbortController;
+  /** Timer waiting for an interrupted autonomous child to become terminal. */
+  interruptGraceTimer?: ReturnType<typeof setTimeout>;
+  /** Synthetic terminal result after the parent-owned interrupt grace expires. */
+  interrupted?: { errorMessage: string; interruptedAt: number };
   recovery?: RecoveryState;
   recoveryKilled?: { errorMessage: string; killedAt: number };
   timeLimit?: TimeLimitConfig;
@@ -876,11 +896,15 @@ export function shouldPreserveSubagentsOnShutdown(reason: unknown): boolean {
 
 export function cleanupSubagentsForShutdown(
   reason: unknown,
-  agents: Map<string, Pick<RunningSubagent, "abortController" | "lifecycle">>,
+  agents: Map<string, Pick<RunningSubagent, "abortController" | "lifecycle" | "interruptGraceTimer">>,
 ): void {
   if (shouldPreserveSubagentsOnShutdown(reason)) return;
 
   for (const agent of agents.values()) {
+    if (agent.interruptGraceTimer != null) {
+      clearTimeout(agent.interruptGraceTimer);
+      agent.interruptGraceTimer = undefined;
+    }
     if (agent.lifecycle) {
       agent.lifecycle = markDelivery(agent.lifecycle, "suppressed");
     }
@@ -1233,6 +1257,66 @@ function reconcileProjectedFailure(running: RunningSubagent, projection: Lifecyc
   return projectLifecycle(running.lifecycle, terminalAt);
 }
 
+function clearInterruptGraceTimer(running: RunningSubagent): void {
+  if (running.interruptGraceTimer == null) return;
+  clearTimeout(running.interruptGraceTimer);
+  running.interruptGraceTimer = undefined;
+}
+
+/**
+ * Finish a parent-requested interrupt without asking the child to publish a
+ * completion sidecar. Escape intentionally disarms child auto-exit; the
+ * parent owns the bounded terminal transition and preserves the JSONL.
+ */
+function finalizeInterruptedSubagent(
+  running: RunningSubagent,
+  now: number,
+  operations: Pick<RecoveryPaneOperations, "closePane" | "abortWatcher"> = DEFAULT_RECOVERY_PANE_OPERATIONS,
+): boolean {
+  const lifecycle = ensureLifecycle(running);
+  if (
+    lifecycle.process.kind === "finalizing" ||
+    isTerminalLifecycle(lifecycle) ||
+    lifecycle.delivery !== "pending"
+  ) {
+    return false;
+  }
+
+  running.interrupted = { errorMessage: INTERRUPTED_ERROR, interruptedAt: now };
+  running.lifecycle = markFailed(lifecycle, INTERRUPTED_ERROR, now, INTERRUPTED_EXIT_CODE);
+  try {
+    operations.closePane(running.surface);
+  } catch {}
+  try {
+    operations.abortWatcher(running.abortController);
+  } catch {}
+  return true;
+}
+
+function scheduleInterruptedFinalization(
+  running: RunningSubagent,
+  graceMs = getInterruptGraceMs(),
+  operations: Pick<RecoveryPaneOperations, "closePane" | "abortWatcher"> = DEFAULT_RECOVERY_PANE_OPERATIONS,
+): boolean {
+  if (
+    running.interactive ||
+    running.interruptGraceTimer != null ||
+    running.interrupted != null ||
+    isTerminalLifecycle(ensureLifecycle(running))
+  ) {
+    return false;
+  }
+
+  const delay = Math.max(0, Math.floor(graceMs));
+  const timer = setTimeout(() => {
+    running.interruptGraceTimer = undefined;
+    if (finalizeInterruptedSubagent(running, Date.now(), operations)) updateWidget();
+  }, delay);
+  timer.unref?.();
+  running.interruptGraceTimer = timer;
+  return true;
+}
+
 /** Idempotent failure teardown shared with future hard-stop paths. */
 function failAndTeardownSubagent(
   running: RunningSubagent,
@@ -1298,6 +1382,20 @@ function buildRecoveryKilledResult(running: RunningSubagent, now: number): Subag
     elapsed: Math.floor(Math.max(0, now - running.startTime) / 1000),
     error: recoveryKilled.errorMessage,
     errorMessage: recoveryKilled.errorMessage,
+  };
+}
+
+function buildInterruptedResult(running: RunningSubagent, now: number): SubagentResult | null {
+  const interrupted = running.interrupted;
+  if (!interrupted) return null;
+  return {
+    name: running.name,
+    task: running.task,
+    summary: `${interrupted.errorMessage}\n\nThe session remains on disk and can be resumed with subagent_resume.`,
+    sessionFile: running.sessionFile,
+    exitCode: INTERRUPTED_EXIT_CODE,
+    elapsed: Math.floor(Math.max(0, now - running.startTime) / 1000),
+    error: "interrupted",
   };
 }
 
@@ -1392,6 +1490,11 @@ function buildTimeLimitStoppedResult(running: RunningSubagent, now: number): Sub
 function handleSubagentInterrupt(
   params: { id?: string; name?: string },
   interruptPaneKey: (surface: string) => void = interruptPane,
+  options: {
+    closePane?: (surface: string) => void;
+    abortWatcher?: (controller: AbortController | undefined) => void;
+    graceMs?: number;
+  } = {},
 ) {
   const resolved = resolveInterruptTarget(params);
   if ("error" in resolved) {
@@ -1430,6 +1533,16 @@ function handleSubagentInterrupt(
   }
 
   running.lifecycle = markInterruptRequested(ensureLifecycle(running), now);
+  if (!running.interactive && running.abortController) {
+    scheduleInterruptedFinalization(
+      running,
+      options.graceMs ?? getInterruptGraceMs(),
+      {
+        closePane: options.closePane ?? closePane,
+        abortWatcher: options.abortWatcher ?? DEFAULT_RECOVERY_PANE_OPERATIONS.abortWatcher,
+      },
+    );
+  }
   updateWidget();
 
   return {
@@ -1522,6 +1635,17 @@ function resolveResumeLaunchBehavior(params: { autoExit?: boolean }): { autoExit
   return { autoExit, interactive: !autoExit };
 }
 
+function buildResumeAutoExitEnv(params: { autoExit: boolean; hasMessage: boolean }): string[] {
+  if (!params.autoExit) return [];
+  return [
+    "PI_SUBAGENT_AUTO_EXIT=1",
+    // A resumed session is a fresh autonomous run even when its JSONL ends in
+    // an operator Escape. The child consumes this one-shot re-arm on settle.
+    "PI_SUBAGENT_AUTO_EXIT_REARM=1",
+    ...(params.hasMessage ? ["PI_SUBAGENT_RESUME_INPUT=1"] : []),
+  ];
+}
+
 export const __test__ = {
   borderLine,
   getShellReadyDelayMs,
@@ -1556,6 +1680,13 @@ export const __test__ = {
   advanceRunningTimeLimit,
   buildTimeLimitStoppedResult,
   buildResultTimeoutDetails,
+  buildInterruptedResult,
+  parseInterruptGraceMs,
+  getInterruptGraceMs,
+  DEFAULT_INTERRUPT_GRACE_MS,
+  scheduleInterruptedFinalization,
+  finalizeInterruptedSubagent,
+  buildResumeAutoExitEnv,
   handleSubagentInterrupt,
   resolveResultPresentation,
   resolveResumeLaunchBehavior,
@@ -1826,6 +1957,11 @@ async function watchSubagent(
     });
 
     const detectedAt = Date.now();
+    const interruptedResult = buildInterruptedResult(running, detectedAt);
+    if (interruptedResult) {
+      updateWidget();
+      return interruptedResult;
+    }
     const timeLimitResult = buildTimeLimitStoppedResult(running, detectedAt);
     if (timeLimitResult) {
       updateWidget();
@@ -1948,6 +2084,11 @@ async function watchSubagent(
       updateWidget();
       return recoveryResult;
     }
+    const interruptedResult = buildInterruptedResult(running, now);
+    if (interruptedResult) {
+      updateWidget();
+      return interruptedResult;
+    }
 
     try {
       closePane(surface);
@@ -1980,6 +2121,7 @@ async function watchSubagent(
       error: err?.message ?? String(err),
     };
   } finally {
+    clearInterruptGraceTimer(running);
     cleanupWrapupDirective(sessionFile);
   }
 }
@@ -2286,13 +2428,15 @@ export default function subagentsExtension(pi: ExtensionAPI) {
       name: "subagent_interrupt",
       label: "Interrupt Subagent",
       description:
-        "Send Escape to the active turn of a currently running Pi-backed subagent. " +
-        "The child pane, session, watcher, and running entry remain alive; this returns only a local acknowledgement " +
-        "and does not emit a subagent_result solely because of this request.",
+        "Interrupt the active turn of a running Pi-backed subagent. " +
+        "Interactive children remain open for operator takeover; autonomous one-shot children " +
+        "close after a bounded grace while their session stays resumable, and the parent delivers " +
+        "a terminal interrupt result.",
       promptSnippet:
-        "Send Escape to the active turn of a currently running Pi-backed subagent. " +
-        "The child pane, session, watcher, and running entry remain alive; this returns only a local acknowledgement " +
-        "and does not emit a subagent_result solely because of this request.",
+        "Interrupt the active turn of a running Pi-backed subagent. " +
+        "Interactive children remain open for operator takeover; autonomous one-shot children " +
+        "close after a bounded grace while their session stays resumable, and the parent delivers " +
+        "a terminal interrupt result.",
       parameters: Type.Object({
         id: Type.Optional(Type.String({ description: "Exact running subagent id" })),
         name: Type.Optional(Type.String({ description: "Exact running subagent display name" })),
@@ -2533,9 +2677,10 @@ export default function subagentsExtension(pi: ExtensionAPI) {
         resumeEnvParts.push(`PI_SUBAGENT_SESSION=${shellQuote(params.sessionPath)}`);
         resumeEnvParts.push(`PI_SUBAGENT_ID=${shellQuote(id)}`);
         resumeEnvParts.push(`PI_SUBAGENT_ACTIVITY_FILE=${shellQuote(activityFile)}`);
-        if (autoExit) {
-          resumeEnvParts.push(`PI_SUBAGENT_AUTO_EXIT=1`);
-        }
+        resumeEnvParts.push(...buildResumeAutoExitEnv({
+          autoExit,
+          hasMessage: Boolean(params.message),
+        }));
         // Spawn rights on resume are clamped to what the first launch recorded:
         // missing metadata ⇒ 0 (deny); never larger than first launch.
         const resumeSpawn = clampResumeSpawn(

--- a/pi-extension/subagents/index.ts
+++ b/pi-extension/subagents/index.ts
@@ -29,6 +29,7 @@ import {
   readPaneAsync,
   inspectPane,
   setPaneTask,
+  listPaneSessionReferences,
 } from "./terminal.ts";
 import { waitForCompletion } from "./completion.ts";
 import {
@@ -103,7 +104,16 @@ import {
   writeWrapupDirective,
   type TimeLimitConfig,
 } from "./time-limits.ts";
-import type { SpawnMetadataRecord } from "./orphan-discovery.ts";
+import {
+  discoverOrphanedSubagents,
+  formatOrphanRestoreReport,
+  isActionableOrphan,
+  isRestorableOrphan,
+  resumeOrphanedSubagents,
+  type DiscoveredOrphan,
+  type OrphanResumeOutcome,
+  type SpawnMetadataRecord,
+} from "./orphan-discovery.ts";
 
 /** Absolute path to `pi-extension/subagents`. https://github.com/nodejs/node/issues/37845 */
 const SUBAGENTS_DIR = dirname(fileURLToPath(import.meta.url));
@@ -1714,6 +1724,11 @@ export const __test__ = {
   preflightSubagentDonePath,
   enrichNoSessionFailure,
   writeSpawnMetadata,
+  discoverOrphanedSubagents,
+  formatOrphanRestoreReport,
+  isActionableOrphan,
+  isRestorableOrphan,
+  resumeOrphanedSubagents,
   runningSubagents,
   formatElapsed,
 };
@@ -1909,7 +1924,7 @@ async function launchSubagent(
       parentSessionId: sessionId,
       childSessionFile: running.sessionFile,
       name: params.name,
-      ...(params.agent ? { agent: params.agent } : {}),
+      agent: params.agent ?? null,
       task: params.task,
       launchedAt: new Date(startTime).toISOString(),
     });
@@ -2154,8 +2169,182 @@ async function watchSubagent(
   }
 }
 
+type RegisteredToolExecutor = (...args: any[]) => Promise<any>;
+
 export default function subagentsExtension(pi: ExtensionAPI) {
   runtime.pi = pi;
+  let spawnToolExecutor: RegisteredToolExecutor | undefined;
+  let resumeToolExecutor: RegisteredToolExecutor | undefined;
+  let restoreInFlight = false;
+
+  function currentSessionFile(ctx: any): string | null {
+    try {
+      const file = ctx?.sessionManager?.getSessionFile?.();
+      return typeof file === "string" && file.trim() ? file : null;
+    } catch {
+      return null;
+    }
+  }
+
+  function discoverCurrentOrphans(ctx: any): DiscoveredOrphan[] {
+    const sessionFile = currentSessionFile(ctx);
+    if (!sessionFile) return [];
+    let sessionId: string | undefined;
+    try {
+      const id = ctx?.sessionManager?.getSessionId?.();
+      if (typeof id === "string" && id.trim()) sessionId = id;
+    } catch {
+      // A damaged/ephemeral session cannot provide an artifact namespace.
+    }
+
+    let paneSessions: ReturnType<typeof listPaneSessionReferences> = [];
+    try {
+      paneSessions = listPaneSessionReferences();
+    } catch {
+      // Herdr may be restarting during parent restore; disk discovery remains useful.
+    }
+    return discoverOrphanedSubagents(sessionFile, {
+      ...(sessionId ? { parentSessionId: sessionId } : {}),
+      paneSessions,
+    });
+  }
+
+  function appendRestoreHandled(child: DiscoveredOrphan, action: "resume" | "relaunch" | "report"): void {
+    const appendEntry = (pi as any).appendEntry;
+    if (typeof appendEntry !== "function") return;
+    try {
+      appendEntry("subagent_restore_handled", {
+        childSessionFile: child.sessionFile,
+        classification: child.classification,
+        action,
+        handledAt: new Date().toISOString(),
+      });
+    } catch {
+      // Completion delivery remains authoritative when the marker cannot be persisted.
+    }
+  }
+
+  function reportOrphansAtSessionStart(ctx: any): void {
+    // A child inherits the parent session directory and must not try to restore
+    // its parent's siblings when its own extension starts.
+    if (process.env.PI_SUBAGENT_ID) return;
+    const children = discoverCurrentOrphans(ctx);
+    const pending = children.filter(isActionableOrphan);
+    const content = formatOrphanRestoreReport(pending);
+    if (!content) return;
+
+    const reportedChildren = pending
+      .filter((child) => child.classification === "completed-undelivered")
+      .map((child) => ({ childSessionFile: child.sessionFile }));
+    try {
+      pi.sendMessage(
+        {
+          customType: "subagent_restore_report",
+          content,
+          display: true,
+          details: {
+            children: pending.map((child) => ({
+              childSessionFile: child.sessionFile,
+              name: child.name,
+              classification: child.classification,
+            })),
+            reportedChildren,
+          },
+        },
+        // Keep startup passive: the report is context for the next user turn,
+        // not an instruction to resume children before the user asks.
+        { triggerTurn: false, deliverAs: "steer" },
+      );
+      for (const child of pending) {
+        if (child.classification === "completed-undelivered") appendRestoreHandled(child, "report");
+      }
+    } catch {
+      // A session can be torn down while startup hooks are still draining.
+    }
+  }
+
+  function isStartedToolResult(result: any): boolean {
+    return result?.details?.status === "started";
+  }
+
+  async function restoreOnResume(ctx: any): Promise<boolean> {
+    if (restoreInFlight) return true;
+    const children = discoverCurrentOrphans(ctx);
+    const pending = children.filter(isRestorableOrphan);
+    if (pending.length === 0) return false;
+    if (!resumeToolExecutor && pending.some((child) => child.classification !== "phantom")) {
+      ctx?.ui?.notify?.("Cannot resume orphaned subagents: subagent_resume is unavailable.", "error");
+      return true;
+    }
+    if (!spawnToolExecutor && pending.some((child) => child.classification === "phantom")) {
+      ctx?.ui?.notify?.("Cannot relaunch phantom subagents: subagent is unavailable.", "error");
+      return true;
+    }
+
+    restoreInFlight = true;
+    try {
+      const outcomes: OrphanResumeOutcome[] = await resumeOrphanedSubagents(pending, {
+        closePane: (paneId) => closePane(paneId),
+        resume: async (child) => {
+          if (!resumeToolExecutor) throw new Error("subagent_resume is unavailable");
+          const result = await resumeToolExecutor(
+            `restore-resume-${child.name}`,
+            {
+              sessionPath: child.sessionFile,
+              name: `Resume ${child.name}`,
+              message: "Re-orient from your existing session, continue the interrupted task, and finish it. Return a concise final report when done.",
+              autoExit: true,
+            },
+            undefined,
+            undefined,
+            ctx,
+          );
+          if (!isStartedToolResult(result)) {
+            throw new Error(result?.content?.[0]?.text ?? "subagent_resume did not start");
+          }
+          // Persist the handled marker before moving to the next child so a
+          // shutdown during a multi-child restore cannot replay this resume.
+          appendRestoreHandled(child, "resume");
+          return result;
+        },
+        relaunch: async (child) => {
+          if (!spawnToolExecutor) throw new Error("subagent is unavailable");
+          const result = await spawnToolExecutor(
+            `restore-relaunch-${child.name}`,
+            {
+              name: child.name,
+              task: child.task,
+              ...(child.agent ? { agent: child.agent } : {}),
+              interactive: false,
+            },
+            undefined,
+            undefined,
+            ctx,
+          );
+          if (!isStartedToolResult(result)) {
+            throw new Error(result?.content?.[0]?.text ?? "subagent did not start");
+          }
+          appendRestoreHandled(child, "relaunch");
+          return result;
+        },
+      });
+      const failed = outcomes.filter((outcome) => !outcome.ok);
+      if (failed.length > 0) {
+        ctx?.ui?.notify?.(
+          `Restore started ${outcomes.length - failed.length} subagent${outcomes.length - failed.length === 1 ? "" : "s"}; ${failed.length} failed to start.`,
+          "warning",
+        );
+      } else {
+        ctx?.ui?.notify?.(
+          `Restore started ${outcomes.length} orphaned subagent${outcomes.length === 1 ? "" : "s"}.`,
+          "info",
+        );
+      }
+      return true;
+    } finally {
+      restoreInFlight = false;
+    }
+  }
 
   // Capture the UI context for widget updates and restore presentation for
   // subagents whose watchers survived a reload.
@@ -2175,6 +2364,7 @@ export default function subagentsExtension(pi: ExtensionAPI) {
       startStatusRefresh(pi);
       updateWidget();
     }
+    reportOrphansAtSessionStart(ctx);
   });
 
   // Clean up on session shutdown
@@ -2204,8 +2394,8 @@ export default function subagentsExtension(pi: ExtensionAPI) {
   const shouldRegister = (name: string) => !deniedTools.has(name);
 
   // ── subagent tool ──
-  if (shouldRegister("subagent"))
-    pi.registerTool({
+  if (shouldRegister("subagent")) {
+    const subagentTool = {
       name: "subagent",
       label: "Subagent",
       description:
@@ -2448,7 +2638,10 @@ export default function subagentsExtension(pi: ExtensionAPI) {
         const text = typeof result.content[0]?.text === "string" ? result.content[0].text : "";
         return new Text(theme.fg("dim", text), 0, 0);
       },
-    });
+    };
+    spawnToolExecutor = subagentTool.execute;
+    pi.registerTool(subagentTool);
+  }
 
   // ── subagent_interrupt tool ──
   if (shouldRegister("subagent_interrupt"))
@@ -2561,8 +2754,8 @@ export default function subagentsExtension(pi: ExtensionAPI) {
 
 
   // ── subagent_resume tool ──
-  if (shouldRegister("subagent_resume"))
-    pi.registerTool({
+  if (shouldRegister("subagent_resume")) {
+    const subagentResumeTool = {
       name: "subagent_resume",
       label: "Resume Subagent",
       description:
@@ -2864,7 +3057,22 @@ export default function subagentsExtension(pi: ExtensionAPI) {
           },
         };
       },
-    });
+    };
+    resumeToolExecutor = subagentResumeTool.execute;
+    pi.registerTool(subagentResumeTool);
+  }
+
+  // "resume" is intentionally handled only when durable restore work exists;
+  // normal /resume session switching is dispatched before this input hook.
+  pi.on("input", async (event, ctx) => {
+    if (process.env.PI_SUBAGENT_ID) return { action: "continue" as const };
+    const text = typeof (event as any)?.text === "string" ? (event as any).text.trim() : "";
+    if ((event as any)?.source === "extension" || text.toLowerCase() !== "resume") {
+      return { action: "continue" as const };
+    }
+    const restored = await restoreOnResume(ctx);
+    return restored ? { action: "handled" as const } : { action: "continue" as const };
+  });
 
   // /iterate command — fork the session into a subagent
   pi.registerCommand("iterate", {

--- a/pi-extension/subagents/lifecycle.ts
+++ b/pi-extension/subagents/lifecycle.ts
@@ -47,7 +47,10 @@ export type PaneObservation =
   | { kind: "unknown" }
   | { kind: "present"; observedAt: number; agentStatus: HerdrAgentStatus }
   | { kind: "read-error"; firstFailedAt: number; lastFailedAt: number; consecutiveFailures: number; error?: string }
-  | { kind: "missing"; detectedAt: number; error?: string };
+  | { kind: "missing"; detectedAt: number; consecutiveMissing: number; error?: string };
+
+export const MISSING_PANE_DEBOUNCE_MS = 500;
+export const MISSING_PANE_ERROR = "Subagent pane disappeared before completion evidence was recorded.";
 
 export type CompletionDelivery = "pending" | "delivered" | "suppressed";
 
@@ -115,10 +118,18 @@ export function observePaneInspection(
   }
 
   if (inspection.kind === "missing") {
-    return {
-      ...lifecycle,
-      pane: { kind: "missing", detectedAt: observedAt, ...(inspection.error ? { error: inspection.error } : {}) },
+    const previous = lifecycle.pane.kind === "missing" ? lifecycle.pane : null;
+    const pane: PaneObservation = {
+      kind: "missing",
+      // Keep the first confirmed miss so repeated observations can debounce
+      // transient Herdr races instead of extending the deadline forever.
+      detectedAt: previous?.detectedAt ?? observedAt,
+      consecutiveMissing: (previous?.consecutiveMissing ?? 0) + 1,
+      ...(inspection.error ? { error: inspection.error } : {}),
     };
+    const next = { ...lifecycle, pane };
+    if (observedAt - pane.detectedAt < MISSING_PANE_DEBOUNCE_MS) return next;
+    return markFailed(next, MISSING_PANE_ERROR, observedAt, 1);
   }
 
   const agentStatus = inspection.agentStatus;
@@ -397,6 +408,21 @@ export function projectLifecycle(
   if (process.kind === "finalizing") return { kind: "finalizing", runtimeEndedAt: process.detectedAt };
   if (process.kind === "completed") return { kind: "completed", runtimeEndedAt: process.completedAt };
   if (process.kind === "failed") return { kind: "failed", label: process.error, runtimeEndedAt: process.completedAt };
+
+  // A pane can disappear between completion-artifact polls. Keep the
+  // projection terminal once the same missing observation survives the small
+  // debounce, even before the watcher records its failure state.
+  if (
+    lifecycle.pane.kind === "missing" &&
+    lifecycle.pane.consecutiveMissing > 1 &&
+    now - lifecycle.pane.detectedAt >= MISSING_PANE_DEBOUNCE_MS
+  ) {
+    return {
+      kind: "failed",
+      label: MISSING_PANE_ERROR,
+      runtimeEndedAt: lifecycle.pane.detectedAt + MISSING_PANE_DEBOUNCE_MS,
+    };
+  }
 
   // Pi activity is optional enrichment. Only authoritative Herdr inspection
   // unavailability may produce a stalled projection.

--- a/pi-extension/subagents/lifecycle.ts
+++ b/pi-extension/subagents/lifecycle.ts
@@ -1,5 +1,6 @@
 import type { ActivityReadResult, SubagentActivityScope } from "./activity.ts";
 import type { CompletionResult } from "./completion.ts";
+import { DEFAULT_ACTIVE_TOOL_STALL_MS } from "./recovery.ts";
 
 export type HerdrAgentStatus =
   | "idle"
@@ -387,7 +388,11 @@ export function markDelivery(lifecycle: SubagentLifecycle, delivery: CompletionD
   return { ...lifecycle, delivery };
 }
 
-export function projectLifecycle(lifecycle: SubagentLifecycle, now: number): LifecycleProjection {
+export function projectLifecycle(
+  lifecycle: SubagentLifecycle,
+  now: number,
+  opts?: { activeToolStallMs?: number },
+): LifecycleProjection {
   const process = lifecycle.process;
   if (process.kind === "finalizing") return { kind: "finalizing", runtimeEndedAt: process.detectedAt };
   if (process.kind === "completed") return { kind: "completed", runtimeEndedAt: process.completedAt };
@@ -407,6 +412,18 @@ export function projectLifecycle(lifecycle: SubagentLifecycle, now: number): Lif
     case "interrupted":
       return { kind: "interrupted", stateDurationSince: turn.requestedAt };
     case "active": {
+      // A child wedged in one tool call keeps phase=active but stops emitting
+      // events, so a tool-scope detail older than the stall window counts as
+      // stalled; stateDurationSince = last activity so duration == silence.
+      const activeToolStallMs = opts?.activeToolStallMs ?? DEFAULT_ACTIVE_TOOL_STALL_MS;
+      if (
+        turn.activity?.kind === "scope" &&
+        turn.activity.scope === "tool" &&
+        activeToolStallMs > 0 &&
+        now - turn.activity.observedAt >= activeToolStallMs
+      ) {
+        return { kind: "stalled", stateDurationSince: turn.activity.observedAt };
+      }
       if (turn.activity?.kind === "scope") {
         const label = turn.activity.label ?? turn.activity.scope;
         return { kind: "active", label, stateDurationSince: turn.startedAt };

--- a/pi-extension/subagents/orphan-discovery.ts
+++ b/pi-extension/subagents/orphan-discovery.ts
@@ -1,0 +1,712 @@
+import {
+  existsSync,
+  readdirSync,
+  readFileSync,
+  statSync,
+  type Dirent,
+} from "node:fs";
+import { basename, dirname, join, resolve } from "node:path";
+import { findLastAssistantMessage, type SessionEntry } from "./session.ts";
+
+export type OrphanClassification =
+  | "completed-delivered"
+  | "completed-undelivered"
+  | "interrupted"
+  | "phantom"
+  | "stale-pane";
+
+export interface SpawnMetadataRecord {
+  allowance?: unknown;
+  parentSessionFile?: string;
+  parentSessionId?: string;
+  childSessionFile?: string;
+  name?: string;
+  agent?: string | null;
+  task?: string;
+  taskArtifactPath?: string;
+  launchedAt?: string;
+}
+
+export interface PaneSessionReference {
+  paneId: string;
+  sessionPath: string;
+}
+
+export interface DiscoveredOrphan {
+  /** Absolute child session path. This is the deduplication key. */
+  sessionFile: string;
+  name: string;
+  agent?: string;
+  task: string;
+  classification: OrphanClassification;
+  /** Final assistant report when classification is completed-undelivered. */
+  report?: string;
+  spawnMetadata?: SpawnMetadataRecord;
+  /** Herdr pane IDs that currently claim this exact child session path. */
+  stalePaneIds: string[];
+  /** A prior restore action was durably recorded in the parent session. */
+  handled: boolean;
+  sources: Array<"sidecar" | "session" | "artifact" | "pane">;
+}
+
+export interface OrphanDiscoveryOptions {
+  /** Override the directory containing the parent session (mainly for tests). */
+  sessionDir?: string;
+  /** Override the parent ID when the parent header is unavailable. */
+  parentSessionId?: string;
+  /** Herdr's persisted pane/session references. No Herdr call is made here. */
+  paneSessions?: readonly PaneSessionReference[];
+  /** Alias accepted by fixture callers. */
+  panes?: readonly PaneSessionReference[];
+}
+
+interface Candidate {
+  sessionFile: string;
+  sources: Set<DiscoveredOrphan["sources"][number]>;
+  metadata?: SpawnMetadataRecord;
+  hasLineageSidecar: boolean;
+  name?: string;
+  agent?: string;
+  task?: string;
+  taskArtifactPath?: string;
+  stalePaneIds: Set<string>;
+}
+
+interface ArtifactHint {
+  sessionFile: string;
+  name?: string;
+  agent?: string;
+  task?: string;
+  taskArtifactPath?: string;
+}
+
+interface ExitEvidence {
+  present: boolean;
+  valid: boolean;
+}
+
+type DiscoverySource = DiscoveredOrphan["sources"][number];
+
+const ARTIFACT_MAX_DEPTH = 4;
+const ARTIFACT_MAX_FILES = 2_000;
+const ACTIONABLE_CLASSIFICATIONS = new Set<OrphanClassification>([
+  "completed-undelivered",
+  "interrupted",
+  "phantom",
+  "stale-pane",
+]);
+const RESTORABLE_CLASSIFICATIONS = new Set<OrphanClassification>([
+  "interrupted",
+  "phantom",
+  "stale-pane",
+]);
+
+function canonicalPath(path: string, base = process.cwd()): string {
+  return resolve(base, path);
+}
+
+function nonEmptyString(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim() ? value : undefined;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function readJsonFile(path: string): unknown | null {
+  try {
+    return JSON.parse(readFileSync(path, "utf8"));
+  } catch {
+    return null;
+  }
+}
+
+function readJsonl(path: string): SessionEntry[] {
+  try {
+    return readFileSync(path, "utf8")
+      .split("\n")
+      .filter((line) => line.trim())
+      .flatMap((line) => {
+        try {
+          const parsed = JSON.parse(line);
+          return isRecord(parsed) ? [parsed as SessionEntry] : [];
+        } catch {
+          // A crash can leave a partial final line. Keep the valid prefix.
+          return [];
+        }
+      });
+  } catch {
+    return [];
+  }
+}
+
+function readSessionHeader(path: string): Record<string, unknown> | null {
+  try {
+    const firstLine = readFileSync(path, "utf8")
+      .split("\n")
+      .find((line) => line.trim());
+    if (!firstLine) return null;
+    const parsed = JSON.parse(firstLine);
+    return isRecord(parsed) && parsed.type === "session" ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+function isRegularFile(path: string): boolean {
+  try {
+    return statSync(path).isFile();
+  } catch {
+    return false;
+  }
+}
+
+function readDir(path: string): Dirent[] {
+  try {
+    return readdirSync(path, { withFileTypes: true });
+  } catch {
+    return [];
+  }
+}
+
+function walkFiles(path: string, maxDepth = ARTIFACT_MAX_DEPTH): string[] {
+  const files: string[] = [];
+  const visit = (dir: string, depth: number) => {
+    if (files.length >= ARTIFACT_MAX_FILES || depth > maxDepth) return;
+    for (const entry of readDir(dir)) {
+      if (files.length >= ARTIFACT_MAX_FILES) return;
+      const child = join(dir, entry.name);
+      if (entry.isDirectory()) visit(child, depth + 1);
+      else if (entry.isFile()) files.push(child);
+    }
+  };
+  visit(path, 0);
+  return files;
+}
+
+function normalizeMetadata(value: unknown): SpawnMetadataRecord | null {
+  if (!isRecord(value)) return null;
+  const metadata: SpawnMetadataRecord = {};
+  for (const key of [
+    "parentSessionFile",
+    "parentSessionId",
+    "childSessionFile",
+    "name",
+    "agent",
+    "task",
+    "taskArtifactPath",
+    "launchedAt",
+  ] as const) {
+    const stringValue = nonEmptyString(value[key]);
+    if (stringValue) metadata[key] = stringValue;
+  }
+  if ("allowance" in value) metadata.allowance = value.allowance;
+  return metadata;
+}
+
+function metadataMatchesParent(
+  metadata: SpawnMetadataRecord,
+  parentSessionFile: string,
+  parentSessionId: string | undefined,
+): boolean {
+  const parentPath = nonEmptyString(metadata.parentSessionFile);
+  const parentId = nonEmptyString(metadata.parentSessionId);
+  return Boolean(
+    (parentPath && canonicalPath(parentPath) === parentSessionFile) ||
+    (parentId && parentSessionId && parentId === parentSessionId),
+  );
+}
+
+function metadataChildPath(metadata: SpawnMetadataRecord, sidecarPath: string): string {
+  const child = nonEmptyString(metadata.childSessionFile);
+  if (child) return canonicalPath(child, dirname(sidecarPath));
+  return canonicalPath(sidecarPath.slice(0, -".spawn.json".length));
+}
+
+function taskFromArtifact(path: string | undefined, baseDir: string): string | undefined {
+  const raw = nonEmptyString(path);
+  if (!raw) return undefined;
+  const candidate = raw.startsWith("@") ? raw.slice(1) : raw;
+  const artifactPath = canonicalPath(candidate, baseDir);
+  try {
+    const content = readFileSync(artifactPath, "utf8").trim();
+    return content || undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function taskFromMetadata(metadata: SpawnMetadataRecord | undefined, baseDir: string): {
+  task?: string;
+  taskArtifactPath?: string;
+} {
+  const task = nonEmptyString(metadata?.task);
+  if (task) return { task };
+  const artifact = nonEmptyString(metadata?.taskArtifactPath);
+  return artifact
+    ? { task: taskFromArtifact(artifact, baseDir), taskArtifactPath: artifact }
+    : {};
+}
+
+function unquoteShellToken(value: string): string {
+  const trimmed = value.trim().replace(/[;,]+$/, "");
+  if (trimmed.startsWith("'") && trimmed.endsWith("'")) {
+    return trimmed.slice(1, -1).replace(/'\\''/g, "'");
+  }
+  if (trimmed.startsWith('"') && trimmed.endsWith('"')) return trimmed.slice(1, -1);
+  return trimmed;
+}
+
+function firstMatch(text: string, patterns: RegExp[]): string | undefined {
+  for (const pattern of patterns) {
+    const match = text.match(pattern);
+    const value = match?.slice(1).find((part) => typeof part === "string" && part.length > 0);
+    if (value) return unquoteShellToken(value);
+  }
+  return undefined;
+}
+
+function artifactHintFromScript(path: string): ArtifactHint | null {
+  let text: string;
+  try {
+    text = readFileSync(path, "utf8");
+  } catch {
+    return null;
+  }
+
+  const session = firstMatch(text, [
+    /^\s*#\s*Session:\s*(.+?)\s*$/m,
+    /PI_SUBAGENT_SESSION=(?:'([^']+)'|"([^"]+)"|(\S+))/,
+    /--session\s+(?:'([^']+)'|"([^"]+)"|(\S+))/,
+  ]);
+  // firstMatch handles one capture group at a time; the alternation captures
+  // are recovered below for the environment/flag forms.
+  const sessionValue = session ?? (() => {
+    for (const pattern of [
+      /PI_SUBAGENT_SESSION=(?:'([^']+)'|"([^"]+)"|(\S+))/,
+      /--session\s+(?:'([^']+)'|"([^"]+)"|(\S+))/,
+    ]) {
+      const match = text.match(pattern);
+      const value = match?.slice(1).find((part) => typeof part === "string" && part.length > 0);
+      if (value) return unquoteShellToken(value);
+    }
+    return undefined;
+  })();
+  if (!sessionValue) return null;
+
+  const taskArtifactPath = firstMatch(text, [/^\s*#\s*Task artifact:\s*(.+?)\s*$/m]) ?? (() => {
+    const matches = text.matchAll(/@(?:"([^"]+)"|'((?:'\\''|[^'])+)'|(\S+))/g);
+    for (const match of matches) {
+      const value = match.slice(1).find((part) => typeof part === "string" && part.length > 0);
+      if (!value) continue;
+      const candidate = canonicalPath(unquoteShellToken(value), dirname(path));
+      if (isRegularFile(candidate)) return candidate;
+    }
+    return undefined;
+  })();
+
+  const task = taskFromArtifact(taskArtifactPath, dirname(path));
+  const name = firstMatch(text, [/^\s*#\s*(?:Subagent|.+? subagent) launch script for\s+(.+?)\s*$/im]);
+  const agent = firstMatch(text, [/PI_SUBAGENT_AGENT=(?:'([^']+)'|"([^"]+)"|(\S+))/]);
+  return {
+    sessionFile: canonicalPath(sessionValue, dirname(path)),
+    ...(name ? { name } : {}),
+    ...(agent ? { agent } : {}),
+    ...(task ? { task } : {}),
+    ...(taskArtifactPath ? { taskArtifactPath } : {}),
+  };
+}
+
+function exitEvidence(sessionFile: string): ExitEvidence {
+  const path = `${sessionFile}.exit`;
+  if (!existsSync(path)) return { present: false, valid: false };
+  const payload = readJsonFile(path);
+  const valid = isRecord(payload) &&
+    (payload.type === "done" || payload.type === "error" || payload.type === "ping");
+  return { present: true, valid };
+}
+
+function messageFromEntry(entry: SessionEntry): Record<string, unknown> | null {
+  return entry.type === "message" && isRecord(entry.message) ? entry.message : null;
+}
+
+function entrySessionReference(entry: SessionEntry): string | undefined {
+  const message = messageFromEntry(entry);
+  const values = [
+    entry.sessionFile,
+    entry.sessionPath,
+    entry.childSessionFile,
+    entry.session_path,
+    message?.sessionFile,
+    message?.sessionPath,
+    message?.childSessionFile,
+    message?.session_path,
+    isRecord(entry.details) ? entry.details.sessionFile : undefined,
+    isRecord(entry.details) ? entry.details.sessionPath : undefined,
+    isRecord(entry.details) ? entry.details.childSessionFile : undefined,
+    isRecord(entry.details) ? entry.details.session_path : undefined,
+    isRecord(message?.details) ? message?.details.sessionFile : undefined,
+    isRecord(message?.details) ? message?.details.sessionPath : undefined,
+    isRecord(message?.details) ? message?.details.childSessionFile : undefined,
+    isRecord(message?.details) ? message?.details.session_path : undefined,
+  ];
+  return values.find((value): value is string => typeof value === "string" && value.trim() !== "");
+}
+
+function customTypeOf(entry: SessionEntry): string | undefined {
+  const message = messageFromEntry(entry);
+  return nonEmptyString(entry.customType) ?? nonEmptyString(message?.customType);
+}
+
+function detailsOf(entry: SessionEntry): Record<string, unknown> | null {
+  const message = messageFromEntry(entry);
+  if (isRecord(entry.details)) return entry.details;
+  return isRecord(message?.details) ? message.details : null;
+}
+
+function handledByParent(entries: SessionEntry[], childSessionFile: string): boolean {
+  return entries.some((entry) => {
+    const customType = customTypeOf(entry);
+    const data = isRecord(entry.data) ? entry.data : detailsOf(entry);
+    if (customType === "subagent_restore_handled") {
+      const path = data?.childSessionFile ?? data?.sessionFile ?? data?.sessionPath;
+      return typeof path === "string" && canonicalPath(path) === childSessionFile;
+    }
+    if (customType !== "subagent_restore_report") return false;
+    const reported = data?.reportedChildren;
+    if (!Array.isArray(reported)) return false;
+    return reported.some((item) => {
+      if (!isRecord(item)) return false;
+      const path = item.childSessionFile ?? item.sessionFile ?? item.sessionPath;
+      return typeof path === "string" && canonicalPath(path) === childSessionFile;
+    });
+  });
+}
+
+function parentRecordedCompletion(
+  entries: SessionEntry[],
+  childSessionFile: string,
+  completionEvidence: boolean,
+): boolean {
+  return entries.some((entry) => {
+    const reference = entrySessionReference(entry);
+    if (!reference || canonicalPath(reference) !== childSessionFile) return false;
+
+    const customType = customTypeOf(entry);
+    if (customType === "subagent_result") return true;
+    if (customType === "subagent_ping" || customType === "subagent_restore_handled") return false;
+
+    const message = messageFromEntry(entry);
+    if (message?.role !== "toolResult") return false;
+    const details = detailsOf(entry);
+    if (details?.status === "started") return false;
+    if (
+      details?.status === "completed" ||
+      details?.status === "done" ||
+      details?.status === "delivered" ||
+      typeof details?.exitCode === "number"
+    ) {
+      return true;
+    }
+
+    // Old fixtures and older pi sessions did not persist a completion status.
+    // A tool result is sufficient only when the child also has durable terminal
+    // evidence; the initial "launched" result must not hide an interruption.
+    return completionEvidence;
+  });
+}
+
+function hasTerminalAssistant(entries: SessionEntry[]): boolean {
+  // Tool-result entries can trail the final assistant tool call. Look for the
+  // latest assistant rather than assuming the final JSONL line is a message.
+  for (let i = entries.length - 1; i >= 0; i -= 1) {
+    const message = messageFromEntry(entries[i]);
+    if (!message) continue;
+    // A later user message means a new turn is in flight. Tool results are
+    // allowed to trail the final subagent_done assistant call.
+    if (message.role === "user") return false;
+    if (message.role !== "assistant") continue;
+    if (message.stopReason === "stop" || message.stopReason === "error") return true;
+
+    // subagent_done writes .exit before shutdown; this catches the narrow
+    // race where the parent consumed that sidecar before the child tool result
+    // was flushed, while ordinary toolUse turns remain interrupted.
+    const blocks = Array.isArray(message.content) ? message.content : [];
+    const toolCalls = [message.toolCalls, message.tool_calls, message.toolCall]
+      .filter((value): value is unknown[] => Array.isArray(value))
+      .flat();
+    return [...blocks, ...toolCalls].some((block) =>
+      isRecord(block) &&
+      (block.name === "subagent_done" || block.toolName === "subagent_done" || block.tool === "subagent_done"),
+    );
+  }
+  return false;
+}
+
+function sessionExists(path: string): boolean {
+  return isRegularFile(path);
+}
+
+function hasChildEntries(entries: SessionEntry[], parentEntries: SessionEntry[]): boolean {
+  const parentIds = new Set(parentEntries.map((entry) => entry.id).filter(Boolean));
+  return entries.some((entry) =>
+    entry.type !== "session" && typeof entry.id === "string" && !parentIds.has(entry.id),
+  );
+}
+
+function upsertCandidate(
+  candidates: Map<string, Candidate>,
+  path: string,
+  source: DiscoverySource,
+  hint: Partial<Candidate> = {},
+): Candidate {
+  const sessionFile = canonicalPath(path);
+  let candidate = candidates.get(sessionFile);
+  if (!candidate) {
+    candidate = {
+      sessionFile,
+      sources: new Set(),
+      hasLineageSidecar: false,
+      stalePaneIds: new Set(),
+    };
+    candidates.set(sessionFile, candidate);
+  }
+  candidate.sources.add(source);
+  if (hint.name && !candidate.name) candidate.name = hint.name;
+  if (hint.agent && !candidate.agent) candidate.agent = hint.agent;
+  if (hint.task && !candidate.task) candidate.task = hint.task;
+  if (hint.taskArtifactPath && !candidate.taskArtifactPath) candidate.taskArtifactPath = hint.taskArtifactPath;
+  return candidate;
+}
+
+function mergeMetadata(candidate: Candidate, metadata: SpawnMetadataRecord, baseDir: string): void {
+  candidate.metadata = { ...candidate.metadata, ...metadata };
+  const task = taskFromMetadata(metadata, baseDir);
+  candidate.name = nonEmptyString(metadata.name) ?? candidate.name;
+  candidate.agent = nonEmptyString(metadata.agent) ?? candidate.agent;
+  candidate.task = task.task ?? candidate.task;
+  candidate.taskArtifactPath = task.taskArtifactPath ?? candidate.taskArtifactPath;
+}
+
+function sourceList(candidate: Candidate): DiscoveredOrphan["sources"] {
+  return ["sidecar", "session", "artifact", "pane"].filter((source) => candidate.sources.has(source)) as DiscoveredOrphan["sources"];
+}
+
+export function isActionableOrphan(child: Pick<DiscoveredOrphan, "classification" | "handled">): boolean {
+  return !child.handled && ACTIONABLE_CLASSIFICATIONS.has(child.classification);
+}
+
+export function isRestorableOrphan(child: Pick<DiscoveredOrphan, "classification" | "handled">): boolean {
+  return !child.handled && RESTORABLE_CLASSIFICATIONS.has(child.classification);
+}
+
+export function taskExcerpt(task: string, maxLength = 240): string {
+  const compact = task.replace(/\s+/g, " ").trim();
+  if (compact.length <= maxLength) return compact;
+  return `${compact.slice(0, Math.max(0, maxLength - 1)).trimEnd()}…`;
+}
+
+export function discoverOrphanedSubagents(
+  parentSessionFile: string,
+  options: OrphanDiscoveryOptions = {},
+): DiscoveredOrphan[] {
+  const parentPath = canonicalPath(parentSessionFile);
+  const sessionDir = canonicalPath(options.sessionDir ?? dirname(parentPath));
+  const parentHeader = readSessionHeader(parentPath);
+  const parentId = nonEmptyString(options.parentSessionId) ?? nonEmptyString(parentHeader?.id);
+  const parentEntries = readJsonl(parentPath);
+  const candidates = new Map<string, Candidate>();
+
+  // Seeded lineage headers cover lineage-only and fork modes. This scan stays
+  // in the parent session directory; standalone/custom-cwd launches are found
+  // through their sidecar or the artifact launch script below.
+  for (const entry of readDir(sessionDir)) {
+    if (!entry.isFile() || !entry.name.endsWith(".jsonl")) continue;
+    const path = join(sessionDir, entry.name);
+    const header = readSessionHeader(path);
+    const linkedParent = nonEmptyString(header?.parentSession);
+    if (linkedParent && canonicalPath(linkedParent, dirname(path)) === parentPath) {
+      upsertCandidate(candidates, path, "session");
+    }
+  }
+
+  const artifactDir = parentId ? join(sessionDir, "artifacts", parentId) : undefined;
+  if (artifactDir) {
+    for (const path of walkFiles(artifactDir)) {
+      if (!path.endsWith(".sh")) continue;
+      const hint = artifactHintFromScript(path);
+      if (!hint) continue;
+      upsertCandidate(candidates, hint.sessionFile, "artifact", hint);
+    }
+  }
+
+  // New launch sidecars are the authoritative standalone/phantom index. A
+  // malformed sidecar is ignored; the parent/session/artifact sources still
+  // provide a conservative fallback.
+  for (const entry of readDir(sessionDir)) {
+    if (!entry.isFile() || !entry.name.endsWith(".spawn.json")) continue;
+    const sidecarPath = join(sessionDir, entry.name);
+    const metadata = normalizeMetadata(readJsonFile(sidecarPath));
+    if (!metadata || !metadataMatchesParent(metadata, parentPath, parentId)) continue;
+    const childPath = metadataChildPath(metadata, sidecarPath);
+    if (childPath === parentPath) continue;
+    const candidate = upsertCandidate(candidates, childPath, "sidecar");
+    candidate.hasLineageSidecar = true;
+    mergeMetadata(candidate, metadata, dirname(sidecarPath));
+  }
+
+  // Artifact scripts can point to a child session directory selected by cwd.
+  // Read its sidecar after the path has been recovered, even when that sidecar
+  // lives outside the parent's own session directory.
+  for (const candidate of candidates.values()) {
+    const sidecarPath = `${candidate.sessionFile}.spawn.json`;
+    if (!isRegularFile(sidecarPath)) continue;
+    const metadata = normalizeMetadata(readJsonFile(sidecarPath));
+    if (!metadata || !metadataMatchesParent(metadata, parentPath, parentId)) continue;
+    candidate.sources.add("sidecar");
+    candidate.hasLineageSidecar = true;
+    mergeMetadata(candidate, metadata, dirname(sidecarPath));
+  }
+
+  // A pane reference is only allowed to attach to a path already discovered
+  // from durable parent-owned evidence. This prevents a crew/orchestrator pane
+  // from becoming a restore target merely because it has a session path.
+  const paneSessions = options.paneSessions ?? options.panes ?? [];
+  for (const pane of paneSessions) {
+    const paneId = nonEmptyString(pane?.paneId);
+    const path = nonEmptyString(pane?.sessionPath);
+    if (!paneId || !path) continue;
+    const candidate = candidates.get(canonicalPath(path));
+    if (!candidate) continue;
+    candidate.sources.add("pane");
+    candidate.stalePaneIds.add(paneId);
+  }
+
+  const result: DiscoveredOrphan[] = [];
+  for (const candidate of candidates.values()) {
+    const fileExists = sessionExists(candidate.sessionFile);
+    const entries = fileExists ? readJsonl(candidate.sessionFile) : [];
+    const hasOwnEntries = fileExists && hasChildEntries(entries, parentEntries);
+    const report = hasOwnEntries ? findLastAssistantMessage(entries) : null;
+    const usableReport = typeof report === "string" && report.trim() ? report.trim() : undefined;
+    const exit = exitEvidence(candidate.sessionFile);
+    const terminalAssistant = hasOwnEntries && hasTerminalAssistant(entries);
+    // An invalid/truncated .exit is not completion evidence. An absent sidecar
+    // may be the narrow consumed-before-delivery race, so a terminal child
+    // report is accepted only when no malformed sidecar is present.
+    const completionEvidence = exit.valid || (!exit.present && terminalAssistant);
+    const delivered = parentRecordedCompletion(parentEntries, candidate.sessionFile, completionEvidence);
+    const handled = handledByParent(parentEntries, candidate.sessionFile);
+
+    let classification: OrphanClassification;
+    if (delivered) {
+      classification = "completed-delivered";
+    } else if (!fileExists && candidate.hasLineageSidecar) {
+      classification = "phantom";
+    } else if (usableReport && completionEvidence) {
+      classification = "completed-undelivered";
+    } else if (fileExists && candidate.stalePaneIds.size > 0) {
+      classification = "stale-pane";
+    } else if (fileExists) {
+      classification = "interrupted";
+    } else if (candidate.hasLineageSidecar) {
+      classification = "phantom";
+    } else {
+      // An artifact reference without a session or enriched sidecar is not
+      // enough to claim a phantom; do not invent a child from stale artifacts.
+      continue;
+    }
+
+    const hintTask = candidate.task ?? taskFromMetadata(candidate.metadata, sessionDir).task;
+    const agent = candidate.agent ?? candidate.metadata?.agent;
+    result.push({
+      sessionFile: candidate.sessionFile,
+      name: candidate.name ?? candidate.metadata?.name ?? basename(candidate.sessionFile, ".jsonl"),
+      ...(agent ? { agent } : {}),
+      task: hintTask ?? "",
+      classification,
+      ...(classification === "completed-undelivered" && usableReport ? { report: usableReport } : {}),
+      ...(candidate.metadata ? { spawnMetadata: candidate.metadata } : {}),
+      stalePaneIds: [...candidate.stalePaneIds],
+      handled,
+      sources: sourceList(candidate),
+    });
+  }
+
+  return result.sort((a, b) => a.sessionFile.localeCompare(b.sessionFile));
+}
+
+export function formatOrphanRestoreReport(children: readonly DiscoveredOrphan[]): string {
+  const pending = children.filter(isActionableOrphan);
+  if (pending.length === 0) return "";
+
+  const lines = [
+    `Crash restore found ${pending.length} orphaned subagent${pending.length === 1 ? "" : "s"}:`,
+  ];
+  for (const child of pending) {
+    const agent = child.agent ? child.agent : "(unknown)";
+    lines.push(`- ${child.name}, agent ${agent} — ${taskExcerpt(child.task) || "(task unavailable)"}`);
+    lines.push(`  Session: ${child.sessionFile}`);
+    lines.push(`  Classification: ${child.classification}`);
+    if (child.classification === "completed-undelivered" && child.report) {
+      lines.push("  Stored final report:");
+      for (const reportLine of child.report.split("\n")) lines.push(`    ${reportLine}`);
+    }
+  }
+  lines.push(
+    "",
+    'Restore contract: when the user sends "resume", resume each interrupted or stale-pane child by calling subagent_resume with its session path; use an auto-exit one-shot continuation that asks the child to re-orient from its session and finish. Relaunch each phantom via subagent with its recorded task. Do nothing for completed-delivered children.',
+  );
+  return lines.join("\n");
+}
+
+export interface OrphanResumeOperations {
+  closePane: (paneId: string, child: DiscoveredOrphan) => void | Promise<void>;
+  resume: (child: DiscoveredOrphan) => Promise<unknown>;
+  relaunch: (child: DiscoveredOrphan) => Promise<unknown>;
+}
+
+export interface OrphanResumeOutcome {
+  child: DiscoveredOrphan;
+  action: "resume" | "relaunch";
+  ok: boolean;
+  result?: unknown;
+  error?: string;
+}
+
+export async function resumeOrphanedSubagents(
+  children: readonly DiscoveredOrphan[],
+  operations: OrphanResumeOperations,
+): Promise<OrphanResumeOutcome[]> {
+  const outcomes: OrphanResumeOutcome[] = [];
+  for (const child of children) {
+    if (!isRestorableOrphan(child)) continue;
+    try {
+      // Never launch a second writer until every pane claiming this exact path
+      // has been closed. Pane IDs come only from the discovered path match.
+      for (const paneId of child.stalePaneIds) await operations.closePane(paneId, child);
+      const action = child.classification === "phantom" ? "relaunch" : "resume";
+      const result = action === "relaunch"
+        ? await operations.relaunch(child)
+        : await operations.resume(child);
+      outcomes.push({ child, action, ok: true, result });
+    } catch (error) {
+      outcomes.push({
+        child,
+        action: child.classification === "phantom" ? "relaunch" : "resume",
+        ok: false,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }
+  return outcomes;
+}
+
+export const __orphanDiscoveryTest__ = {
+  artifactHintFromScript,
+  exitEvidence,
+  hasTerminalAssistant,
+  parentRecordedCompletion,
+  taskFromArtifact,
+  taskExcerpt,
+};

--- a/pi-extension/subagents/recovery.ts
+++ b/pi-extension/subagents/recovery.ts
@@ -1,0 +1,61 @@
+export const MIN_RECOVERY_DELAY_MS = 10_000;
+export const DEFAULT_RECOVERY_DELAYS = [30_000, 60_000, 90_000] as const;
+
+export type RecoveryDelays = readonly [number, number, number];
+export type RecoveryStage = "waiting" | "nudged" | "escalated" | "killed";
+export type RecoveryAction = "nudge" | "escalate" | "kill" | null;
+
+export interface RecoveryState {
+  stage: RecoveryStage;
+  stageSince: number;
+}
+
+export interface RecoveryAdvance {
+  state: RecoveryState | undefined;
+  action: RecoveryAction;
+}
+
+function defaultRecoveryDelays(): RecoveryDelays {
+  return [...DEFAULT_RECOVERY_DELAYS];
+}
+
+/** Parse PI_SUBAGENT_RECOVERY_DELAYS_MS without reading process.env. */
+export function parseRecoveryDelays(raw: string | undefined): RecoveryDelays {
+  const parts = raw?.split(",").map((part) => part.trim());
+  if (!parts || parts.length !== 3 || parts.some((part) => !part)) {
+    return defaultRecoveryDelays();
+  }
+
+  const values = parts.map(Number);
+  if (values.some((value) => !Number.isSafeInteger(value))) {
+    return defaultRecoveryDelays();
+  }
+
+  return values.map((value) => Math.max(MIN_RECOVERY_DELAY_MS, value)) as RecoveryDelays;
+}
+
+/** Advance one stalled-child recovery tick using the caller's clock. */
+export function advanceRecoveryLadder(
+  state: RecoveryState | undefined,
+  input: { now: number; stalled: boolean; exempt: boolean; delays: RecoveryDelays },
+): RecoveryAdvance {
+  if (state?.stage === "killed") return { state, action: null };
+  if (!input.stalled || input.exempt) return { state: undefined, action: null };
+  if (!state) return { state: { stage: "waiting", stageSince: input.now }, action: null };
+
+  const elapsed = Math.max(0, input.now - state.stageSince);
+  if (state.stage === "waiting" && elapsed >= input.delays[0]) {
+    return { state: { stage: "nudged", stageSince: input.now }, action: "nudge" };
+  }
+  if (state.stage === "nudged" && elapsed >= input.delays[1]) {
+    return { state: { stage: "escalated", stageSince: input.now }, action: "escalate" };
+  }
+  if (state.stage === "escalated" && elapsed >= input.delays[2]) {
+    return { state: { stage: "killed", stageSince: input.now }, action: "kill" };
+  }
+  return { state, action: null };
+}
+
+export function formatRecoveryKillError(elapsedMs: number): string {
+  return `Subagent recovery-kill after ${Math.floor(Math.max(0, elapsedMs) / 1000)}s.`;
+}

--- a/pi-extension/subagents/recovery.ts
+++ b/pi-extension/subagents/recovery.ts
@@ -19,6 +19,17 @@ function defaultRecoveryDelays(): RecoveryDelays {
   return [...DEFAULT_RECOVERY_DELAYS];
 }
 
+export const DEFAULT_ACTIVE_TOOL_STALL_MS = 600_000;
+
+/** Parse PI_SUBAGENT_ACTIVE_TOOL_STALL_MS without reading process.env; 0 disables. */
+export function parseActiveToolStallMs(raw: string | undefined): number {
+  const trimmed = raw?.trim();
+  if (!trimmed) return DEFAULT_ACTIVE_TOOL_STALL_MS;
+  const value = Number(trimmed);
+  if (!Number.isSafeInteger(value) || value < 0) return DEFAULT_ACTIVE_TOOL_STALL_MS;
+  return value;
+}
+
 /** Parse PI_SUBAGENT_RECOVERY_DELAYS_MS without reading process.env. */
 export function parseRecoveryDelays(raw: string | undefined): RecoveryDelays {
   const parts = raw?.split(",").map((part) => part.trim());

--- a/pi-extension/subagents/session.ts
+++ b/pi-extension/subagents/session.ts
@@ -72,7 +72,13 @@ function readEntries(sessionFile: string): SessionEntry[] {
   return raw
     .split("\n")
     .filter((line) => line.trim())
-    .map((line) => JSON.parse(line) as SessionEntry);
+    .flatMap((line) => {
+      try {
+        return [JSON.parse(line) as SessionEntry];
+      } catch {
+        return [];
+      }
+    });
 }
 
 /**
@@ -89,7 +95,13 @@ export function getLeafId(sessionFile: string): string | null {
 export function getNewEntries(sessionFile: string, afterLine: number): SessionEntry[] {
   const raw = readFileSync(sessionFile, "utf8");
   const lines = raw.split("\n").filter((line) => line.trim());
-  return lines.slice(afterLine).map((line) => JSON.parse(line) as SessionEntry);
+  return lines.slice(afterLine).flatMap((line) => {
+    try {
+      return [JSON.parse(line) as SessionEntry];
+    } catch {
+      return [];
+    }
+  });
 }
 
 /**
@@ -124,31 +136,109 @@ export function findObservedSessionRuntime(entries: SessionEntry[]): ObservedSes
 }
 
 export function findLastAssistantMessage(entries: SessionEntry[]): string | null {
+  // Deep's L-162 phase 2 priority chain:
+  // (1) final same-message text; (2) final subagent_done arguments.report (non-empty);
+  // (3) final provider error; (4) most recent earlier assistant text; (5) null.
+  // This keeps Muse's text+toolCall impossibility from silencing the report,
+  // while error-over-stale-text remains intact for overload failures.
+  let lastIdx = -1;
   for (let i = entries.length - 1; i >= 0; i--) {
     const entry = entries[i];
     if (entry.type !== "message") continue;
     const msg = entry as MessageEntry;
     if (msg.message.role !== "assistant") continue;
-
-    const texts = msg.message.content
-      .filter(
-        (block) =>
-          block.type === "text" && typeof block.text === "string" && block.text.trim() !== "",
-      )
-      .map((block) => block.text as string);
-
-    if (texts.length > 0 && texts.join("").trim()) return texts.join("\n");
-
-    const stopReason = (msg.message as { stopReason?: unknown }).stopReason;
-    const errorMessage = (msg.message as { errorMessage?: unknown }).errorMessage;
-    if (
-      stopReason === "error" &&
-      typeof errorMessage === "string" &&
-      errorMessage.trim() !== ""
-    ) {
-      return `Subagent error: ${errorMessage.trim()}`;
-    }
+    lastIdx = i;
+    break;
   }
+  if (lastIdx === -1) return null;
+
+  const lastEntry = entries[lastIdx] as MessageEntry;
+  const lastMsg: any = lastEntry.message as any;
+  const lastContent: any[] = Array.isArray(lastMsg.content) ? lastMsg.content : [];
+
+  // (1) final same-message text
+  const lastTexts = lastContent
+    .filter((block: any) => block.type === "text" && typeof block.text === "string" && block.text.trim() !== "")
+    .map((block: any) => block.text as string);
+  if (lastTexts.length > 0 && lastTexts.join("").trim()) return lastTexts.join("\n");
+
+  // (2) final subagent_done toolCall arguments.report (non-empty string)
+  const extractReport = (blocks: any[]): string | null => {
+    for (const block of blocks) {
+      if (!block || typeof block !== "object") continue;
+      const type = (block as any).type;
+      const toolName = (block as any).name ?? (block as any).toolName ?? (block as any).tool ?? "";
+      // Only consider subagent_done tool calls; skip other tools even if they happen to have a report field.
+      if (toolName !== "subagent_done") {
+        if (type === "toolCall" || type === "tool_call" || type === "functionCall" || type === "function_call") continue;
+        continue;
+      }
+      let report: unknown;
+      const candidates = [
+        (block as any).arguments,
+        (block as any).args,
+        (block as any).input,
+        (block as any).parameters,
+        (block as any).params,
+      ];
+      for (const cand of candidates) {
+        if (cand == null) continue;
+        if (typeof cand === "object" && typeof (cand as any).report === "string") {
+          report = (cand as any).report;
+          break;
+        }
+        if (typeof cand === "string") {
+          try {
+            const parsed = JSON.parse(cand);
+            if (typeof parsed.report === "string") {
+              report = parsed.report;
+              break;
+            }
+          } catch {
+            // ignore malformed JSON in report argument; treat as no report
+            void 0;
+          }
+        }
+      }
+      if (report === undefined && typeof (block as any).report === "string") report = (block as any).report;
+      if (typeof report === "string" && report.trim() !== "") return report.trim();
+    }
+    return null;
+  };
+
+  const reportFromContent = extractReport(lastContent);
+  if (reportFromContent !== null) return reportFromContent;
+
+  // Also check alternative message-level tool-call arrays (defensive: some Pi builds store tool calls outside content).
+  const altArrays: any[] = [];
+  if (Array.isArray(lastMsg.toolCalls)) altArrays.push(...lastMsg.toolCalls);
+  if (Array.isArray(lastMsg.tool_calls)) altArrays.push(...lastMsg.tool_calls);
+  if (Array.isArray(lastMsg.toolCall)) altArrays.push(...lastMsg.toolCall);
+  if (altArrays.length > 0) {
+    const altReport = extractReport(altArrays);
+    if (altReport !== null) return altReport;
+  }
+
+  // (3) final provider error (stopReason: "error" with errorMessage)
+  const stopReason = (lastMsg as { stopReason?: unknown }).stopReason;
+  const errorMessage = (lastMsg as { errorMessage?: unknown }).errorMessage;
+  if (stopReason === "error" && typeof errorMessage === "string" && errorMessage.trim() !== "") {
+    return `Subagent error: ${errorMessage.trim()}`;
+  }
+
+  // (4) most recent earlier assistant text (fallback)
+  for (let i = lastIdx - 1; i >= 0; i--) {
+    const entry = entries[i];
+    if (entry.type !== "message") continue;
+    const msg = entry as MessageEntry;
+    if (msg.message.role !== "assistant") continue;
+    const texts = (msg.message.content || [])
+      .filter((block: any) => block.type === "text" && typeof block.text === "string" && block.text.trim() !== "")
+      .map((block: any) => block.text as string);
+    if (texts.length > 0 && texts.join("").trim()) return texts.join("\n");
+  }
+
+  // (5) null → caller falls back to "Sub-agent exited without output"
   return null;
 }
 

--- a/pi-extension/subagents/subagent-done.ts
+++ b/pi-extension/subagents/subagent-done.ts
@@ -8,6 +8,7 @@ import { Box, Text } from "@earendil-works/pi-tui";
 import { Type } from "@sinclair/typebox";
 import { writeFileSync } from "node:fs";
 import { createSubagentActivityRecorder } from "./activity.ts";
+import { consumeWrapupDirective } from "./time-limits.ts";
 
 export function shouldMarkUserTookOver(agentStarted: boolean): boolean {
   return agentStarted;
@@ -68,11 +69,19 @@ export function findLatestAssistantError(
   return null;
 }
 
-export function buildCompletionSidecar(messages: any[] | undefined):
-  | { type: "done" }
+export function buildCompletionSidecar(messages: any[] | undefined, wrapup = false):
+  | { type: "done"; wrapup?: true }
   | { type: "error"; errorMessage: string; stopReason: "error" } {
   const errorInfo = findLatestAssistantError(messages);
-  return errorInfo ? { type: "error", ...errorInfo } : { type: "done" };
+  return errorInfo ? { type: "error", ...errorInfo } : { type: "done", ...(wrapup ? { wrapup: true } : {}) };
+}
+
+export function latestAssistantWasAborted(messages: any[] | undefined): boolean {
+  if (!messages) return false;
+  for (let i = messages.length - 1; i >= 0; i--) {
+    if (messages[i]?.role === "assistant") return messages[i].stopReason === "aborted";
+  }
+  return false;
 }
 
 export function parseDeniedTools(rawValue: string | undefined): string[] {
@@ -151,6 +160,7 @@ export default function (pi: ExtensionAPI) {
   let userTookOver = false;
   let agentStarted = false;
   let latestAgentMessages: any[] | undefined;
+  let wrapupInProgress = false;
 
   // Show widget + status bar on session start
   pi.on("session_start", (_event, ctx) => {
@@ -162,8 +172,11 @@ export default function (pi: ExtensionAPI) {
     renderWidget(ctx, null);
   });
 
-  pi.on("input", () => {
+  pi.on("input", (event) => {
     recorder.input();
+    // Extension-injected report directives are not operator takeover. This keeps
+    // the report-only continuation compatible with sticky auto-exit disarming.
+    if ((event as any).source === "extension") return;
     // Ignore the initial task message that starts an autonomous subagent.
     // Only inputs after the first agent run has started count as user takeover.
     if (!shouldMarkUserTookOver(agentStarted)) return;
@@ -188,19 +201,30 @@ export default function (pi: ExtensionAPI) {
   });
 
   pi.on("agent_settled", (_event, ctx) => {
-    const shouldExit = autoExit
-      && shouldAutoExitOnAgentEnd(userTookOver, latestAgentMessages);
+    const sessionFile = process.env.PI_SUBAGENT_SESSION;
+    const directive = !wrapupInProgress && latestAssistantWasAborted(latestAgentMessages)
+      ? consumeWrapupDirective(sessionFile)
+      : null;
+    if (directive) {
+      wrapupInProgress = true;
+      // This creates an extension-sourced turn; it is not text typed into the pane.
+      pi.sendUserMessage(directive);
+      return;
+    }
+
+    const shouldExit =
+      (autoExit && shouldAutoExitOnAgentEnd(userTookOver, latestAgentMessages)) ||
+      (wrapupInProgress && !latestAssistantWasAborted(latestAgentMessages));
 
     if (shouldExit) {
       // Surface stopReason: "error" turns (auto-retry exhausted, provider
       // overload, etc.) to the parent via the .exit sidecar so the watcher
       // can report a clear failure with the underlying error message.
-      const sessionFile = process.env.PI_SUBAGENT_SESSION;
       if (sessionFile) {
         try {
           writeFileSync(
             `${sessionFile}.exit`,
-            JSON.stringify(buildCompletionSidecar(latestAgentMessages)),
+            JSON.stringify(buildCompletionSidecar(latestAgentMessages, wrapupInProgress)),
           );
         } catch {
           // Best effort — the watcher can still detect the terminal sentinel
@@ -320,7 +344,10 @@ export default function (pi: ExtensionAPI) {
       const sessionFile = process.env.PI_SUBAGENT_SESSION;
       recorder.subagentDone();
       if (sessionFile) {
-        writeFileSync(`${sessionFile}.exit`, JSON.stringify({ type: "done" }));
+        writeFileSync(
+          `${sessionFile}.exit`,
+          JSON.stringify({ type: "done", ...(wrapupInProgress ? { wrapup: true } : {}) }),
+        );
       }
       ctx.shutdown();
       return {

--- a/pi-extension/subagents/subagent-done.ts
+++ b/pi-extension/subagents/subagent-done.ts
@@ -426,8 +426,17 @@ export default function (pi: ExtensionAPI) {
       "The final report must be written as text in the SAME assistant message as this tool call — " +
       "include the report text alongside the tool call. " +
       "Calling it without accompanying text returns no summary to the caller " +
-      "(\"Sub-agent exited without output\").",
-    parameters: Type.Object({}),
+      "(\"Sub-agent exited without output\"). " +
+      "Profiles which cannot emit text alongside tool calls must pass the report via the `report` argument.",
+    parameters: Type.Object({
+      report: Type.Optional(
+        Type.String({
+          description:
+            "Final report summary for the parent session. Use this when your profile cannot emit text alongside the tool call; otherwise prefer same-message text.",
+          minLength: 1,
+        }),
+      ),
+    }),
     async execute(_toolCallId, _params, _signal, _onUpdate, ctx) {
       const sessionFile = process.env.PI_SUBAGENT_SESSION;
       recorder.subagentDone();

--- a/pi-extension/subagents/subagent-done.ts
+++ b/pi-extension/subagents/subagent-done.ts
@@ -423,7 +423,10 @@ export default function (pi: ExtensionAPI) {
     description:
       "Call this tool when you have completed your task. " +
       "It will close this session and return your results to the main session. " +
-      "Your LAST assistant message before calling this becomes the summary returned to the caller.",
+      "The final report must be written as text in the SAME assistant message as this tool call — " +
+      "include the report text alongside the tool call. " +
+      "Calling it without accompanying text returns no summary to the caller " +
+      "(\"Sub-agent exited without output\").",
     parameters: Type.Object({}),
     async execute(_toolCallId, _params, _signal, _onUpdate, ctx) {
       const sessionFile = process.env.PI_SUBAGENT_SESSION;

--- a/pi-extension/subagents/subagent-done.ts
+++ b/pi-extension/subagents/subagent-done.ts
@@ -187,6 +187,15 @@ export default function (pi: ExtensionAPI) {
   let agentStarted = false;
   let latestAgentMessages: any[] | undefined;
   let wrapupInProgress = false;
+  let exitSidecarWritten = false;
+
+  function writeExitSidecar(data: object): void {
+    if (exitSidecarWritten) return;
+    const sessionFile = process.env.PI_SUBAGENT_SESSION;
+    if (!sessionFile) return;
+    writeFileSync(`${sessionFile}.exit`, JSON.stringify(data));
+    exitSidecarWritten = true;
+  }
 
   // Operator takeover (typed input or an Escape abort) permanently disarms
   // auto-exit for this session. The warning is latched so it is emitted
@@ -286,10 +295,7 @@ export default function (pi: ExtensionAPI) {
       // can report a clear failure with the underlying error message.
       if (sessionFile) {
         try {
-          writeFileSync(
-            `${sessionFile}.exit`,
-            JSON.stringify(buildCompletionSidecar(latestAgentMessages, wrapupInProgress)),
-          );
+          writeExitSidecar(buildCompletionSidecar(latestAgentMessages, wrapupInProgress));
         } catch {
           // Best effort — the watcher can still detect the terminal sentinel
           // after shutdown if the completion sidecar cannot be written.
@@ -407,7 +413,7 @@ export default function (pi: ExtensionAPI) {
         name: process.env.PI_SUBAGENT_NAME ?? "subagent",
         message: params.message,
       };
-      writeFileSync(`${sessionFile}.exit`, JSON.stringify(exitData));
+      writeExitSidecar(exitData);
 
       ctx.shutdown();
       return {
@@ -441,10 +447,7 @@ export default function (pi: ExtensionAPI) {
       const sessionFile = process.env.PI_SUBAGENT_SESSION;
       recorder.subagentDone();
       if (sessionFile) {
-        writeFileSync(
-          `${sessionFile}.exit`,
-          JSON.stringify({ type: "done", ...(wrapupInProgress ? { wrapup: true } : {}) }),
-        );
+        writeExitSidecar({ type: "done", ...(wrapupInProgress ? { wrapup: true } : {}) });
       }
       ctx.shutdown();
       return {

--- a/pi-extension/subagents/subagent-done.ts
+++ b/pi-extension/subagents/subagent-done.ts
@@ -125,6 +125,8 @@ export default function (pi: ExtensionAPI) {
   const subagentAgent = process.env.PI_SUBAGENT_AGENT ?? "";
   const deniedToolsValue = process.env.PI_DENY_TOOLS;
   const autoExit = process.env.PI_SUBAGENT_AUTO_EXIT === "1";
+  const resumedAutoExitRearm = autoExit && process.env.PI_SUBAGENT_AUTO_EXIT_REARM === "1";
+  let resumeInputPending = autoExit && process.env.PI_SUBAGENT_RESUME_INPUT === "1";
   const recorder = createSubagentActivityRecorder({
     runningChildId: process.env.PI_SUBAGENT_ID,
     activityFile: process.env.PI_SUBAGENT_ACTIVITY_FILE,
@@ -181,8 +183,11 @@ export default function (pi: ExtensionAPI) {
     );
   }
 
-  let disarmed = false;
-  let oneShotReArm = false;
+  // A delegated resume is a fresh autonomous run even when the JSONL's last
+  // turn was operator-aborted. Re-arm it explicitly, rather than deriving
+  // state from historical session contents.
+  let disarmed = resumedAutoExitRearm;
+  let oneShotReArm = resumedAutoExitRearm;
   let warnedOperatorTakeover = false;
   let agentStarted = false;
   let latestAgentMessages: any[] | undefined;
@@ -223,6 +228,13 @@ export default function (pi: ExtensionAPI) {
 
   pi.on("input", (event, ctx) => {
     recorder.input();
+    // The resume command's positional message is machine input, even though
+    // Pi reports it as a normal input event. Consume that marker once so it
+    // cannot disarm the newly re-armed autonomous run.
+    if (resumeInputPending) {
+      resumeInputPending = false;
+      return;
+    }
     // Extension-injected report directives are not operator takeover. This keeps
     // the report-only continuation compatible with sticky auto-exit disarming.
     if ((event as any).source === "extension") return;

--- a/pi-extension/subagents/subagent-done.ts
+++ b/pi-extension/subagents/subagent-done.ts
@@ -37,6 +37,40 @@ export function shouldAutoExitOnAgentEnd(
   return true;
 }
 
+export interface AutoExitDecisionState {
+  /** Sticky: set when the operator typed into the session or Escape-aborted a run. */
+  disarmed: boolean;
+  /** Set by /auto-exit: allows exactly one more settled completion to exit. */
+  oneShotReArm: boolean;
+}
+
+/**
+ * Pure auto-exit decision for a settled agent turn.
+ *
+ * - Armed and untouched: exits on terminal stops and errors exactly as
+ *   v0.2.0 did; Escape-aborted runs keep the session open.
+ * - Disarmed (operator takeover): never exits, whatever the stop reason.
+ * - One-shot re-arm (/auto-exit): behaves like armed for a single further
+ *   completion; the caller consumes the flag once that exit happens.
+ */
+export function resolveAutoExit(
+  state: AutoExitDecisionState,
+  stopReason: string | undefined,
+): boolean {
+  if (state.disarmed && !state.oneShotReArm) return false;
+  return stopReason !== "aborted";
+}
+
+function latestAssistantStopReason(messages: any[] | undefined): string | undefined {
+  if (messages) {
+    for (let i = messages.length - 1; i >= 0; i--) {
+      const msg = messages[i];
+      if (msg?.role === "assistant") return msg.stopReason as string | undefined;
+    }
+  }
+  return undefined;
+}
+
 export interface SubagentErrorInfo {
   errorMessage: string;
   stopReason: "error";
@@ -148,9 +182,25 @@ export default function (pi: ExtensionAPI) {
     );
   }
 
-  let userTookOver = false;
+  let disarmed = false;
+  let oneShotReArm = false;
+  let warnedOperatorTakeover = false;
   let agentStarted = false;
   let latestAgentMessages: any[] | undefined;
+
+  // Operator takeover (typed input or an Escape abort) permanently disarms
+  // auto-exit for this session. The warning is latched so it is emitted
+  // exactly once no matter how often the operator interacts afterwards.
+  function disarmAutoExit(cause: string, ctx: any): void {
+    disarmed = true;
+    if (!autoExit || warnedOperatorTakeover) return;
+    warnedOperatorTakeover = true;
+    ctx.ui.notify(
+      `Auto-exit disabled (${cause}). You are driving this session now — ` +
+        "/auto-exit closes it after its next completion.",
+      "warning",
+    );
+  }
 
   // Show widget + status bar on session start
   pi.on("session_start", (_event, ctx) => {
@@ -162,12 +212,12 @@ export default function (pi: ExtensionAPI) {
     renderWidget(ctx, null);
   });
 
-  pi.on("input", () => {
+  pi.on("input", (_event, ctx) => {
     recorder.input();
     // Ignore the initial task message that starts an autonomous subagent.
     // Only inputs after the first agent run has started count as user takeover.
     if (!shouldMarkUserTookOver(agentStarted)) return;
-    userTookOver = true;
+    disarmAutoExit("operator input", ctx);
   });
 
   pi.on("before_agent_start", () => {
@@ -188,8 +238,21 @@ export default function (pi: ExtensionAPI) {
   });
 
   pi.on("agent_settled", (_event, ctx) => {
+    const stopReason = latestAssistantStopReason(latestAgentMessages);
+
+    // An Escape-triggered abort is operator takeover too: permanently disarm
+    // (single warning above) and leave the session open for inspection.
+    if (stopReason === "aborted") {
+      disarmAutoExit("Escape", ctx);
+    }
+
     const shouldExit = autoExit
-      && shouldAutoExitOnAgentEnd(userTookOver, latestAgentMessages);
+      && resolveAutoExit({ disarmed, oneShotReArm }, stopReason);
+    if (shouldExit && oneShotReArm) {
+      // Consume the one-shot re-arm: after this exit auto-exit is disarmed
+      // again until the operator runs /auto-exit once more.
+      oneShotReArm = false;
+    }
 
     if (shouldExit) {
       // Surface stopReason: "error" turns (auto-retry exhausted, provider
@@ -211,12 +274,6 @@ export default function (pi: ExtensionAPI) {
       recorder.agentEndDone();
       ctx.shutdown();
       return;
-    }
-
-    if (autoExit) {
-      // Reset any recorded manual input marker. Auto-exit is decided by whether
-      // the latest settled agent run completed normally, not by who initiated it.
-      userTookOver = false;
     }
   });
 
@@ -265,6 +322,33 @@ export default function (pi: ExtensionAPI) {
   });
 
   // Toggle expand/collapse with Ctrl+J
+  // Re-arm auto-exit for exactly one completion after operator takeover.
+  pi.registerCommand("auto-exit", {
+    description: "Close this session automatically after its next completed turn",
+    handler: async (_args, ctx) => {
+      if (!autoExit) {
+        ctx.ui.notify("Auto-exit is not enabled for this session.", "info");
+        return;
+      }
+      if (!disarmed) {
+        ctx.ui.notify("Auto-exit is already armed.", "info");
+        return;
+      }
+      if (oneShotReArm) {
+        ctx.ui.notify(
+          "Auto-exit is already re-armed for the next completion.",
+          "info",
+        );
+        return;
+      }
+      oneShotReArm = true;
+      ctx.ui.notify(
+        "Auto-exit re-armed: this session will close after its next completion.",
+        "info",
+      );
+    },
+  });
+
   pi.registerShortcut("ctrl+j", {
     description: "Toggle subagent tools widget",
     handler: (ctx) => {

--- a/pi-extension/subagents/subagent-done.ts
+++ b/pi-extension/subagents/subagent-done.ts
@@ -1,6 +1,6 @@
 /**
  * Extension loaded into sub-agents.
- * - Shows agent identity + available tools as a styled widget above the editor (toggle with Ctrl+J)
+ * - Shows agent identity + available tools as a styled widget above the editor (toggle with Alt+J)
  * - Provides a `subagent_done` tool for autonomous agents to self-terminate
  */
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
@@ -142,7 +142,7 @@ export default function (pi: ExtensionAPI) {
         if (expanded) {
           // Expanded: full tool list + denied
           const countInfo = theme.fg("dim", ` — ${toolNames.length} available`);
-          const hint = theme.fg("muted", "  (Ctrl+J to collapse)");
+          const hint = theme.fg("muted", "  (Alt+J to collapse)");
 
           const toolList = toolNames
             .map((name: string) => theme.fg("dim", name))
@@ -169,7 +169,7 @@ export default function (pi: ExtensionAPI) {
             denied.length > 0
               ? theme.fg("dim", " · ") + theme.fg("error", `${denied.length} denied`)
               : "";
-          const hint = theme.fg("muted", "  (Ctrl+J to expand)");
+          const hint = theme.fg("muted", "  (Alt+J to expand)");
 
           const content = new Text(`${agentTag}${countInfo}${deniedInfo}${hint}`, 0, 0);
           box.addChild(content);
@@ -352,7 +352,7 @@ export default function (pi: ExtensionAPI) {
     recorder.sessionShutdown((event as any).reason);
   });
 
-  // Toggle expand/collapse with Ctrl+J
+  // Toggle expand/collapse with Alt+J (ctrl-J is pi's built-in tui.input.newLine)
   // Re-arm auto-exit for exactly one completion after operator takeover.
   pi.registerCommand("auto-exit", {
     description: "Close this session automatically after its next completed turn",
@@ -380,7 +380,7 @@ export default function (pi: ExtensionAPI) {
     },
   });
 
-  pi.registerShortcut("ctrl+j", {
+  pi.registerShortcut("alt+j", {
     description: "Toggle subagent tools widget",
     handler: (ctx) => {
       expanded = !expanded;

--- a/pi-extension/subagents/subagent-done.ts
+++ b/pi-extension/subagents/subagent-done.ts
@@ -14,28 +14,26 @@ export function shouldMarkUserTookOver(agentStarted: boolean): boolean {
   return agentStarted;
 }
 
+function isTerminalAutoExitStopReason(stopReason: string | undefined): boolean {
+  return stopReason === "stop" || stopReason === "error";
+}
+
 export function shouldAutoExitOnAgentEnd(
   _userTookOver: boolean,
   messages: any[] | undefined,
 ): boolean {
-  // Manual input should not strand an auto-exit subagent. If the latest agent
-  // turn completed normally, close the session. Escape/abort still leaves it
-  // open for inspection or another prompt.
-  //
-  // stopReason: "error" (e.g. exhausted retries on a provider overload) also
-  // returns true — we want to shut down so the parent is woken up — but we
-  // pair this with findLatestAssistantError() so the parent learns it was an
-  // error, not a clean completion.
+  // A tool-use response is an intermediate turn boundary. Keep the child
+  // alive so Pi can deliver the next assistant response or a tool failure.
   if (messages) {
     for (let i = messages.length - 1; i >= 0; i--) {
       const msg = messages[i];
       if (msg?.role === "assistant") {
-        return msg.stopReason !== "aborted";
+        return isTerminalAutoExitStopReason(msg.stopReason);
       }
     }
   }
 
-  return true;
+  return false;
 }
 
 export interface AutoExitDecisionState {
@@ -59,7 +57,7 @@ export function resolveAutoExit(
   stopReason: string | undefined,
 ): boolean {
   if (state.disarmed && !state.oneShotReArm) return false;
-  return stopReason !== "aborted";
+  return isTerminalAutoExitStopReason(stopReason);
 }
 
 function latestAssistantStopReason(messages: any[] | undefined): string | undefined {
@@ -275,7 +273,7 @@ export default function (pi: ExtensionAPI) {
     const autoExitShouldFire = autoExit
       && resolveAutoExit({ disarmed, oneShotReArm }, stopReason);
     const shouldExit = autoExitShouldFire
-      || (wrapupInProgress && stopReason !== "aborted");
+      || (wrapupInProgress && isTerminalAutoExitStopReason(stopReason));
     if (autoExitShouldFire && oneShotReArm) {
       // Consume the one-shot re-arm: after this exit auto-exit is disarmed
       // again until the operator runs /auto-exit once more.

--- a/pi-extension/subagents/terminal.ts
+++ b/pi-extension/subagents/terminal.ts
@@ -14,6 +14,8 @@ import {
   reportHerdrPaneTask,
   sendHerdrCommand,
   sendHerdrEscape,
+  listHerdrPaneSessions,
+  type HerdrPaneSessionReference,
 } from "./herdr.ts";
 
 export type PaneId = string;
@@ -116,6 +118,11 @@ export async function inspectPane(paneId: PaneId): Promise<import("./lifecycle.t
 export function closePane(paneId: PaneId): void {
   assertTerminalAvailable();
   closeHerdrSurface(paneId);
+}
+
+export function listPaneSessionReferences(): HerdrPaneSessionReference[] {
+  if (!isTerminalAvailable()) return [];
+  return listHerdrPaneSessions();
 }
 
 export function setPaneTask(paneId: PaneId, task: string): void {

--- a/pi-extension/subagents/time-limits.ts
+++ b/pi-extension/subagents/time-limits.ts
@@ -1,0 +1,134 @@
+import { existsSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+
+export interface TimeLimitConfig {
+  timeLimitSeconds?: number;
+  idleTimeoutSeconds?: number;
+  timeoutWarnThreshold?: number;
+}
+
+export type TimeLimitAction = "none" | "warn" | "hard-stop";
+
+export const REPORT_ONLY_WRAPUP_DIRECTIVE =
+  "Your time limit is nearly exhausted. Do not continue implementation or use tools. " +
+  "Provide a concise final partial report with completed work, remaining work, and blockers.";
+
+export interface WrapupFileOperations {
+  exists(file: string): boolean;
+  read(file: string): string;
+  write(file: string, content: string): void;
+  remove(file: string): void;
+}
+
+const DEFAULT_WRAPUP_FILE_OPERATIONS: WrapupFileOperations = {
+  exists: existsSync,
+  read: (file) => readFileSync(file, "utf8"),
+  write: (file, content) => writeFileSync(file, content, "utf8"),
+  remove: (file) => rmSync(file, { force: true }),
+};
+
+export function parsePositiveIntegerSeconds(value: string | undefined): number | undefined {
+  if (!value || !/^[1-9]\d*$/.test(value)) return undefined;
+  const seconds = Number(value);
+  return Number.isSafeInteger(seconds) ? seconds : undefined;
+}
+
+export function parseTimeoutWarnThreshold(value: string | undefined): number | undefined {
+  if (!value) return undefined;
+  const threshold = Number(value);
+  return Number.isFinite(threshold) && threshold > 0 && threshold < 1 ? threshold : undefined;
+}
+
+function deadlineAt(start: number, seconds: number | undefined): number | undefined {
+  if (!Number.isFinite(start) || !Number.isFinite(seconds) || seconds <= 0) return undefined;
+  const deadline = start + seconds * 1_000;
+  return Number.isFinite(deadline) ? deadline : undefined;
+}
+
+function earlierDeadline(...deadlines: Array<number | undefined>): number | undefined {
+  const valid = deadlines.filter((deadline): deadline is number => deadline != null);
+  return valid.length > 0 ? Math.min(...valid) : undefined;
+}
+
+/** The earliest hard deadline; idle limits require a child activity timestamp. */
+export function getTimeLimitDeadlineAt(
+  startTime: number,
+  lastActivityAt: number | undefined,
+  config: TimeLimitConfig,
+): number | undefined {
+  return earlierDeadline(
+    deadlineAt(startTime, config.timeLimitSeconds),
+    Number.isFinite(lastActivityAt) ? deadlineAt(lastActivityAt!, config.idleTimeoutSeconds) : undefined,
+  );
+}
+
+function getWarnDeadlineAt(
+  startTime: number,
+  lastActivityAt: number | undefined,
+  config: TimeLimitConfig,
+): number | undefined {
+  const threshold = config.timeoutWarnThreshold;
+  if (!Number.isFinite(threshold) || threshold! <= 0 || threshold! >= 1) return undefined;
+  return earlierDeadline(
+    deadlineAt(startTime, config.timeLimitSeconds == null ? undefined : config.timeLimitSeconds * threshold!),
+    Number.isFinite(lastActivityAt)
+      ? deadlineAt(lastActivityAt!, config.idleTimeoutSeconds == null ? undefined : config.idleTimeoutSeconds * threshold!)
+      : undefined,
+  );
+}
+
+/** Evaluate a single tick using only caller-supplied time and state. */
+export function evalTimeLimit(
+  now: number,
+  startTime: number,
+  lastActivityAt: number | undefined,
+  config: TimeLimitConfig,
+  warned = false,
+): TimeLimitAction {
+  const hardDeadline = getTimeLimitDeadlineAt(startTime, lastActivityAt, config);
+  if (hardDeadline != null && now >= hardDeadline) return "hard-stop";
+  if (warned) return "none";
+  const warnDeadline = getWarnDeadlineAt(startTime, lastActivityAt, config);
+  return warnDeadline != null && now >= warnDeadline ? "warn" : "none";
+}
+
+export function wrapupDirectiveFile(sessionFile: string): string {
+  return `${sessionFile}.wrapup`;
+}
+
+export function writeWrapupDirective(
+  sessionFile: string,
+  operations: WrapupFileOperations = DEFAULT_WRAPUP_FILE_OPERATIONS,
+): void {
+  operations.write(wrapupDirectiveFile(sessionFile), REPORT_ONLY_WRAPUP_DIRECTIVE);
+}
+
+/** Consume the one-shot parent directive before starting the report-only turn. */
+export function consumeWrapupDirective(
+  sessionFile: string | undefined,
+  operations: WrapupFileOperations = DEFAULT_WRAPUP_FILE_OPERATIONS,
+): string | null {
+  if (!sessionFile) return null;
+  const file = wrapupDirectiveFile(sessionFile);
+  if (!operations.exists(file)) return null;
+  try {
+    const directive = operations.read(file).trim();
+    operations.remove(file);
+    return directive || null;
+  } catch {
+    return null;
+  }
+}
+
+export function cleanupWrapupDirective(
+  sessionFile: string | undefined,
+  operations: Pick<WrapupFileOperations, "remove"> = DEFAULT_WRAPUP_FILE_OPERATIONS,
+): void {
+  if (!sessionFile) return;
+  try {
+    operations.remove(wrapupDirectiveFile(sessionFile));
+  } catch {}
+}
+
+export function formatTimeLimitError(elapsedMs: number): string {
+  return `Subagent timed out after ${Math.floor(Math.max(0, elapsedMs) / 1_000)}s.`;
+}

--- a/test/f108-interrupted-resume.test.ts
+++ b/test/f108-interrupted-resume.test.ts
@@ -1,0 +1,220 @@
+import { describe, it, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import subagentDoneExtension from "../pi-extension/subagents/subagent-done.ts";
+import { __test__ as subagentsTest } from "../pi-extension/subagents/index.ts";
+import { waitForCompletion } from "../pi-extension/subagents/completion.ts";
+import { createLifecycle } from "../pi-extension/subagents/lifecycle.ts";
+
+function createChildApi() {
+  const eventHandlers = new Map<string, Function[]>();
+  const commands: Array<{ name: string; handler: Function }> = [];
+  return {
+    eventHandlers,
+    commands,
+    api: {
+      on(event: string, handler: Function) {
+        eventHandlers.set(event, [...(eventHandlers.get(event) ?? []), handler]);
+      },
+      registerTool() {},
+      registerCommand(name: string, command: any) {
+        commands.push({ name, handler: command.handler });
+      },
+      registerMessageRenderer() {},
+      registerShortcut() {},
+      sendUserMessage() {},
+      sendMessage() {},
+      getAllTools() { return []; },
+    } as any,
+  };
+}
+
+const originalEnv = {
+  autoExit: process.env.PI_SUBAGENT_AUTO_EXIT,
+  rearm: process.env.PI_SUBAGENT_AUTO_EXIT_REARM,
+  resumeInput: process.env.PI_SUBAGENT_RESUME_INPUT,
+  session: process.env.PI_SUBAGENT_SESSION,
+  interruptGrace: process.env.PI_SUBAGENT_INTERRUPT_GRACE_MS,
+};
+const tempDirs = new Set<string>();
+
+function restoreEnv(name: string, value: string | undefined) {
+  if (value == null) delete process.env[name];
+  else process.env[name] = value;
+}
+
+afterEach(() => {
+  restoreEnv("PI_SUBAGENT_AUTO_EXIT", originalEnv.autoExit);
+  restoreEnv("PI_SUBAGENT_AUTO_EXIT_REARM", originalEnv.rearm);
+  restoreEnv("PI_SUBAGENT_RESUME_INPUT", originalEnv.resumeInput);
+  restoreEnv("PI_SUBAGENT_SESSION", originalEnv.session);
+  restoreEnv("PI_SUBAGENT_INTERRUPT_GRACE_MS", originalEnv.interruptGrace);
+  for (const dir of tempDirs) rmSync(dir, { recursive: true, force: true });
+  tempDirs.clear();
+  const running = subagentsTest.runningSubagents as Map<string, any>;
+  running.clear();
+});
+
+describe("F-108 interrupted delegation lifecycle", () => {
+  function makeRunning(overrides: Record<string, unknown> = {}) {
+    return {
+      id: "child-1",
+      name: "Worker",
+      task: "bounded task",
+      surface: "pane-1",
+      startTime: Date.now(),
+      sessionFile: join((() => {
+        const dir = mkdtempSync(join(tmpdir(), "f108-session-"));
+        tempDirs.add(dir);
+        return dir;
+      })(), "child.jsonl"),
+      cli: "pi",
+      interactive: false,
+      lifecycle: createLifecycle(Date.now()),
+      ...overrides,
+    };
+  }
+
+  it("marks an interrupted autonomous child terminal and closes it only after grace", async () => {
+    const testApi = subagentsTest;
+    const runningMap = testApi.runningSubagents as Map<string, any>;
+    let closes = 0;
+    let aborts = 0;
+    const running = makeRunning({
+      abortController: { abort() { aborts += 1; } },
+    });
+    writeFileSync(running.sessionFile, "session remains resumable\n");
+    runningMap.set(running.id, running);
+
+    const result = testApi.handleSubagentInterrupt(
+      { id: running.id },
+      () => {},
+      {
+        graceMs: 10,
+        closePane: () => { closes += 1; },
+        abortWatcher: () => { aborts += 1; },
+      },
+    );
+
+    assert.equal(result.details.status, "interrupt_requested");
+    assert.equal(closes, 0, "the pane must remain during the grace window");
+    assert.equal(running.lifecycle.turn.kind, "interrupted");
+
+    await new Promise((resolve) => setTimeout(resolve, 30));
+
+    assert.equal(closes, 1, "the pane closes after the bounded grace");
+    assert.equal(aborts, 1, "the completion watcher is stopped after close");
+    assert.equal(running.lifecycle.process.kind, "failed");
+    assert.match(running.lifecycle.process.error, /interrupted/i);
+    assert.equal(existsSync(running.sessionFile), true, "the session JSONL is retained");
+    assert.equal(runningMap.has(running.id), true, "terminal row remains deliverable until watcher handoff");
+  });
+
+  it("keeps interactive takeover panes open", async () => {
+    const testApi = subagentsTest;
+    const runningMap = testApi.runningSubagents as Map<string, any>;
+    let closes = 0;
+    const running = makeRunning({
+      interactive: true,
+      abortController: { abort() {} },
+    });
+    runningMap.set(running.id, running);
+
+    testApi.handleSubagentInterrupt(
+      { id: running.id },
+      () => {},
+      { graceMs: 0, closePane: () => { closes += 1; }, abortWatcher: () => {} },
+    );
+    await new Promise((resolve) => setTimeout(resolve, 20));
+
+    assert.equal(closes, 0);
+    assert.equal(running.lifecycle.turn.kind, "interrupted");
+    assert.equal(running.lifecycle.process.kind, "starting");
+  });
+});
+
+describe("F-108 resumed auto-exit", () => {
+  function boot(opts: { rearm?: boolean; resumeInput?: boolean } = {}) {
+    process.env.PI_SUBAGENT_AUTO_EXIT = "1";
+    if (opts.rearm) process.env.PI_SUBAGENT_AUTO_EXIT_REARM = "1";
+    else delete process.env.PI_SUBAGENT_AUTO_EXIT_REARM;
+    if (opts.resumeInput) process.env.PI_SUBAGENT_RESUME_INPUT = "1";
+    else delete process.env.PI_SUBAGENT_RESUME_INPUT;
+    const dir = mkdtempSync(join(tmpdir(), "f108-resume-"));
+    tempDirs.add(dir);
+    const sessionFile = join(dir, "child.jsonl");
+    writeFileSync(sessionFile, "session header\n");
+    process.env.PI_SUBAGENT_SESSION = sessionFile;
+    const { api, eventHandlers } = createChildApi();
+    subagentDoneExtension(api);
+    const ctx: any = {
+      shutdowns: 0,
+      ui: { notify() {}, setWidget() {} },
+      shutdown() { ctx.shutdowns += 1; },
+    };
+    return {
+      sessionFile,
+      ctx,
+      fire(event: string, payload: any = {}) {
+        for (const handler of eventHandlers.get(event) ?? []) handler(payload, ctx);
+      },
+    };
+  }
+
+  it("keeps the normal one-shot close path unchanged", async () => {
+    const child = boot();
+    child.fire("agent_start");
+    child.fire("agent_end", { messages: [{ role: "assistant", stopReason: "stop" }] });
+    child.fire("agent_settled");
+
+    assert.equal(child.ctx.shutdowns, 1);
+    assert.deepEqual(JSON.parse(readFileSync(`${child.sessionFile}.exit`, "utf8")), { type: "done" });
+    const result = await waitForCompletion(new AbortController().signal, {
+      intervalMs: 1,
+      sessionFile: child.sessionFile,
+      readTerminalTail: async () => "",
+    });
+    assert.deepEqual(result, { reason: "done", exitCode: 0 });
+    assert.equal(existsSync(`${child.sessionFile}.exit`), false);
+  });
+
+  it("treats the resumed prompt as machine input and writes a fresh sidecar", async () => {
+    const child = boot({ rearm: true, resumeInput: true });
+    child.fire("agent_start");
+    child.fire("input", { type: "input", text: "continue after the interrupt" });
+    child.fire("agent_end", { messages: [{ role: "assistant", stopReason: "stop" }] });
+    child.fire("agent_settled");
+
+    assert.equal(child.ctx.shutdowns, 1, "resume re-arms one-shot completion");
+    assert.deepEqual(JSON.parse(readFileSync(`${child.sessionFile}.exit`, "utf8")), { type: "done" });
+
+    const result = await waitForCompletion(new AbortController().signal, {
+      intervalMs: 1,
+      sessionFile: child.sessionFile,
+      readTerminalTail: async () => "",
+    });
+    assert.deepEqual(result, { reason: "done", exitCode: 0 });
+    assert.equal(existsSync(`${child.sessionFile}.exit`), false, "the fresh sidecar is consumed");
+  });
+});
+
+describe("F-108 interrupt grace configuration", () => {
+  it("marks autonomous resumes for one-shot auto-exit and prompt filtering", () => {
+    assert.deepEqual(subagentsTest.buildResumeAutoExitEnv({ autoExit: true, hasMessage: true }), [
+      "PI_SUBAGENT_AUTO_EXIT=1",
+      "PI_SUBAGENT_AUTO_EXIT_REARM=1",
+      "PI_SUBAGENT_RESUME_INPUT=1",
+    ]);
+    assert.deepEqual(subagentsTest.buildResumeAutoExitEnv({ autoExit: false, hasMessage: true }), []);
+  });
+
+  it("accepts a finite non-negative grace override and falls back safely", () => {
+    const testApi = subagentsTest;
+    assert.equal(testApi.parseInterruptGraceMs("1250"), 1250);
+    assert.equal(testApi.parseInterruptGraceMs("0"), 0);
+    assert.equal(testApi.parseInterruptGraceMs("not-a-number"), testApi.DEFAULT_INTERRUPT_GRACE_MS);
+    assert.equal(testApi.parseInterruptGraceMs("-1"), testApi.DEFAULT_INTERRUPT_GRACE_MS);
+  });
+});

--- a/test/f111-restore-flow.test.ts
+++ b/test/f111-restore-flow.test.ts
@@ -1,0 +1,321 @@
+import { afterEach, beforeEach, describe, it } from "node:test";
+import assert from "node:assert/strict";
+import {
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import subagentsExtension, { __test__ as subagentsTest } from "../pi-extension/subagents/index.ts";
+import { __herdrTest__ } from "../pi-extension/subagents/herdr.ts";
+
+const originalEnv = new Map([
+  "HERDR_ENV",
+  "HERDR_PANE_ID",
+  "HERDR_TAB_ID",
+  "HERDR_WORKSPACE_ID",
+  "PATH",
+  "PI_CODING_AGENT_DIR",
+  "PI_SUBAGENT_ID",
+  "PI_DENY_TOOLS",
+  "PI_SUBAGENT_SHELL_READY_DELAY_MS",
+  "HERDR_LOG",
+  "HERDR_PANES",
+].map((name) => [name, process.env[name]]));
+const tempRoots = new Set<string>();
+
+beforeEach(() => {
+  delete process.env.PI_SUBAGENT_ID;
+  delete process.env.PI_DENY_TOOLS;
+});
+
+function restoreEnv(): void {
+  for (const [name, value] of originalEnv) {
+    if (value == null) delete process.env[name];
+    else process.env[name] = value;
+  }
+}
+
+afterEach(() => {
+  restoreEnv();
+  subagentsTest.runningSubagents.clear();
+  for (const root of tempRoots) rmSync(root, { recursive: true, force: true });
+  tempRoots.clear();
+});
+
+function writeJsonl(path: string, entries: object[]): void {
+  writeFileSync(path, entries.map((entry) => JSON.stringify(entry)).join("\n") + "\n", "utf8");
+}
+
+function header(id: string, cwd: string, parentSession?: string): object {
+  return {
+    type: "session",
+    version: 3,
+    id,
+    timestamp: "2026-09-02T00:00:00.000Z",
+    cwd,
+    ...(parentSession ? { parentSession } : {}),
+  };
+}
+
+function report(text: string): object {
+  return {
+    type: "message",
+    id: `assistant-${text}`,
+    message: {
+      role: "assistant",
+      stopReason: "stop",
+      content: [{ type: "text", text }],
+    },
+  };
+}
+
+function sidecar(parent: string, parentId: string, child: string, name: string, task: string): void {
+  writeFileSync(`${child}.spawn.json`, JSON.stringify({
+    allowance: 0,
+    parentSessionFile: parent,
+    parentSessionId: parentId,
+    childSessionFile: child,
+    name,
+    agent: "worker",
+    task,
+    launchedAt: "2026-09-02T00:00:00.000Z",
+  }), "utf8");
+}
+
+function fakeHerdr(root: string, panes: object[]): { bin: string; log: string } {
+  const bin = join(root, "bin");
+  const command = join(bin, "herdr");
+  const log = join(root, "herdr.log");
+  mkdirSync(bin, { recursive: true });
+  writeFileSync(command, `#!/usr/bin/env python3
+import json, os, re, shlex, sys
+args = sys.argv[1:]
+with open(os.environ["HERDR_LOG"], "a", encoding="utf-8") as f:
+    f.write(" ".join(args) + "\\n")
+if args[:2] == ["pane", "list"]:
+    print(json.dumps({"result": {"type": "pane_list", "panes": json.loads(os.environ.get("HERDR_PANES", "[]"))}}))
+elif args[:2] == ["pane", "current"]:
+    print(json.dumps({"result": {"pane": {"pane_id": "parent-pane", "tab_id": "parent-tab", "workspace_id": "parent-workspace"}}}))
+elif args[:2] == ["tab", "create"]:
+    print(json.dumps({"result": {"root_pane": {"pane_id": "new-pane-" + str(os.getpid())}}}))
+elif args[:2] == ["pane", "get"]:
+    print(json.dumps({"result": {"pane": {"pane_id": args[2], "agent_status": "done"}}}))
+elif args[:2] in (["pane", "rename"], ["pane", "report-metadata"], ["pane", "close"]):
+    pass
+elif args[:2] == ["pane", "read"]:
+    print("")
+elif args[:2] == ["pane", "run"]:
+    script = args[3] if len(args) > 3 else ""
+    try:
+        script_path = shlex.split(script)[1]
+        text = open(script_path, encoding="utf-8").read()
+        match = re.search(r"PI_SUBAGENT_SESSION='([^']+)'", text)
+        if not match:
+            match = re.search(r"--session '([^']+)'", text)
+        if match:
+            session = match.group(1)
+            os.makedirs(os.path.dirname(session), exist_ok=True)
+            if not os.path.exists(session):
+                with open(session, "w", encoding="utf-8") as f:
+                    json.dump({"type": "session", "version": 3, "id": "fake-child", "cwd": os.path.dirname(session)}, f)
+                    f.write("\\n")
+            with open(session, "a", encoding="utf-8") as f:
+                json.dump({"type": "message", "id": "fake-report", "message": {"role": "assistant", "stopReason": "stop", "content": [{"type": "text", "text": "restored child report"}]}}, f)
+                f.write("\\n")
+            with open(session + ".exit", "w", encoding="utf-8") as f:
+                json.dump({"type": "done"}, f)
+    except Exception as error:
+        with open(os.environ["HERDR_LOG"], "a", encoding="utf-8") as f:
+            f.write("fake-error:" + repr(error) + "\\n")
+`, "utf8");
+  chmodSync(command, 0o755);
+  writeFileSync(log, "", "utf8");
+  process.env.HERDR_LOG = log;
+  process.env.HERDR_PANES = JSON.stringify(panes);
+  process.env.PATH = `${bin}:${originalEnv.get("PATH") ?? ""}`;
+  return { bin, log };
+}
+
+function createApi(parentSession: string, entries: object[]) {
+  const handlers = new Map<string, Function[]>();
+  const tools: any[] = [];
+  const messages: any[] = [];
+  const notifications: Array<{ message: string; type?: string }> = [];
+  const append = (entry: object) => {
+    entries.push(entry);
+    writeFileSync(parentSession, entries.map((value) => JSON.stringify(value)).join("\n") + "\n", "utf8");
+  };
+  const api = {
+    on(event: string, handler: Function) {
+      handlers.set(event, [...(handlers.get(event) ?? []), handler]);
+    },
+    registerTool(tool: any) { tools.push(tool); },
+    registerCommand() {},
+    registerMessageRenderer() {},
+    registerShortcut() {},
+    getAllTools() { return []; },
+    getThinkingLevel() { return "medium"; },
+    sendUserMessage() {},
+    sendMessage(message: any) {
+      messages.push(message);
+      append({
+        type: "custom_message",
+        id: `custom-${messages.length}`,
+        customType: message.customType,
+        content: message.content,
+        display: message.display,
+        details: message.details,
+      });
+    },
+    appendEntry(type: string, data: object) {
+      append({ type: "custom", id: `entry-${entries.length}`, customType: type, data });
+    },
+  } as any;
+  return {
+    api,
+    handlers,
+    tools,
+    messages,
+    notifications,
+    ctx: {
+      cwd: process.cwd(),
+      hasUI: true,
+      mode: "tui",
+      model: { provider: "fake", id: "parent" },
+      modelRegistry: {
+        find: (provider: string, id: string) => ({ provider, id, reasoning: true }),
+        getAvailable: () => [],
+        hasConfiguredAuth: () => true,
+      },
+      sessionManager: {
+        getSessionFile: () => parentSession,
+        getSessionId: () => "parent-id",
+        getSessionDir: () => process.cwd(),
+      },
+      ui: {
+        notify(message: string, type?: string) { notifications.push({ message, type }); },
+        setWidget() {},
+      },
+    } as any,
+  };
+}
+
+function contextFor(parent: string, root: string, entries: object[]) {
+  const built = createApi(parent, entries);
+  built.ctx.cwd = root;
+  built.ctx.sessionManager.getSessionDir = () => root;
+  return built;
+}
+
+describe("F-111.2 restore flow", () => {
+  it("injects the startup report, closes only the matching stale pane, resumes children, and is idempotent", async () => {
+    const root = mkdtempSync(join(tmpdir(), "f111-flow-"));
+    tempRoots.add(root);
+    const parent = join(root, "parent.jsonl");
+    const entries: object[] = [header("parent-id", root)];
+    writeJsonl(parent, entries);
+    const stale = join(root, "stale.jsonl");
+    const interrupted = join(root, "interrupted.jsonl");
+    const undelivered = join(root, "undelivered.jsonl");
+    for (const [path, id, name, task] of [
+      [stale, "stale-id", "Stale worker", "stale task"],
+      [interrupted, "interrupted-id", "Interrupted worker", "interrupted task"],
+      [undelivered, "undelivered-id", "Reviewer", "review task"],
+    ] as const) {
+      writeJsonl(path, [header(id, root, parent)]);
+      sidecar(parent, "parent-id", path, name, task);
+    }
+    writeJsonl(undelivered, [header("undelivered-id", root, parent), report("stored reviewer report")]);
+    writeFileSync(`${undelivered}.exit`, JSON.stringify({ type: "done" }), "utf8");
+
+    const { log } = fakeHerdr(root, [
+      { pane_id: "stale-pane", agent_session: { kind: "path", value: stale } },
+      { pane_id: "crew-pane", agent_session: { kind: "path", value: join(root, "crew.jsonl") } },
+    ]);
+    process.env.HERDR_ENV = "1";
+    process.env.HERDR_PANE_ID = "parent-pane";
+    process.env.HERDR_TAB_ID = "parent-tab";
+    process.env.HERDR_WORKSPACE_ID = "parent-workspace";
+    process.env.PI_CODING_AGENT_DIR = join(root, "agent");
+    process.env.PI_SUBAGENT_SHELL_READY_DELAY_MS = "0";
+    __herdrTest__.clearCommandAvailability();
+
+    const first = contextFor(parent, root, entries);
+    subagentsExtension(first.api);
+    const start = first.handlers.get("session_start")?.[0];
+    assert.ok(start);
+    start({}, first.ctx);
+    assert.equal(first.messages.length, 1);
+    const startupReport = first.messages[0].content as string;
+    for (const text of ["Stale worker", "Interrupted worker", "Reviewer", "stored reviewer report", "stale-pane", "completed-undelivered"]) {
+      assert.match(startupReport, new RegExp(text.replace(/[.*+?^${}()|[\\]\\]/g, "\\$&")));
+    }
+
+    const input = first.handlers.get("input")?.[0];
+    assert.ok(input);
+    const inputResult = await input({ text: "resume", source: "interactive" }, first.ctx);
+    assert.deepEqual(inputResult, { action: "handled" });
+    const logText = readFileSync(log, "utf8");
+    assert.match(logText, /pane close stale-pane/);
+    assert.doesNotMatch(logText, /pane close crew-pane/);
+    assert.match(logText, /pane run/);
+
+    await new Promise((resolve) => setTimeout(resolve, 100));
+    const delivered = first.messages.filter((message) => message.customType === "subagent_result");
+    assert.equal(delivered.length, 2, "both resumed children should auto-deliver results");
+
+    const second = contextFor(parent, root, entries);
+    subagentsExtension(second.api);
+    const secondStart = second.handlers.get("session_start")?.[0];
+    assert.ok(secondStart);
+    secondStart({}, second.ctx);
+    assert.equal(second.messages.length, 0, "handled children must not be reported on restart");
+  });
+
+  it("relaunches a phantom through subagent with its recorded task", async () => {
+    const root = mkdtempSync(join(tmpdir(), "f111-phantom-flow-"));
+    tempRoots.add(root);
+    const parent = join(root, "parent.jsonl");
+    const entries: object[] = [header("parent-id", root)];
+    writeJsonl(parent, entries);
+    const phantom = join(root, "phantom.jsonl");
+    sidecar(parent, "parent-id", phantom, "Phantom", "relaunch this exact task");
+
+    const { log } = fakeHerdr(root, []);
+    process.env.HERDR_ENV = "1";
+    process.env.HERDR_PANE_ID = "parent-pane";
+    process.env.HERDR_TAB_ID = "parent-tab";
+    process.env.HERDR_WORKSPACE_ID = "parent-workspace";
+    process.env.PI_CODING_AGENT_DIR = join(root, "agent");
+    process.env.PI_SUBAGENT_SHELL_READY_DELAY_MS = "0";
+    __herdrTest__.clearCommandAvailability();
+
+    const built = contextFor(parent, root, entries);
+    subagentsExtension(built.api);
+    const start = built.handlers.get("session_start")?.[0];
+    assert.ok(start);
+    start({}, built.ctx);
+    assert.match(built.messages[0].content, /relaunch this exact task/);
+
+    const input = built.handlers.get("input")?.[0];
+    assert.ok(input);
+    assert.deepEqual(await input({ text: "resume", source: "interactive" }, built.ctx), { action: "handled" });
+    const scripts = readdirSync(join(root, "artifacts", "parent-id", "subagent-scripts"));
+    assert.equal(scripts.length, 1);
+    const launchScript = readFileSync(join(root, "artifacts", "parent-id", "subagent-scripts", scripts[0]), "utf8");
+    assert.match(launchScript, /Subagent launch script/);
+    assert.doesNotMatch(launchScript, /Subagent resume script/);
+    const contextFiles = readdirSync(join(root, "artifacts", "parent-id", "context"));
+    assert.ok(contextFiles.some((file) => readFileSync(join(root, "artifacts", "parent-id", "context", file), "utf8").includes("relaunch this exact task")));
+    assert.match(readFileSync(log, "utf8"), /pane run/);
+    await new Promise((resolve) => setTimeout(resolve, 100));
+    assert.equal(existsSync(phantom), false, "the original phantom path is not materialized by resume");
+  });
+});

--- a/test/harness-drivers.test.ts
+++ b/test/harness-drivers.test.ts
@@ -134,6 +134,10 @@ describe("Pi Harness Driver", () => {
     assert.ok(built.command.includes("pi --session '/tmp/sessions/subagent.jsonl'"));
     assert.ok(built.command.includes("--model 'anthropic/claude-sonnet-4-5'"));
     assert.ok(built.command.includes("--thinking 'high'"));
+    assert.ok(
+      built.command.includes("PI_SUBAGENT_ACTIVITY_FILE='/tmp/artifacts/subagent-activity/abc12345.json'"),
+      "the child and parent must use the same activity file for idle-timeout supervision",
+    );
     assert.ok(built.command.includes("echo '__SUBAGENT_DONE_'$?'__'"));
   });
 });

--- a/test/harness-drivers.test.ts
+++ b/test/harness-drivers.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
-import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import {
@@ -139,6 +139,59 @@ describe("Pi Harness Driver", () => {
       "the child and parent must use the same activity file for idle-timeout supervision",
     );
     assert.ok(built.command.includes("echo '__SUBAGENT_DONE_'$?'__'"));
+  });
+
+  it("keeps task and system-prompt artifacts unique per spawn", () => {
+    const artifactDir = mkdtempSync(join(tmpdir(), "f113-artifacts-"));
+    try {
+      const taskA = driver.buildCommand(createMockLaunchContext({
+        artifactDir,
+        taskDelivery: "artifact",
+        params: { id: "a1111111", name: "backend", task: "BRIEF A" },
+      }));
+      const taskB = driver.buildCommand(createMockLaunchContext({
+        artifactDir,
+        taskDelivery: "artifact",
+        params: { id: "b2222222", name: "backend", task: "BRIEF B" },
+      }));
+      const taskPathA = taskA.command.match(/'@([^']+\/context\/[^']+\.md)'/)?.[1];
+      const taskPathB = taskB.command.match(/'@([^']+\/context\/[^']+\.md)'/)?.[1];
+
+      assert.ok(taskPathA);
+      assert.ok(taskPathB);
+      assert.notEqual(taskPathA, taskPathB);
+      assert.equal(existsSync(taskPathA), true);
+      assert.equal(existsSync(taskPathB), true);
+      assert.match(readFileSync(taskPathA, "utf8"), /BRIEF A/);
+      assert.match(readFileSync(taskPathB, "utf8"), /BRIEF B/);
+
+      const systemPromptA = driver.buildCommand(createMockLaunchContext({
+        artifactDir,
+        taskDelivery: "artifact",
+        identity: "IDENTITY A",
+        identityInSystemPrompt: true,
+        params: { id: "c3333333", name: "backend", task: "BRIEF C" },
+      }));
+      const systemPromptB = driver.buildCommand(createMockLaunchContext({
+        artifactDir,
+        taskDelivery: "artifact",
+        identity: "IDENTITY B",
+        identityInSystemPrompt: true,
+        params: { id: "d4444444", name: "backend", task: "BRIEF D" },
+      }));
+      const systemPromptPathA = systemPromptA.command.match(/--(?:append-)?system-prompt '([^']+\/context\/[^']+\.md)'/)?.[1];
+      const systemPromptPathB = systemPromptB.command.match(/--(?:append-)?system-prompt '([^']+\/context\/[^']+\.md)'/)?.[1];
+
+      assert.ok(systemPromptPathA);
+      assert.ok(systemPromptPathB);
+      assert.notEqual(systemPromptPathA, systemPromptPathB);
+      assert.equal(existsSync(systemPromptPathA), true);
+      assert.equal(existsSync(systemPromptPathB), true);
+      assert.equal(readFileSync(systemPromptPathA, "utf8"), "IDENTITY A");
+      assert.equal(readFileSync(systemPromptPathB, "utf8"), "IDENTITY B");
+    } finally {
+      rmSync(artifactDir, { recursive: true, force: true });
+    }
   });
 });
 

--- a/test/orphan-discovery.test.ts
+++ b/test/orphan-discovery.test.ts
@@ -1,0 +1,282 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import {
+  discoverOrphanedSubagents,
+  formatOrphanRestoreReport,
+  isRestorableOrphan,
+  resumeOrphanedSubagents,
+  type DiscoveredOrphan,
+} from "../pi-extension/subagents/orphan-discovery.ts";
+import { __test__ as subagentsTest } from "../pi-extension/subagents/index.ts";
+
+function fixtureDir(): string {
+  return mkdtempSync(join(tmpdir(), "f111-orphan-"));
+}
+
+function writeJsonl(path: string, entries: object[]): void {
+  writeFileSync(path, entries.map((entry) => JSON.stringify(entry)).join("\n") + "\n", "utf8");
+}
+
+function childHeader(parentSession: string, id: string) {
+  return { type: "session", version: 3, id, timestamp: "2026-09-02T00:00:00.000Z", parentSession };
+}
+
+function spawnSidecar(parentSession: string, parentId: string, childSession: string, name: string, task: string) {
+  writeFileSync(`${childSession}.spawn.json`, JSON.stringify({
+    allowance: 2,
+    parentSessionFile: parentSession,
+    parentSessionId: parentId,
+    childSessionFile: childSession,
+    name,
+    agent: "worker",
+    task,
+    launchedAt: "2026-09-02T00:00:00.000Z",
+  }), "utf8");
+}
+
+function childReport(text: string) {
+  return {
+    type: "message",
+    id: `assistant-${text}`,
+    message: {
+      role: "assistant",
+      stopReason: "stop",
+      content: [{ type: "text", text }],
+    },
+  };
+}
+
+describe("F-111.1 orphan discovery", () => {
+  it("deduplicates all disk sources and classifies the five-state matrix", () => {
+    const root = fixtureDir();
+    try {
+      const parent = join(root, "parent.jsonl");
+      writeJsonl(parent, [{ type: "session", version: 3, id: "parent-id", cwd: root }]);
+
+      const delivered = join(root, "delivered.jsonl");
+      writeJsonl(delivered, [childHeader(parent, "delivered-id"), childReport("delivered report")]);
+      spawnSidecar(parent, "parent-id", delivered, "Delivered", "already delivered task");
+      writeJsonl(parent, [{
+        type: "session", version: 3, id: "parent-id", cwd: root,
+      }, {
+        type: "custom_message",
+        customType: "subagent_result",
+        content: "Subagent completed",
+        details: { sessionFile: delivered },
+      }]);
+
+      const undelivered = join(root, "undelivered.jsonl");
+      writeJsonl(undelivered, [childHeader(parent, "undelivered-id"), childReport("stored final report")]);
+      writeFileSync(`${undelivered}.exit`, JSON.stringify({ type: "done" }), "utf8");
+      spawnSidecar(parent, "parent-id", undelivered, "Undelivered", "report task");
+
+      const interrupted = join(root, "interrupted.jsonl");
+      writeJsonl(interrupted, [childHeader(parent, "interrupted-id"), {
+        type: "message",
+        id: "user-interrupted",
+        message: { role: "user", content: [{ type: "text", text: "start work" }] },
+      }]);
+      spawnSidecar(parent, "parent-id", interrupted, "Interrupted", "resume task");
+
+      const phantom = join(root, "phantom.jsonl");
+      spawnSidecar(parent, "parent-id", phantom, "Phantom", "relaunch task");
+
+      const stale = join(root, "stale.jsonl");
+      writeJsonl(stale, [childHeader(parent, "stale-id"), {
+        type: "message",
+        id: "user-stale",
+        message: { role: "user", content: [{ type: "text", text: "start stale" }] },
+      }]);
+      spawnSidecar(parent, "parent-id", stale, "Stale", "stale task");
+
+      const found = discoverOrphanedSubagents(parent, {
+        paneSessions: [{ paneId: "pane-stale", sessionPath: stale }],
+      });
+      assert.equal(found.length, 5);
+      const byName = new Map(found.map((child) => [child.name, child]));
+      assert.equal(byName.get("Delivered")?.classification, "completed-delivered");
+      assert.equal(byName.get("Undelivered")?.classification, "completed-undelivered");
+      assert.equal(byName.get("Undelivered")?.report, "stored final report");
+      assert.equal(byName.get("Interrupted")?.classification, "interrupted");
+      assert.equal(byName.get("Phantom")?.classification, "phantom");
+      assert.equal(byName.get("Stale")?.classification, "stale-pane");
+      assert.deepEqual(byName.get("Stale")?.stalePaneIds, ["pane-stale"]);
+      assert.deepEqual(byName.get("Delivered")?.sources, ["sidecar", "session"]);
+      assert.equal(isRestorableOrphan(byName.get("Delivered")!), false);
+      assert.equal(isRestorableOrphan(byName.get("Interrupted")!), true);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("does not mistake copied fork context for a completed child", () => {
+    const root = fixtureDir();
+    try {
+      const parent = join(root, "parent.jsonl");
+      const parentEntries = [
+        { type: "session", version: 3, id: "fork-parent", cwd: root },
+        { type: "message", id: "parent-user", message: { role: "user", content: [{ type: "text", text: "parent work" }] } },
+        { type: "message", id: "parent-assistant", message: { role: "assistant", stopReason: "stop", content: [{ type: "text", text: "parent answer" }] } },
+      ];
+      writeJsonl(parent, parentEntries);
+      const child = join(root, "fork-child.jsonl");
+      writeJsonl(child, [childHeader(parent, "fork-child-id"), ...parentEntries.slice(1)]);
+      spawnSidecar(parent, "fork-parent", child, "Fork", "fork task");
+
+      const [found] = discoverOrphanedSubagents(parent);
+      assert.equal(found.classification, "interrupted");
+      assert.equal(found.report, undefined);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("uses artifact launch scripts as a fallback and recovers task text", () => {
+    const root = fixtureDir();
+    try {
+      const parent = join(root, "parent.jsonl");
+      writeJsonl(parent, [{ type: "session", version: 3, id: "artifact-parent", cwd: root }]);
+      const child = join(root, "other-sessions", "child.jsonl");
+      mkdirSync(join(root, "artifacts", "artifact-parent", "subagent-scripts"), { recursive: true });
+      mkdirSync(join(root, "other-sessions"), { recursive: true });
+      writeJsonl(child, [childHeader(parent, "artifact-child"), {
+        type: "message",
+        id: "child-user",
+        message: { role: "user", content: [{ type: "text", text: "work" }] },
+      }]);
+      const taskArtifact = join(root, "artifacts", "artifact-parent", "task.md");
+      writeFileSync(taskArtifact, "Recover the child from its durable task artifact", "utf8");
+      writeFileSync(
+        join(root, "artifacts", "artifact-parent", "subagent-scripts", "worker.sh"),
+        `#!/bin/bash\n# Subagent launch script for Worker\n# Session: ${child}\npi @${taskArtifact}\n`,
+        "utf8",
+      );
+
+      const [found] = discoverOrphanedSubagents(parent);
+      assert.equal(found.name, "Worker");
+      assert.equal(found.sessionFile, child);
+      assert.equal(found.task, "Recover the child from its durable task artifact");
+      assert.equal(found.classification, "interrupted");
+      assert.ok(found.sources.includes("artifact"));
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("survives malformed sidecars and truncated session tails conservatively", () => {
+    const root = fixtureDir();
+    try {
+      const parent = join(root, "parent.jsonl");
+      writeJsonl(parent, [{ type: "session", version: 3, id: "safe-parent", cwd: root }]);
+      const child = join(root, "partial.jsonl");
+      writeFileSync(
+        child,
+        `${JSON.stringify(childHeader(parent, "partial-child"))}\n{"type":"message","id":"partial","message":`,
+        "utf8",
+      );
+      writeFileSync(`${child}.spawn.json`, "{\"parentSessionFile\":", "utf8");
+
+      assert.doesNotThrow(() => discoverOrphanedSubagents(parent));
+      const [found] = discoverOrphanedSubagents(parent);
+      assert.equal(found.classification, "interrupted");
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("writes enriched spawn metadata atomically without leaving temp files", () => {
+    const root = fixtureDir();
+    try {
+      const child = join(root, "child.jsonl");
+      subagentsTest.writeSpawnMetadata(child, {
+        allowance: 0,
+        parentSessionFile: join(root, "parent.jsonl"),
+        parentSessionId: "parent",
+        childSessionFile: child,
+        name: "Worker",
+        task: "atomic task",
+        launchedAt: "2026-09-02T00:00:00.000Z",
+      });
+      assert.deepEqual(JSON.parse(readFileSync(`${child}.spawn.json`, "utf8")), {
+        allowance: 0,
+        parentSessionFile: join(root, "parent.jsonl"),
+        parentSessionId: "parent",
+        childSessionFile: child,
+        name: "Worker",
+        task: "atomic task",
+        launchedAt: "2026-09-02T00:00:00.000Z",
+      });
+      assert.deepEqual(readdirSync(root).filter((name) => name.endsWith(".tmp")), []);
+      assert.equal(existsSync(`${child}.spawn.json`), true);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("F-111.2 restore orchestration primitives", () => {
+  function child(classification: DiscoveredOrphan["classification"], paneIds: string[] = []): DiscoveredOrphan {
+    return {
+      sessionFile: `/sessions/${classification}.jsonl`,
+      name: classification,
+      task: `${classification} task`,
+      classification,
+      stalePaneIds: paneIds,
+      handled: false,
+      sources: ["sidecar"],
+    };
+  }
+
+  it("closes only discovered stale panes before resuming, and relaunches phantoms", async () => {
+    const calls: string[] = [];
+    const outcomes = await resumeOrphanedSubagents([
+      child("stale-pane", ["child-pane"]),
+      child("interrupted"),
+      child("phantom"),
+      child("completed-undelivered"),
+      { ...child("interrupted"), handled: true },
+    ], {
+      closePane: (paneId) => calls.push(`close:${paneId}`),
+      resume: async (orphan) => { calls.push(`resume:${orphan.name}`); return orphan.sessionFile; },
+      relaunch: async (orphan) => { calls.push(`relaunch:${orphan.name}`); return orphan.sessionFile; },
+    });
+
+    assert.deepEqual(calls, [
+      "close:child-pane",
+      "resume:stale-pane",
+      "resume:interrupted",
+      "relaunch:phantom",
+    ]);
+    assert.deepEqual(outcomes.map((outcome) => [outcome.action, outcome.ok]), [
+      ["resume", true],
+      ["resume", true],
+      ["relaunch", true],
+    ]);
+  });
+
+  it("formats a passive startup report with the restore contract and stored report", () => {
+    const report = formatOrphanRestoreReport([
+      { ...child("interrupted"), name: "Worker", agent: "worker", task: "finish the migration" },
+      { ...child("completed-undelivered"), name: "Reviewer", task: "review changes", report: "Review is complete." },
+      child("completed-delivered"),
+    ]);
+    assert.match(report, /Worker.*worker.*finish the migration/);
+    assert.match(report, /Classification: interrupted/);
+    assert.match(report, /Reviewer/);
+    assert.match(report, /stored final report/i);
+    assert.match(report, /Review is complete\./);
+    assert.match(report, /when the user sends "resume"/);
+    assert.doesNotMatch(report, /Classification: completed-delivered/);
+  });
+});

--- a/test/recovery-ladder.test.ts
+++ b/test/recovery-ladder.test.ts
@@ -1,0 +1,211 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import * as subagentsModule from "../pi-extension/subagents/index.ts";
+import {
+  DEFAULT_RECOVERY_DELAYS,
+  advanceRecoveryLadder,
+  parseRecoveryDelays,
+  type RecoveryState,
+} from "../pi-extension/subagents/recovery.ts";
+import {
+  createLifecycle,
+  observeActivity,
+  observePaneInspection,
+  projectLifecycle,
+} from "../pi-extension/subagents/lifecycle.ts";
+
+const delays = [30_000, 60_000, 90_000] as const;
+
+function makeRunning(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "child-1",
+    name: "Worker",
+    task: "Recover the provider failure",
+    surface: "pane-1",
+    startTime: 0,
+    sessionFile: "/tmp/worker.jsonl",
+    interactive: false,
+    lifecycle: createLifecycle(0),
+    ...overrides,
+  };
+}
+
+describe("recovery delay parsing", () => {
+  it("uses defaults for missing or malformed values and clamps short stages", () => {
+    for (const [raw, expected] of [
+      [undefined, DEFAULT_RECOVERY_DELAYS],
+      ["", DEFAULT_RECOVERY_DELAYS],
+      ["30000,60000", DEFAULT_RECOVERY_DELAYS],
+      ["30000,wat,90000", DEFAULT_RECOVERY_DELAYS],
+      ["30000,60000,90000,120000", DEFAULT_RECOVERY_DELAYS],
+      ["30000,60000,90000.5", DEFAULT_RECOVERY_DELAYS],
+      [" 12000, 22000, 32000 ", [12_000, 22_000, 32_000]],
+      ["1,9999,-2", [10_000, 10_000, 10_000]],
+    ] as const) {
+      assert.deepEqual(parseRecoveryDelays(raw), expected, String(raw));
+    }
+  });
+});
+
+describe("recovery ladder", () => {
+  it("advances wait, nudge, escalation, and kill from injected fake-clock ticks", () => {
+    let now = 0;
+    let state: RecoveryState | undefined;
+    const tick = (nextNow: number, stalled = true, exempt = false) => {
+      now = nextNow;
+      const advance = advanceRecoveryLadder(state, { now, stalled, exempt, delays });
+      state = advance.state;
+      return advance;
+    };
+
+    assert.deepEqual(tick(0), { state: { stage: "waiting", stageSince: 0 }, action: null });
+    assert.equal(tick(29_999).action, null);
+    assert.deepEqual(tick(30_000), { state: { stage: "nudged", stageSince: 30_000 }, action: "nudge" });
+    assert.equal(tick(30_001).action, null);
+    assert.equal(tick(89_999).action, null);
+    assert.deepEqual(tick(90_000), { state: { stage: "escalated", stageSince: 90_000 }, action: "escalate" });
+    assert.equal(tick(179_999).action, null);
+    assert.deepEqual(tick(180_000), { state: { stage: "killed", stageSince: 180_000 }, action: "kill" });
+    assert.equal(tick(999_999).action, null, "terminal recovery state must be a no-op");
+  });
+
+  it("uses injected pane operations, tears down once, and reports recovery-kill as a failure", () => {
+    const testApi = (subagentsModule as any).__test__;
+    const running = makeRunning({
+      abortController: {
+        abort() {
+          aborts += 1;
+        },
+      },
+    });
+    let nudges = 0;
+    let closes = 0;
+    let aborts = 0;
+    const operations = {
+      interruptPane(surface: string) {
+        assert.equal(surface, "pane-1");
+        nudges += 1;
+      },
+      closePane(surface: string) {
+        assert.equal(surface, "pane-1");
+        closes += 1;
+      },
+      abortWatcher() {
+        assert.match(running.recoveryKilled?.errorMessage ?? "", /recovery-kill after 180s/);
+        running.abortController.abort();
+      },
+    };
+
+    for (const now of [0, 30_000, 90_000, 180_000]) {
+      testApi.advanceRunningRecovery(running, { kind: "stalled" }, now, delays, operations);
+    }
+
+    assert.equal(nudges, 1);
+    assert.equal(closes, 1);
+    assert.equal(aborts, 1);
+    assert.equal(running.recovery.stage, "killed");
+    assert.equal(running.lifecycle.process.kind, "failed");
+    assert.match(running.lifecycle.process.error, /recovery-kill after 180s/);
+
+    const result = testApi.buildRecoveryKilledResult(running, 180_001);
+    assert.equal(result.exitCode, 1);
+    assert.equal(result.error, running.lifecycle.process.error);
+    assert.match(result.errorMessage, /recovery-kill after 180s/);
+    assert.match(result.summary, /recovery-kill/);
+    assert.doesNotMatch(result.summary, /cancelled|wrap-up|completed/i);
+
+    const presentation = testApi.resolveResultPresentation(result, running.name);
+    assert.match(presentation, /failed/);
+    assert.doesNotMatch(presentation, /completed/);
+
+    const repeated = testApi.advanceRunningRecovery(running, { kind: "stalled" }, 999_999, delays, operations);
+    assert.equal(repeated.action, null, "terminal recovery state must not produce a duplicate result");
+    assert.equal(closes, 1, "repeated ticks must not close a pane twice");
+    assert.equal(aborts, 1, "repeated ticks must not abort twice");
+    running.lifecycle = { ...running.lifecycle, delivery: "delivered" };
+    assert.equal(subagentsModule.shouldDeliverSubagentCompletion(running), false);
+  });
+
+  it("does not arm interactive or wrap-up children", () => {
+    const testApi = (subagentsModule as any).__test__;
+    for (const overrides of [{ interactive: true }, { wrapupPending: true }]) {
+      const running = makeRunning(overrides);
+      let paneCalls = 0;
+      const advance = testApi.advanceRunningRecovery(
+        running,
+        { kind: "stalled" },
+        1_000_000,
+        delays,
+        {
+          interruptPane() {
+            paneCalls += 1;
+          },
+          closePane() {
+            paneCalls += 1;
+          },
+          abortWatcher() {
+            paneCalls += 1;
+          },
+        },
+      );
+      assert.equal(advance.action, null);
+      assert.equal(running.recovery, undefined);
+      assert.equal(paneCalls, 0);
+    }
+  });
+
+  it("never advances healthy tool, streaming, or provider activity despite long runtime", () => {
+    const testApi = (subagentsModule as any).__test__;
+    for (const scope of ["tool", "streaming", "provider"] as const) {
+      const now = 1_000_000;
+      let lifecycle = createLifecycle(0);
+      lifecycle = observePaneInspection(lifecycle, {
+        kind: "present",
+        observedAt: now,
+        agentStatus: "working",
+      }, now);
+      lifecycle = observeActivity(lifecycle, {
+        ok: true,
+        activity: {
+          version: 1,
+          runningChildId: "child-1",
+          createdAt: 0,
+          updatedAt: now,
+          sequence: 1,
+          latestEvent: "agent_start",
+          phase: "active",
+          agentActive: true,
+          turnActive: true,
+          providerActive: scope === "provider",
+          toolActive: scope === "tool",
+          activeScope: scope,
+          activeSince: now,
+          ...(scope === "tool" ? { toolName: "bash", toolStartedAt: now } : {}),
+        },
+      }, now);
+      const projection = projectLifecycle(lifecycle, now + 1);
+      assert.equal(projection.kind, "active", scope);
+
+      const running = makeRunning({ lifecycle });
+      const advance = testApi.advanceRunningRecovery(
+        running,
+        projection,
+        now + delays[0] + delays[1] + delays[2] + 1,
+        delays,
+        {
+          interruptPane() {
+            throw new Error("healthy activity must not be nudged");
+          },
+          closePane() {
+            throw new Error("healthy activity must not be killed");
+          },
+          abortWatcher() {
+            throw new Error("healthy activity must not be aborted");
+          },
+        },
+      );
+      assert.equal(advance.action, null, scope);
+      assert.equal(running.recovery, undefined, scope);
+    }
+  });
+});

--- a/test/spawn-grants.test.ts
+++ b/test/spawn-grants.test.ts
@@ -6,6 +6,7 @@ import { tmpdir } from "node:os";
 import { PiHarnessDriver } from "../pi-extension/subagents/harness/index.ts";
 import type { SubagentLaunchContext } from "../pi-extension/subagents/harness/types.ts";
 import * as subagentsModule from "../pi-extension/subagents/index.ts";
+import subagentsExtension from "../pi-extension/subagents/index.ts";
 
 const testApi = (subagentsModule as any).__test__;
 const SPAWNING_TOOLS = [...testApi.SPAWNING_TOOLS as Set<string>].sort();
@@ -208,5 +209,83 @@ describe("termination regression", () => {
     assert.equal(testApi.blockedSelfSpawn("planner", "scout"), false);
     assert.equal(testApi.blockedSelfSpawn(undefined, "scout"), false);
     assert.equal(testApi.blockedSelfSpawn("scout", undefined), false);
+  });
+});
+
+describe("self-spawn guard via the real registered tool execute()", () => {
+  function registerExtensionAndGetTools() {
+    const tools = new Map<string, any>();
+    // Registration-time calls only; handler bodies never run in these tests.
+    const mockPi = {
+      on: () => {},
+      registerTool: (tool: any) => tools.set(tool.name, tool),
+      registerCommand: () => {},
+      registerMessageRenderer: () => {},
+      sendMessage: () => {},
+      sendUserMessage: () => {},
+      getThinkingLevel: () => "off",
+    };
+    // Strip child-agent env so no spawning tools look denied during registration.
+    const savedId = process.env.PI_SUBAGENT_ID;
+    const savedDeny = process.env.PI_DENY_TOOLS;
+    delete process.env.PI_SUBAGENT_ID;
+    delete process.env.PI_DENY_TOOLS;
+    try {
+      subagentsExtension(mockPi as any);
+    } finally {
+      if (savedId === undefined) delete process.env.PI_SUBAGENT_ID;
+      else process.env.PI_SUBAGENT_ID = savedId;
+      if (savedDeny === undefined) delete process.env.PI_DENY_TOOLS;
+      else process.env.PI_DENY_TOOLS = savedDeny;
+    }
+    return tools;
+  }
+
+  it("returns guidance text instead of throwing when an agent spawns itself", async () => {
+    const previousAgent = process.env.PI_SUBAGENT_AGENT;
+    process.env.PI_SUBAGENT_AGENT = "planner";
+    try {
+      const tool = registerExtensionAndGetTools().get("subagent");
+      assert.ok(tool, "subagent tool must be registered");
+
+      const result = await tool.execute(
+        "test-call",
+        { name: "dup", task: "do work", agent: "planner" },
+        undefined,
+        undefined,
+        {},
+      );
+
+      const text = result.content[0].text as string;
+      assert.match(text, /You are the planner agent/);
+      assert.match(text, /do not start another planner/);
+      assert.deepEqual(result.details, { error: "self-spawn blocked" });
+    } finally {
+      if (previousAgent === undefined) delete process.env.PI_SUBAGENT_AGENT;
+      else process.env.PI_SUBAGENT_AGENT = previousAgent;
+    }
+  });
+
+  it("does not block spawning a different agent", async () => {
+    process.env.PI_SUBAGENT_AGENT = "planner";
+    try {
+      const tool = registerExtensionAndGetTools().get("subagent");
+      assert.ok(tool);
+
+      await assert.rejects(
+        () =>
+          tool.execute(
+            "test-call",
+            { name: "s", task: "t", agent: "scout" },
+            undefined,
+            undefined,
+            {},
+          ),
+        // Guard passes; execution then fails later on missing prerequisites.
+        // Any throw proves it got past the self-spawn guard without one.
+      );
+    } finally {
+      delete process.env.PI_SUBAGENT_AGENT;
+    }
   });
 });

--- a/test/spawn-grants.test.ts
+++ b/test/spawn-grants.test.ts
@@ -1,6 +1,7 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
-import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
+import { createHash } from "node:crypto";
+import { mkdtempSync, readFileSync, writeFileSync, rmSync, mkdirSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { PiHarnessDriver } from "../pi-extension/subagents/harness/index.ts";
@@ -209,6 +210,83 @@ describe("termination regression", () => {
     assert.equal(testApi.blockedSelfSpawn("planner", "scout"), false);
     assert.equal(testApi.blockedSelfSpawn(undefined, "scout"), false);
     assert.equal(testApi.blockedSelfSpawn("scout", undefined), false);
+  });
+});
+
+describe("resume session cwd preflight", () => {
+  it("heals a missing cwd and preserves every byte after the header", () => {
+    const dir = mkdtempSync(join(tmpdir(), "resume-cwd-test-"));
+    try {
+      const sessionFile = join(dir, "session.jsonl");
+      const resumeCwd = join(dir, "resuming");
+      mkdirSync(resumeCwd);
+      const header = {
+        type: "session",
+        version: 3,
+        id: "session-id",
+        timestamp: "2026-08-26T00:00:00.000Z",
+        cwd: join(dir, "pruned-worktree"),
+      };
+      const tail = `{"type":"message","id":"message-id","payload":"preserve me"}\n{"type":"turn_end","id":"turn-end-id"}\n`;
+      writeFileSync(sessionFile, JSON.stringify(header) + "\n" + tail, "utf8");
+      const before = readFileSync(sessionFile);
+      const firstNewline = before.indexOf(0x0a);
+      const tailHash = createHash("sha256").update(before.subarray(firstNewline + 1)).digest("hex");
+
+      const result = testApi.ensureResumeSessionCwd(sessionFile, resumeCwd);
+
+      assert.deepEqual(result, { ok: true, healed: true });
+      const after = readFileSync(sessionFile);
+      assert.equal(
+        createHash("sha256").update(after.subarray(after.indexOf(0x0a) + 1)).digest("hex"),
+        tailHash,
+      );
+      const healedHeader = JSON.parse(after.subarray(0, after.indexOf(0x0a)).toString("utf8"));
+      assert.equal(healedHeader.cwd, resumeCwd);
+      assert.equal(healedHeader.type, header.type);
+      assert.equal(healedHeader.id, header.id);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("leaves a session with an existing cwd byte-identical", () => {
+    const dir = mkdtempSync(join(tmpdir(), "resume-cwd-test-"));
+    try {
+      const sessionFile = join(dir, "session.jsonl");
+      const header = {
+        type: "session",
+        cwd: dir,
+        id: "existing-cwd",
+      };
+      const original = Buffer.from(JSON.stringify(header) + "\r\nsecond line\n", "utf8");
+      writeFileSync(sessionFile, original);
+
+      const result = testApi.ensureResumeSessionCwd(sessionFile, join(dir, "other"));
+
+      assert.deepEqual(result, { ok: true, healed: false });
+      assert.deepEqual(readFileSync(sessionFile), original);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("blocks a corrupt header before resume can launch", () => {
+    const dir = mkdtempSync(join(tmpdir(), "resume-cwd-test-"));
+    try {
+      const sessionFile = join(dir, "session.jsonl");
+      const original = Buffer.from("{not valid json\n{\"type\":\"message\"}\n", "utf8");
+      writeFileSync(sessionFile, original);
+
+      const result = testApi.ensureResumeSessionCwd(sessionFile, dir);
+
+      assert.equal(result.ok, false);
+      if (result.ok) assert.fail("corrupt headers must block resume");
+      assert.match(result.error, /parse.*header|header.*parse/i);
+      assert.deepEqual(readFileSync(sessionFile), original);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
   });
 });
 

--- a/test/spawn-grants.test.ts
+++ b/test/spawn-grants.test.ts
@@ -1,0 +1,212 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { PiHarnessDriver } from "../pi-extension/subagents/harness/index.ts";
+import type { SubagentLaunchContext } from "../pi-extension/subagents/harness/types.ts";
+import * as subagentsModule from "../pi-extension/subagents/index.ts";
+
+const testApi = (subagentsModule as any).__test__;
+const SPAWNING_TOOLS = [...testApi.SPAWNING_TOOLS as Set<string>].sort();
+
+function createMockLaunchContext(overrides?: Partial<SubagentLaunchContext>): SubagentLaunchContext {
+  return {
+    params: {
+      id: "abc12345",
+      name: "worker",
+      task: "Analyze the repository structure",
+    },
+    runtimePlan: {
+      provider: "anthropic",
+      modelId: "claude-sonnet-4-5",
+      model: "anthropic/claude-sonnet-4-5",
+      thinking: "medium",
+      modelSource: "request",
+      thinkingSource: "request",
+    },
+    effectiveModel: "anthropic/claude-sonnet-4-5",
+    effectiveThinking: "medium",
+    parentThinking: "medium",
+    surface: "pane-1",
+    artifactDir: "/tmp/artifacts",
+    sessionDir: "/tmp/sessions",
+    subagentSessionFile: "/tmp/sessions/subagent.jsonl",
+    effectiveCwd: "/tmp/project",
+    effectiveAutoExit: true,
+    effectiveInteractive: false,
+    inheritsConversationContext: true,
+    taskDelivery: "direct",
+    subagentsDir: "/path/to/subagents",
+    shellQuote: (s: string) => `'${s.replace(/'/g, "'\\''")}'`,
+    ...overrides,
+  };
+}
+
+describe("resolveDenyTools — deny-by-default spawn grants", () => {
+  it("denies all spawning tools by default (no agent defs, bare spawn)", () => {
+    const denied = testApi.resolveDenyTools(null);
+    for (const tool of SPAWNING_TOOLS) assert.equal(denied.has(tool), true, `expected ${tool} denied`);
+  });
+
+  it("denies all spawning tools when frontmatter omits `spawning`", () => {
+    const denied = testApi.resolveDenyTools({ name: "worker" });
+    for (const tool of SPAWNING_TOOLS) assert.equal(denied.has(tool), true);
+  });
+
+  it("denies all spawning tools when frontmatter sets spawning:false", () => {
+    const denied = testApi.resolveDenyTools({ spawning: false });
+    for (const tool of SPAWNING_TOOLS) assert.equal(denied.has(tool), true);
+  });
+
+  it("grants spawning tools only with explicit spawning:true and remaining depth", () => {
+    const granted = testApi.resolveDenyTools({ spawning: true }, null);
+    for (const tool of SPAWNING_TOOLS) assert.equal(granted.has(tool), false);
+    assert.equal(testApi.resolveDenyTools({ spawning: true }, 3).size, 0);
+  });
+
+  it("remaining 0 denies spawning despite a frontmatter grant", () => {
+    const denied = testApi.resolveDenyTools({ spawning: true }, 0);
+    for (const tool of SPAWNING_TOOLS) assert.equal(denied.has(tool), true);
+  });
+
+  it("deny-tools additions stack on top of grants and denials", () => {
+    // Granted agent with extra denials
+    const grantedWithExtra = testApi.resolveDenyTools(
+      { spawning: true, denyTools: "bash, read" },
+      null,
+    );
+    assert.deepEqual([...grantedWithExtra].sort(), ["bash", "read"]);
+
+    // Denied-by-default agent stacking an unrelated denial
+    const deniedWithExtra = testApi.resolveDenyTools({ denyTools: "write" });
+    for (const tool of SPAWNING_TOOLS) assert.equal(deniedWithExtra.has(tool), true);
+    assert.equal(deniedWithExtra.has("write"), true);
+
+    // Redundant listing of a spawning tool changes nothing
+    assert.equal(testApi.resolveDenyTools({ spawning: true, denyTools: "subagent" }, 2).has("subagent"), true);
+
+    // Empty / junk entries are ignored
+    assert.equal(testApi.resolveDenyTools({ spawning: true, denyTools: " , ," }, 1).size, 0);
+  });
+});
+
+describe("spawn depth math", () => {
+  it("parseSpawnDepth reads PI_SUBAGENT_SPAWN_DEPTH conservatively", () => {
+    assert.equal(testApi.parseSpawnDepth(undefined), null); // unset → unlimited (grant still required)
+    assert.equal(testApi.parseSpawnDepth(""), null);
+    assert.equal(testApi.parseSpawnDepth("  "), null);
+    assert.equal(testApi.parseSpawnDepth("junk"), null);
+    assert.equal(testApi.parseSpawnDepth("-1"), null);
+    assert.equal(testApi.parseSpawnDepth("0"), 0);
+    assert.equal(testApi.parseSpawnDepth("7"), 7);
+    assert.equal(testApi.parseSpawnDepth(" 3 "), 3);
+  });
+
+  it("decrementSpawnDepth never rises and clamps at zero", () => {
+    assert.equal(testApi.decrementSpawnDepth(null), null); // unlimited stays unlimited
+    assert.equal(testApi.decrementSpawnDepth(5), 4);
+    assert.equal(testApi.decrementSpawnDepth(1), 0);
+    assert.equal(testApi.decrementSpawnDepth(0), 0);
+  });
+});
+
+describe("Pi harness driver emits depth + deny env", () => {
+  const driver = new PiHarnessDriver();
+
+  it("emits PI_DENY_TOOLS including spawning tools and PI_SUBAGENT_SPAWN_DEPTH=<remaining>", () => {
+    const denySet = new Set<string>(SPAWNING_TOOLS);
+    const built = driver.buildCommand(createMockLaunchContext({ denySet, childSpawnDepth: 2 }));
+
+    assert.match(built.command, /PI_DENY_TOOLS='[^']*subagent[^']*'/);
+    for (const tool of SPAWNING_TOOLS) {
+      assert.ok(built.command.includes(`'${tool}'`) || built.command.includes(tool),
+        `expected ${tool} in PI_DENY_TOOLS`);
+    }
+    assert.ok(built.command.includes("PI_SUBAGENT_SPAWN_DEPTH=2"));
+  });
+
+  it("emits PI_SUBAGENT_SPAWN_DEPTH=0 at exhaustion (explicit, not absent)", () => {
+    const built = driver.buildCommand(createMockLaunchContext({ childSpawnDepth: 0 }));
+    assert.ok(built.command.includes("PI_SUBAGENT_SPAWN_DEPTH=0"));
+  });
+
+  it("omits PI_SUBAGENT_SPAWN_DEPTH when unlimited (no ceiling configured)", () => {
+    const built = driver.buildCommand(createMockLaunchContext({ childSpawnDepth: null }));
+    assert.equal(built.command.includes("PI_SUBAGENT_SPAWN_DEPTH="), false);
+
+    const legacyBuilt = driver.buildCommand(createMockLaunchContext());
+    assert.equal(legacyBuilt.command.includes("PI_SUBAGENT_SPAWN_DEPTH="), false);
+  });
+});
+
+describe("resume clamp — first-launch metadata wins", () => {
+  it("missing/corrupt metadata resolves to 0 (deny)", () => {
+    assert.deepEqual(testApi.clampResumeSpawn(undefined, 9), { maySpawn: false, childEnvDepth: 0 });
+    assert.deepEqual(testApi.clampResumeSpawn(null, 9), { maySpawn: false, childEnvDepth: 0 });
+    assert.deepEqual(testApi.clampResumeSpawn({}, 9), { maySpawn: false, childEnvDepth: 0 });
+    assert.deepEqual(testApi.clampResumeSpawn({ allowance: "3" }, 9), { maySpawn: false, childEnvDepth: 0 });
+    assert.deepEqual(testApi.clampResumeSpawn({ allowance: -2 }, 9), { maySpawn: false, childEnvDepth: 0 });
+  });
+
+  it("clamps to min(recorded allowance, requested)", () => {
+    // recorded 3, environment would allow 5 → 3, child gets 2
+    assert.deepEqual(testApi.clampResumeSpawn({ allowance: 3 }, 5), { maySpawn: true, childEnvDepth: 2 });
+    // recorded 3, environment allows 1 → 1, child gets 0
+    assert.deepEqual(testApi.clampResumeSpawn({ allowance: 3 }, 1), { maySpawn: true, childEnvDepth: 0 });
+    // recorded 3, no ceiling in environment → recorded 3 stands
+    assert.deepEqual(testApi.clampResumeSpawn({ allowance: 3 }, null), { maySpawn: true, childEnvDepth: 2 });
+    // exhausted at first launch → resume cannot revive
+    assert.deepEqual(testApi.clampResumeSpawn({ allowance: 0 }, 9), { maySpawn: false, childEnvDepth: 0 });
+  });
+
+  it("recorded unlimited stays bounded by the requesting environment only", () => {
+    assert.deepEqual(testApi.clampResumeSpawn({ allowance: null }, 4), { maySpawn: true, childEnvDepth: 3 });
+    assert.deepEqual(testApi.clampResumeSpawn({ allowance: null }, null), { maySpawn: true, childEnvDepth: null });
+  });
+
+  it("readSpawnMetadata returns null on missing or corrupt sidecar files", () => {
+    const dir = mkdtempSync(join(tmpdir(), "spawn-grants-test-"));
+    try {
+      assert.equal(testApi.readSpawnMetadata(join(dir, "missing.jsonl")), null);
+
+      const sessionFile = join(dir, "session.jsonl");
+      writeFileSync(`${sessionFile}.spawn.json`, JSON.stringify({ allowance: 4 }), "utf8");
+      assert.deepEqual(testApi.readSpawnMetadata(sessionFile), { allowance: 4 });
+
+      writeFileSync(`${sessionFile}.spawn.json`, "{not json", "utf8");
+      assert.equal(testApi.readSpawnMetadata(sessionFile), null);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("termination regression", () => {
+  it("A-spawns-B-spawns-A terminates: depth decrements every generation until denial", () => {
+    const grantedDefs = { spawning: true };
+    let allowance: number | null = 3;
+    let spawnerIsA = true;
+    let spawns = 0;
+
+    while (true) {
+      const denied = testApi.resolveDenyTools(grantedDefs, allowance);
+      if (denied.has("subagent")) break;
+      allowance = testApi.decrementSpawnDepth(allowance);
+      spawns++;
+      spawnerIsA = !spawnerIsA;
+      assert.ok(spawns <= 10, "mutual spawning must terminate");
+    }
+
+    // ceiling 3 → A, B, A each spawn once; B's fourth attempt is denied
+    assert.equal(spawns, 3);
+    assert.equal(spawnerIsA, false);
+  });
+
+  it("keeps the same-agent respawn guard working regardless of depth", () => {
+    assert.equal(testApi.blockedSelfSpawn("planner", "planner"), true);
+    assert.equal(testApi.blockedSelfSpawn("planner", "scout"), false);
+    assert.equal(testApi.blockedSelfSpawn(undefined, "scout"), false);
+    assert.equal(testApi.blockedSelfSpawn("scout", undefined), false);
+  });
+});

--- a/test/stale-active-stall.test.ts
+++ b/test/stale-active-stall.test.ts
@@ -1,0 +1,193 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import * as subagentsModule from "../pi-extension/subagents/index.ts";
+import { DEFAULT_ACTIVE_TOOL_STALL_MS, parseActiveToolStallMs } from "../pi-extension/subagents/recovery.ts";
+import {
+  createLifecycle,
+  lifecycleTransition,
+  observeActivity,
+  observePaneInspection,
+  projectLifecycle,
+} from "../pi-extension/subagents/lifecycle.ts";
+
+const delays = [30_000, 60_000, 90_000] as const;
+
+function makeRunning(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "child-1",
+    name: "Worker",
+    task: "Run the hung tool",
+    surface: "pane-1",
+    startTime: 0,
+    sessionFile: "/tmp/worker.jsonl",
+    interactive: false,
+    lifecycle: createLifecycle(0),
+    ...overrides,
+  };
+}
+
+function toolActivity(observedAt: number, sequence = 1) {
+  return {
+    ok: true as const,
+    activity: {
+      version: 1 as const,
+      runningChildId: "child-1",
+      createdAt: 0,
+      updatedAt: observedAt,
+      sequence,
+      latestEvent: "tool_execution_start" as const,
+      phase: "active" as const,
+      agentActive: true,
+      turnActive: true,
+      providerActive: false,
+      toolActive: true,
+      activeScope: "tool" as const,
+      activeSince: observedAt,
+      toolName: "bash",
+      toolStartedAt: observedAt,
+    },
+  };
+}
+
+function scopeActivity(scope: "provider" | "streaming" | "agent", observedAt: number) {
+  return {
+    ok: true as const,
+    activity: {
+      version: 1 as const,
+      runningChildId: "child-1",
+      createdAt: 0,
+      updatedAt: observedAt,
+      sequence: 1,
+      latestEvent: "agent_start" as const,
+      phase: "active" as const,
+      agentActive: true,
+      turnActive: true,
+      providerActive: scope === "provider",
+      toolActive: false,
+      activeScope: scope,
+      activeSince: observedAt,
+    },
+  };
+}
+
+/** Lifecycle whose turn is active on a tool-scope detail observed at `observedAt`. */
+function activeToolLifecycle(observedAt: number, sequence = 1) {
+  let lifecycle = createLifecycle(0);
+  lifecycle = observePaneInspection(lifecycle, {
+    kind: "present",
+    observedAt,
+    agentStatus: "working",
+  }, observedAt);
+  return observeActivity(lifecycle, toolActivity(observedAt, sequence), observedAt);
+}
+
+describe("active tool stall parsing", () => {
+  it("defaults for missing/malformed values, honors non-negative ints, and treats 0 as disabled", () => {
+    for (const [raw, expected] of [
+      [undefined, DEFAULT_ACTIVE_TOOL_STALL_MS],
+      ["", DEFAULT_ACTIVE_TOOL_STALL_MS],
+      ["   ", DEFAULT_ACTIVE_TOOL_STALL_MS],
+      ["wat", DEFAULT_ACTIVE_TOOL_STALL_MS],
+      ["-1", DEFAULT_ACTIVE_TOOL_STALL_MS],
+      ["1.5", DEFAULT_ACTIVE_TOOL_STALL_MS],
+      ["0", 0],
+      [" 120000 ", 120_000],
+      ["123456", 123_456],
+    ] as const) {
+      assert.equal(parseActiveToolStallMs(raw), expected, String(raw));
+    }
+  });
+});
+
+describe("stale tool-scope projection", () => {
+  it("projects stalled once tool silence reaches the window, with duration equal to silence", () => {
+    const stall = 600_000;
+    const lifecycle = activeToolLifecycle(1000);
+    const fresh = projectLifecycle(lifecycle, 1000 + stall - 1);
+    assert.equal(fresh.kind, "active");
+    assert.equal(fresh.label, "bash");
+
+    const stale = projectLifecycle(lifecycle, 1000 + stall);
+    assert.deepEqual(stale, { kind: "stalled", stateDurationSince: 1000 });
+  });
+
+  it("omitted opts defaults to the enabled 600000ms window", () => {
+    const lifecycle = activeToolLifecycle(0);
+    assert.equal(projectLifecycle(lifecycle, 599_999).kind, "active");
+    assert.equal(projectLifecycle(lifecycle, 600_000).kind, "stalled");
+  });
+
+  it("threshold 0 disables stale-stalling entirely", () => {
+    const lifecycle = activeToolLifecycle(0);
+    const projection = projectLifecycle(lifecycle, Number.MAX_SAFE_INTEGER / 2, { activeToolStallMs: 0 });
+    assert.equal(projection.kind, "active");
+  });
+
+  it("provider, streaming, and agent scopes never stale-stall regardless of age", () => {
+    for (const scope of ["provider", "streaming", "agent"] as const) {
+      let lifecycle = createLifecycle(0);
+      lifecycle = observePaneInspection(lifecycle, {
+        kind: "present",
+        observedAt: 0,
+        agentStatus: "working",
+      }, 0);
+      lifecycle = observeActivity(lifecycle, scopeActivity(scope, 0), 0);
+      const projection = projectLifecycle(lifecycle, DEFAULT_ACTIVE_TOOL_STALL_MS * 10);
+      assert.equal(projection.kind, "active", scope);
+    }
+  });
+
+  it("fresh tool activity after a stalled projection emits a recovered transition", () => {
+    let lifecycle = activeToolLifecycle(0);
+    assert.equal(projectLifecycle(lifecycle, 600_000).kind, "stalled");
+
+    lifecycle = observeActivity(lifecycle, toolActivity(600_500, 2), 600_500);
+    const next = projectLifecycle(lifecycle, 600_501);
+    assert.equal(next.kind, "active");
+    assert.equal(lifecycleTransition("stalled", next.kind), "recovered");
+  });
+});
+
+describe("stale tool child drives the recovery ladder", () => {
+  it("nudges after delays[0] and kills after delays[2] using fake-clock ticks", () => {
+    const testApi = (subagentsModule as any).__test__;
+    const running = makeRunning();
+    let nudges = 0;
+    let closes = 0;
+    let aborts = 0;
+    const operations = {
+      interruptPane() {
+        nudges += 1;
+      },
+      closePane() {
+        closes += 1;
+      },
+      abortWatcher() {
+        aborts += 1;
+      },
+    };
+
+    // Child enters a bash call at t=1000 and the activity file goes silent.
+    running.lifecycle = activeToolLifecycle(1000);
+    const tick = (now: number) => {
+      const projection = projectLifecycle(running.lifecycle, now);
+      return testApi.advanceRunningRecovery(running, projection, now, delays, operations);
+    };
+
+    assert.equal(tick(1000).action, null, "fresh tool activity must not arm the ladder");
+    assert.equal(running.recovery, undefined);
+
+    const stalledAt = 1000 + 600_000;
+    assert.equal(tick(stalledAt).state?.stage, "waiting", "silence past the window arms the ladder");
+    assert.equal(tick(stalledAt + 30_000 - 1).action, null, "below delays[0] must not nudge");
+    assert.equal(tick(stalledAt + delays[0]).action, "nudge");
+    assert.equal(tick(stalledAt + delays[0] + delays[1]).action, "escalate");
+    assert.equal(tick(stalledAt + delays[0] + delays[1] + delays[2] - 1).action, null);
+    const killTick = tick(stalledAt + delays[0] + delays[1] + delays[2]);
+    assert.equal(killTick.action, "kill");
+    assert.equal(nudges, 1);
+    assert.equal(closes, 1);
+    assert.equal(aborts, 1);
+    assert.match(running.lifecycle.process.error, /recovery-kill after 781s/);
+  });
+});

--- a/test/subagent-done-autoexit.test.ts
+++ b/test/subagent-done-autoexit.test.ts
@@ -18,10 +18,12 @@ interface Notification {
 function createExtensionApi() {
   const eventHandlers = new Map<string, Array<Function>>();
   const registeredCommands: Array<{ name: string; handler: Function }> = [];
+  const registeredTools: any[] = [];
   const sentUserMessages: string[] = [];
   return {
     eventHandlers,
     registeredCommands,
+    registeredTools,
     sentUserMessages,
     api: {
       on(event: string, handler: Function) {
@@ -29,7 +31,9 @@ function createExtensionApi() {
         handlers.push(handler);
         eventHandlers.set(event, handlers);
       },
-      registerTool() {},
+      registerTool(tool: any) {
+        registeredTools.push(tool);
+      },
       registerCommand(name: string, command: any) {
         registeredCommands.push({ name, ...command });
       },
@@ -81,7 +85,7 @@ describe("subagent-done auto-exit hardening (L-95)", () => {
       delete process.env.PI_SUBAGENT_SESSION;
     }
 
-    const { api, eventHandlers, registeredCommands, sentUserMessages } = createExtensionApi();
+    const { api, eventHandlers, registeredCommands, registeredTools, sentUserMessages } = createExtensionApi();
     subagentDoneExtension(api);
 
     const notifications: Notification[] = [];
@@ -103,6 +107,7 @@ describe("subagent-done auto-exit hardening (L-95)", () => {
       notifications,
       sessionFile,
       registeredCommands,
+      registeredTools,
       sentUserMessages,
       fire(event: string, payload: any = {}) {
         for (const handler of eventHandlers.get(event) ?? []) handler(payload, ctx);
@@ -365,6 +370,26 @@ describe("subagent-done auto-exit hardening (L-95)", () => {
       errorMessage: "529 overloaded",
       stopReason: "error",
     });
+  });
+
+  it("does not overwrite an explicit completion sidecar when agent_settled follows", async () => {
+    for (const [name, params] of [
+      ["caller_ping", { message: "need help" }],
+      ["subagent_done", { report: "finished" }],
+    ] as const) {
+      const child = boot();
+      const tool = child.registeredTools.find((candidate: any) => candidate.name === name);
+      assert.ok(tool, `${name} must be registered`);
+
+      await tool.execute("call-1", params, new AbortController().signal, undefined, child.ctx);
+      const sidecarPath = `${child.sessionFile}.exit`;
+      const before = readFileSync(sidecarPath, "utf8");
+
+      child.fire("agent_end", { messages: [{ role: "assistant", stopReason: "stop" }] });
+      child.fire("agent_settled", { type: "agent_settled" });
+
+      assert.equal(readFileSync(sidecarPath, "utf8"), before, `${name} sidecar must stay latched`);
+    }
   });
 
   it("non-auto-exit sessions never warn and ignore /auto-exit state changes", async () => {

--- a/test/subagent-done-autoexit.test.ts
+++ b/test/subagent-done-autoexit.test.ts
@@ -20,11 +20,13 @@ function createExtensionApi() {
   const registeredCommands: Array<{ name: string; handler: Function }> = [];
   const registeredTools: any[] = [];
   const sentUserMessages: string[] = [];
+  const registeredShortcuts: Array<{ key: string; options: any }> = [];
   return {
     eventHandlers,
     registeredCommands,
     registeredTools,
     sentUserMessages,
+    registeredShortcuts,
     api: {
       on(event: string, handler: Function) {
         const handlers = eventHandlers.get(event) ?? [];
@@ -38,7 +40,9 @@ function createExtensionApi() {
         registeredCommands.push({ name, ...command });
       },
       registerMessageRenderer() {},
-      registerShortcut() {},
+      registerShortcut(key: string, options: any) {
+        registeredShortcuts.push({ key, options });
+      },
       sendUserMessage(message: string) {
         sentUserMessages.push(message);
       },
@@ -85,7 +89,7 @@ describe("subagent-done auto-exit hardening (L-95)", () => {
       delete process.env.PI_SUBAGENT_SESSION;
     }
 
-    const { api, eventHandlers, registeredCommands, registeredTools, sentUserMessages } = createExtensionApi();
+    const { api, eventHandlers, registeredCommands, registeredTools, sentUserMessages, registeredShortcuts } = createExtensionApi();
     subagentDoneExtension(api);
 
     const notifications: Notification[] = [];
@@ -109,6 +113,7 @@ describe("subagent-done auto-exit hardening (L-95)", () => {
       registeredCommands,
       registeredTools,
       sentUserMessages,
+      registeredShortcuts,
       fire(event: string, payload: any = {}) {
         for (const handler of eventHandlers.get(event) ?? []) handler(payload, ctx);
       },
@@ -405,5 +410,33 @@ describe("subagent-done auto-exit hardening (L-95)", () => {
       0,
       "nothing to disarm, so no takeover warning",
     );
+  });
+  // F-90 — extension shortcuts must not shadow pi built-in default keys.
+  // ctrl+j is the built-in tui.input.newLine default; the widget toggle was
+  // rebinding it silently. Source: pi docs keybindings.md All Actions tables.
+  const PI_BUILTIN_DEFAULT_KEYS = new Set([
+    "alt+b", "alt+backspace", "alt+d", "alt+delete", "alt+down", "alt+enter",
+    "alt+f", "alt+left", "alt+right", "alt+up", "alt+y", "backspace",
+    "ctrl+]", "ctrl+alt+]", "ctrl+a", "ctrl+b", "ctrl+backspace", "ctrl+c",
+    "ctrl+d", "ctrl+e", "ctrl+end", "ctrl+f", "ctrl+g", "ctrl+home", "ctrl+j",
+    "ctrl+k", "ctrl+l", "ctrl+left", "ctrl+n", "ctrl+o", "ctrl+p",
+    "ctrl+pagedown", "ctrl+pageup", "ctrl+r", "ctrl+right", "ctrl+s",
+    "ctrl+shift+down", "ctrl+shift+g", "ctrl+shift+up", "ctrl+t", "ctrl+u",
+    "ctrl+w", "ctrl+x", "ctrl+y", "delete", "down", "end", "enter", "escape",
+    "home", "left", "pagedown", "pageup", "right", "shift+ctrl+o",
+    "shift+enter", "shift+l", "shift+t", "shift+tab", "tab", "up",
+  ]);
+
+  it("registers no shortcut on ctrl+j or any pi built-in default key (F-90)", () => {
+    const child = boot();
+    assert.equal(child.registeredShortcuts.length >= 1, true, "widget toggle shortcut must be registered");
+    for (const { key } of child.registeredShortcuts) {
+      assert.notEqual(key.toLowerCase(), "ctrl+j", "ctrl+j is pi built-in tui.input.newLine");
+      assert.equal(
+        PI_BUILTIN_DEFAULT_KEYS.has(key.toLowerCase()),
+        false,
+        `shortcut ${key} shadows a pi built-in default key`,
+      );
+    }
   });
 });

--- a/test/subagent-done-autoexit.test.ts
+++ b/test/subagent-done-autoexit.test.ts
@@ -218,6 +218,41 @@ describe("subagent-done auto-exit hardening (L-95)", () => {
     });
   });
 
+  it("keeps a policy-denied tool boundary open before reporting terminal failure", () => {
+    const child = boot();
+    child.settle([
+      {
+        role: "assistant",
+        stopReason: "toolUse",
+        content: [{ type: "toolCall", id: "call-policy", name: "read", arguments: {} }],
+      },
+      {
+        role: "toolResult",
+        toolCallId: "call-policy",
+        isError: true,
+        details: { error: "policy denied" },
+        content: [{ type: "text", text: "Tool execution blocked by policy" }],
+      },
+    ]);
+    assert.equal(child.ctx.shutdowns, 0, "policy tool-use boundary must not complete the child");
+    assert.equal(sidecarOf(child), null, "policy boundary is not a clean completion");
+
+    child.settle([
+      {
+        role: "assistant",
+        stopReason: "error",
+        errorMessage: "Tool execution blocked by policy",
+        content: [],
+      },
+    ]);
+    assert.equal(child.ctx.shutdowns, 1, "later terminal error wakes the parent");
+    assert.deepEqual(sidecarOf(child), {
+      type: "error",
+      errorMessage: "Tool execution blocked by policy",
+      stopReason: "error",
+    });
+  });
+
   it("does not treat a wrap-up tool-use boundary as the report", () => {
     const child = boot();
     writeFileSync(`${child.sessionFile}.wrapup`, "provide a final partial report");

--- a/test/subagent-done-autoexit.test.ts
+++ b/test/subagent-done-autoexit.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, beforeEach, afterEach } from "node:test";
 import assert from "node:assert/strict";
-import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import subagentDoneExtension, {
@@ -18,9 +18,11 @@ interface Notification {
 function createExtensionApi() {
   const eventHandlers = new Map<string, Array<Function>>();
   const registeredCommands: Array<{ name: string; handler: Function }> = [];
+  const sentUserMessages: string[] = [];
   return {
     eventHandlers,
     registeredCommands,
+    sentUserMessages,
     api: {
       on(event: string, handler: Function) {
         const handlers = eventHandlers.get(event) ?? [];
@@ -33,7 +35,9 @@ function createExtensionApi() {
       },
       registerMessageRenderer() {},
       registerShortcut() {},
-      sendUserMessage() {},
+      sendUserMessage(message: string) {
+        sentUserMessages.push(message);
+      },
       sendMessage() {},
       getAllTools() {
         return [];
@@ -77,7 +81,7 @@ describe("subagent-done auto-exit hardening (L-95)", () => {
       delete process.env.PI_SUBAGENT_SESSION;
     }
 
-    const { api, eventHandlers, registeredCommands } = createExtensionApi();
+    const { api, eventHandlers, registeredCommands, sentUserMessages } = createExtensionApi();
     subagentDoneExtension(api);
 
     const notifications: Notification[] = [];
@@ -99,6 +103,7 @@ describe("subagent-done auto-exit hardening (L-95)", () => {
       notifications,
       sessionFile,
       registeredCommands,
+      sentUserMessages,
       fire(event: string, payload: any = {}) {
         for (const handler of eventHandlers.get(event) ?? []) handler(payload, ctx);
       },
@@ -128,7 +133,8 @@ describe("subagent-done auto-exit hardening (L-95)", () => {
       [false, false, "stop", true],
       [false, false, "error", true],
       [false, false, "aborted", false],
-      [false, false, undefined, true],
+      [false, false, "toolUse", false],
+      [false, false, undefined, false],
       // Disarmed: never exits, whatever happened.
       [true, false, "stop", false],
       [true, false, "error", false],
@@ -139,6 +145,7 @@ describe("subagent-done auto-exit hardening (L-95)", () => {
       [true, true, "stop", true],
       [true, true, "error", true],
       [true, true, "aborted", false],
+      [true, true, "toolUse", false],
       // Re-arm while armed cannot occur via CLI but is harmless.
       [false, true, "stop", true],
     ];
@@ -157,6 +164,85 @@ describe("subagent-done auto-exit hardening (L-95)", () => {
     assert.equal(child.ctx.shutdowns, 1, "zero-real-input child still exits");
     assert.deepEqual(sidecarOf(child), { type: "done" });
     assert.equal(child.notifications.length, 0, "no warning for the injected task");
+  });
+
+  it("keeps the child alive after a tool-use turn until the final report", () => {
+    const child = boot();
+    child.fire("agent_start", {});
+    child.fire("tool_execution_start", { toolCallId: "call-1", toolName: "read" });
+    child.fire("tool_result", { toolCallId: "call-1", toolName: "read" });
+    child.fire("tool_execution_end", { toolCallId: "call-1", toolName: "read" });
+
+    child.settle([
+      {
+        role: "assistant",
+        stopReason: "toolUse",
+        content: [{ type: "toolCall", id: "call-1", name: "read", arguments: {} }],
+      },
+      {
+        role: "toolResult",
+        toolCallId: "call-1",
+        isError: false,
+        content: [{ type: "text", text: "successful tool result" }],
+      },
+    ]);
+    assert.equal(child.ctx.shutdowns, 0, "tool-use boundary must not auto-exit");
+    assert.equal(sidecarOf(child), null, "no completion sidecar at tool-use boundary");
+
+    child.settle([
+      {
+        role: "assistant",
+        stopReason: "stop",
+        content: [{ type: "text", text: "final report" }],
+      },
+    ]);
+    assert.equal(child.ctx.shutdowns, 1, "later final assistant turn exits");
+    assert.deepEqual(sidecarOf(child), { type: "done" });
+  });
+
+  it("publishes an injected tool or policy error as a failure", () => {
+    const child = boot();
+    child.settle([
+      {
+        role: "assistant",
+        stopReason: "error",
+        errorMessage: "Tool execution blocked by policy",
+        content: [],
+      },
+    ]);
+    assert.equal(child.ctx.shutdowns, 1, "terminal tool error wakes the parent");
+    assert.deepEqual(sidecarOf(child), {
+      type: "error",
+      errorMessage: "Tool execution blocked by policy",
+      stopReason: "error",
+    });
+  });
+
+  it("does not treat a wrap-up tool-use boundary as the report", () => {
+    const child = boot();
+    writeFileSync(`${child.sessionFile}.wrapup`, "provide a final partial report");
+    child.settle([{ role: "assistant", stopReason: "aborted" }]);
+    assert.equal(child.ctx.shutdowns, 0);
+    assert.deepEqual(child.sentUserMessages, ["provide a final partial report"]);
+
+    child.settle([
+      {
+        role: "assistant",
+        stopReason: "toolUse",
+        content: [{ type: "toolCall", id: "call-wrapup", name: "read", arguments: {} }],
+      },
+    ]);
+    assert.equal(child.ctx.shutdowns, 0, "wrap-up stays open through tool use");
+
+    child.settle([
+      {
+        role: "assistant",
+        stopReason: "stop",
+        content: [{ type: "text", text: "partial report" }],
+      },
+    ]);
+    assert.equal(child.ctx.shutdowns, 1, "wrap-up exits on its final report");
+    assert.deepEqual(sidecarOf(child), { type: "done", wrapup: true });
   });
 
   it("operator input disarms auto-exit persistently across settled turns", () => {

--- a/test/subagent-done-autoexit.test.ts
+++ b/test/subagent-done-autoexit.test.ts
@@ -1,0 +1,263 @@
+import { describe, it, beforeEach, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import subagentDoneExtension, {
+  resolveAutoExit,
+} from "../pi-extension/subagents/subagent-done.ts";
+
+// L-95 — auto-exit hardening: operator input / Escape permanently disarms,
+// /auto-exit re-arms for exactly one completion. Child-side only.
+
+interface Notification {
+  message: string;
+  type?: string;
+}
+
+function createExtensionApi() {
+  const eventHandlers = new Map<string, Array<Function>>();
+  const registeredCommands: Array<{ name: string; handler: Function }> = [];
+  return {
+    eventHandlers,
+    registeredCommands,
+    api: {
+      on(event: string, handler: Function) {
+        const handlers = eventHandlers.get(event) ?? [];
+        handlers.push(handler);
+        eventHandlers.set(event, handlers);
+      },
+      registerTool() {},
+      registerCommand(name: string, command: any) {
+        registeredCommands.push({ name, ...command });
+      },
+      registerMessageRenderer() {},
+      registerShortcut() {},
+      sendUserMessage() {},
+      sendMessage() {},
+      getAllTools() {
+        return [];
+      },
+    } as any,
+  };
+}
+
+const origAutoExit = process.env.PI_SUBAGENT_AUTO_EXIT;
+const origSession = process.env.PI_SUBAGENT_SESSION;
+
+function restoreEnv(name: string, value: string | undefined) {
+  if (value === undefined) delete process.env[name];
+  else process.env[name] = value;
+}
+
+describe("subagent-done auto-exit hardening (L-95)", () => {
+  let dir: string | undefined;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "l95-autoexit-"));
+  });
+
+  afterEach(() => {
+    restoreEnv("PI_SUBAGENT_AUTO_EXIT", origAutoExit);
+    restoreEnv("PI_SUBAGENT_SESSION", origSession);
+    if (dir) rmSync(dir, { recursive: true, force: true });
+    dir = undefined;
+  });
+
+  function boot(opts: { autoExit?: boolean; withSessionFile?: boolean } = {}) {
+    const autoExit = opts.autoExit ?? true;
+    if (autoExit) process.env.PI_SUBAGENT_AUTO_EXIT = "1";
+    else delete process.env.PI_SUBAGENT_AUTO_EXIT;
+
+    let sessionFile: string | undefined;
+    if (opts.withSessionFile !== false) {
+      sessionFile = join(dir!, "child.jsonl");
+      process.env.PI_SUBAGENT_SESSION = sessionFile;
+    } else {
+      delete process.env.PI_SUBAGENT_SESSION;
+    }
+
+    const { api, eventHandlers, registeredCommands } = createExtensionApi();
+    subagentDoneExtension(api);
+
+    const notifications: Notification[] = [];
+    const ctx: any = {
+      shutdowns: 0,
+      ui: {
+        notify(message: string, type?: string) {
+          notifications.push({ message, type });
+        },
+        setWidget() {},
+      },
+      shutdown() {
+        ctx.shutdowns += 1;
+      },
+    };
+
+    return {
+      ctx,
+      notifications,
+      sessionFile,
+      registeredCommands,
+      fire(event: string, payload: any = {}) {
+        for (const handler of eventHandlers.get(event) ?? []) handler(payload, ctx);
+      },
+      // agent_end + agent_settled: mirrors how Pi settles a finished turn.
+      settle(messages: any[]) {
+        this.fire("agent_end", { messages });
+        this.fire("agent_settled", { type: "agent_settled" });
+      },
+      async runCommand(name: string, args = "") {
+        const command = registeredCommands.find((c) => c.name === name);
+        assert.ok(command, `command /${name} must be registered`);
+        await command.handler(args, ctx);
+      },
+    };
+  }
+
+  function sidecarOf(child: ReturnType<typeof boot>): any | null {
+    if (!child.sessionFile || !existsSync(`${child.sessionFile}.exit`)) return null;
+    return JSON.parse(readFileSync(`${child.sessionFile}.exit`, "utf8"));
+  }
+
+  describe("resolveAutoExit decision table", () => {
+    // [disarmed, oneShotReArm, stopReason, expected]
+    const cases: Array<[boolean, boolean, string | undefined, boolean]> = [
+      // Armed (never disarmed): identical to v0.2.0 — terminal stop or error
+      // exits, aborted stays open.
+      [false, false, "stop", true],
+      [false, false, "error", true],
+      [false, false, "aborted", false],
+      [false, false, undefined, true],
+      // Disarmed: never exits, whatever happened.
+      [true, false, "stop", false],
+      [true, false, "error", false],
+      [true, false, "aborted", false],
+      [true, false, undefined, false],
+      // One-shot re-arm via /auto-exit: one more terminal stop or error may
+      // exit; an aborted turn still stays open.
+      [true, true, "stop", true],
+      [true, true, "error", true],
+      [true, true, "aborted", false],
+      // Re-arm while armed cannot occur via CLI but is harmless.
+      [false, true, "stop", true],
+    ];
+
+    for (const [disarmed, reArm, reason, expected] of cases) {
+      it(`disarmed=${disarmed} reArm=${reArm} stop=${reason} -> ${expected}`, () => {
+        assert.equal(resolveAutoExit({ disarmed, oneShotReArm: reArm }, reason), expected);
+      });
+    }
+  });
+
+  it("ignores the initial task input before the first agent run", () => {
+    const child = boot();
+    child.fire("input", { type: "input", text: "do the whole task" });
+    child.settle([{ role: "assistant", stopReason: "stop" }]);
+    assert.equal(child.ctx.shutdowns, 1, "zero-real-input child still exits");
+    assert.deepEqual(sidecarOf(child), { type: "done" });
+    assert.equal(child.notifications.length, 0, "no warning for the injected task");
+  });
+
+  it("operator input disarms auto-exit persistently across settled turns", () => {
+    const child = boot();
+    child.fire("agent_start", {});
+    child.fire("input", { type: "input", text: "hold on, steer this way" });
+    for (let i = 0; i < 3; i++) {
+      child.settle([{ role: "assistant", stopReason: "stop" }]);
+    }
+    assert.equal(child.ctx.shutdowns, 0, "disarm survives settled turns (no reset)");
+    assert.equal(sidecarOf(child), null, "no done sidecar after disarm");
+  });
+
+  it("warns exactly once when input first disarms auto-exit", () => {
+    const child = boot();
+    child.fire("agent_start", {});
+    child.fire("input", { type: "input", text: "first takeover" });
+    child.fire("input", { type: "input", text: "second takeover" });
+    child.fire("input", { type: "input", text: "third takeover" });
+    child.settle([{ role: "assistant", stopReason: "aborted" }]);
+    const warnings = child.notifications.filter((n) => n.type === "warning");
+    assert.equal(warnings.length, 1, "exactly one warning despite repeated inputs");
+    assert.match(warnings[0].message, /auto-exit/i);
+  });
+
+  it("Escape-triggered abort disarms auto-exit and keeps the session open", () => {
+    const child = boot();
+    child.settle([{ role: "assistant", stopReason: "aborted" }]);
+    assert.equal(child.ctx.shutdowns, 0, "aborted run does not exit");
+    assert.equal(
+      child.notifications.filter((n) => n.type === "warning").length,
+      1,
+      "one takeover warning for the Escape abort",
+    );
+    // Session stays open and disarmed: a later normal completion must not exit.
+    child.settle([{ role: "assistant", stopReason: "stop" }]);
+    assert.equal(child.ctx.shutdowns, 0);
+  });
+
+  it("/auto-exit re-arms for exactly one completion, then disarms again", async () => {
+    const child = boot();
+    child.fire("agent_start", {});
+    child.fire("input", { type: "input", text: "taking over" });
+    child.settle([{ role: "assistant", stopReason: "stop" }]);
+    assert.equal(child.ctx.shutdowns, 0);
+
+    // Double invocation must not stack two completions.
+    await child.runCommand("auto-exit");
+    await child.runCommand("auto-exit");
+
+    child.settle([{ role: "assistant", stopReason: "stop" }]);
+    assert.equal(child.ctx.shutdowns, 1, "re-armed child exits on next completion");
+    assert.deepEqual(sidecarOf(child), { type: "done" }, "done sidecar written");
+
+    // One-shot consumed: another settled completion does not exit again.
+    child.settle([{ role: "assistant", stopReason: "stop" }]);
+    assert.equal(child.ctx.shutdowns, 1, "auto-exit is disarmed again after one-shot exit");
+  });
+
+  it("/auto-exit is a no-op while auto-exit is still armed", async () => {
+    const child = boot();
+    await child.runCommand("auto-exit");
+    child.settle([{ role: "assistant", stopReason: "stop" }]);
+    assert.equal(child.ctx.shutdowns, 1, "plain armed behavior unchanged");
+  });
+
+  it("background regression: zero-input child behaves byte-for-byte like v0.2.0", () => {
+    const child = boot();
+    child.fire("session_start", {});
+    child.fire("agent_end", { messages: [{ role: "assistant", stopReason: "stop" }] });
+    assert.equal(child.ctx.shutdowns, 0, "no shutdown before agent_settled");
+    assert.equal(existsSync(`${child.sessionFile}.exit`), false);
+    child.fire("agent_settled", { type: "agent_settled" });
+    assert.equal(child.ctx.shutdowns, 1);
+    assert.deepEqual(sidecarOf(child), { type: "done" });
+    assert.equal(child.notifications.length, 0, "silent for background children");
+
+    const failing = boot();
+    failing.settle([
+      { role: "assistant", stopReason: "error", errorMessage: "529 overloaded" },
+    ]);
+    assert.equal(failing.ctx.shutdowns, 1, "error stopReason still wakes the parent");
+    assert.deepEqual(sidecarOf(failing), {
+      type: "error",
+      errorMessage: "529 overloaded",
+      stopReason: "error",
+    });
+  });
+
+  it("non-auto-exit sessions never warn and ignore /auto-exit state changes", async () => {
+    const child = boot({ autoExit: false });
+    child.fire("agent_start", {});
+    child.fire("input", { type: "input", text: "interactive use" });
+    child.settle([{ role: "assistant", stopReason: "stop" }]);
+    child.settle([{ role: "assistant", stopReason: "aborted" }]);
+    await child.runCommand("auto-exit");
+    assert.equal(child.ctx.shutdowns, 0, "interactive child never auto-exits");
+    assert.equal(
+      child.notifications.filter((n) => n.type === "warning").length,
+      0,
+      "nothing to disarm, so no takeover warning",
+    );
+  });
+});

--- a/test/test.ts
+++ b/test/test.ts
@@ -2027,6 +2027,46 @@ describe("completion.ts", () => {
   });
 });
 
+describe("child launch hardening", () => {
+  const testApi = (subagentsModule as any).__test__;
+
+  it("reports a missing child extension with the absolute path and swap cause", () => {
+    const missingRoot = createTestDir();
+    const missingPath = join(missingRoot, "subagent-done.ts");
+
+    assert.throws(
+      () => testApi.preflightSubagentDonePath(missingRoot),
+      (error: unknown) => {
+        const message = error instanceof Error ? error.message : String(error);
+        assert.match(message, new RegExp(missingPath.replace(/[.*+?^${}()|[\\]\\]/g, "\\$&")));
+        assert.match(message, /live.*package.*swap/i);
+        return true;
+      },
+    );
+  });
+
+  it("includes a wider pane tail in non-zero no-session failures", () => {
+    const sessionFile = join(createTestDir(), "child.jsonl");
+    let requestedLines: number | undefined;
+    const paneTail = 'Error: Failed to load extension "/missing/subagent-done.ts"\n';
+
+    const result = testApi.enrichNoSessionFailure(
+      { exitCode: 1 },
+      { sessionFile, surface: "pane-1" },
+      "Sub-agent exited with code 1",
+      (_surface: string, lines?: number) => {
+        requestedLines = lines;
+        return paneTail;
+      },
+    );
+
+    assert.equal(requestedLines, 20);
+    assert.match(result.summary, /Sub-agent exited with code 1/);
+    assert.match(result.summary, /Failed to load extension/);
+    assert.equal(result.error, paneTail);
+  });
+});
+
 describe("commands", () => {
   it("/iterate always emits a full-context fork tool call", () => {
     const { api, registeredCommands, sentUserMessages } = createMockExtensionApi();

--- a/test/test.ts
+++ b/test/test.ts
@@ -75,17 +75,22 @@ before(() => {
   delete process.env.PI_SUBAGENT_ID;
   delete process.env.PI_DENY_TOOLS;
 });
+const createdTestDirs: string[] = [];
+
 after(() => {
   if (inheritedSubagentId == null) delete process.env.PI_SUBAGENT_ID;
   else process.env.PI_SUBAGENT_ID = inheritedSubagentId;
   if (inheritedDenyTools == null) delete process.env.PI_DENY_TOOLS;
   else process.env.PI_DENY_TOOLS = inheritedDenyTools;
+  for (const dir of createdTestDirs) rmSync(dir, { recursive: true, force: true });
 });
 
 // --- Helpers ---
 
 function createTestDir(): string {
-  return mkdtempSync(join(tmpdir(), "subagents-test-"));
+  const dir = mkdtempSync(join(tmpdir(), "subagents-test-"));
+  createdTestDirs.push(dir);
+  return dir;
 }
 
 function createSessionFile(dir: string, entries: object[]): string {

--- a/test/test.ts
+++ b/test/test.ts
@@ -396,6 +396,44 @@ describe("session.ts", () => {
       };
       assert.equal(findLastAssistantMessage([msg] as any[]), null);
     });
+
+    it("L-162: returns text when final assistant message carries text alongside subagent_done toolCall", () => {
+      // The fix requires the report text to be in the SAME message as the
+      // subagent_done tool call; extraction must not drop the text when a
+      // toolCall block is present in the same content array.
+      const msg = {
+        type: "message",
+        message: {
+          role: "assistant",
+          content: [
+            { type: "text", text: "Task complete: updated docs." },
+            { type: "toolCall", toolName: "subagent_done", toolCallId: "tc-done" },
+          ],
+        },
+      };
+      assert.equal(findLastAssistantMessage([msg] as any[]), "Task complete: updated docs.");
+    });
+
+    it("L-162: returns null when final assistant message has only a subagent_done toolCall, so caller falls back to 'Sub-agent exited without output'", () => {
+      // muse-spark calls subagent_done with a thinking+toolCall message and no
+      // text block; the extractor must return nothing so the parent at
+      // index.ts:1813 falls back to the no-output wording.
+      const msg = {
+        type: "message",
+        message: {
+          role: "assistant",
+          content: [
+            { type: "thinking", thinking: "done" },
+            { type: "toolCall", toolName: "subagent_done", toolCallId: "tc-done" },
+          ],
+        },
+      };
+      const extracted = findLastAssistantMessage([msg] as any[]);
+      assert.equal(extracted, null);
+      // Replicates the fallback branch in pi-extension/subagents/index.ts
+      const fallback = extracted ?? "Sub-agent exited without output";
+      assert.equal(fallback, "Sub-agent exited without output");
+    });
   });
 
   describe("findObservedSessionRuntime", () => {

--- a/test/test.ts
+++ b/test/test.ts
@@ -434,6 +434,134 @@ describe("session.ts", () => {
       const fallback = extracted ?? "Sub-agent exited without output";
       assert.equal(fallback, "Sub-agent exited without output");
     });
+
+    it("L-162 phase2: same-message text wins over arguments.report", () => {
+      const msg = {
+        type: "message",
+        message: {
+          role: "assistant",
+          content: [
+            { type: "text", text: "Preferred same-message report" },
+            { type: "toolCall", toolName: "subagent_done", toolCallId: "tc-done", arguments: { report: "Fallback report param" } },
+          ],
+        },
+      };
+      assert.equal(findLastAssistantMessage([msg] as any[]), "Preferred same-message report");
+    });
+
+    it("L-162 phase2: toolCall-only with non-empty report returns the report", () => {
+      const msg = {
+        type: "message",
+        message: {
+          role: "assistant",
+          content: [{ type: "toolCall", toolName: "subagent_done", toolCallId: "tc-done", arguments: { report: "Report via arg" } }],
+        },
+      };
+      assert.equal(findLastAssistantMessage([msg] as any[]), "Report via arg");
+    });
+
+    it("L-162 phase2: handles report via name field and stringified JSON arguments", () => {
+      const viaName = {
+        type: "message",
+        message: {
+          role: "assistant",
+          content: [{ type: "toolCall", name: "subagent_done", id: "tc-done", arguments: { report: "Via name field" } }],
+        },
+      };
+      assert.equal(findLastAssistantMessage([viaName] as any[]), "Via name field");
+
+      const viaJsonString = {
+        type: "message",
+        message: {
+          role: "assistant",
+          content: [{ type: "toolCall", toolName: "subagent_done", toolCallId: "tc-done", arguments: JSON.stringify({ report: "Via JSON string" }) }],
+        },
+      };
+      assert.equal(findLastAssistantMessage([viaJsonString] as any[]), "Via JSON string");
+    });
+
+    it("L-162 phase2: toolCall-only without report falls back to earlier assistant text", () => {
+      const earlier = {
+        type: "message",
+        message: {
+          role: "assistant",
+          content: [{ type: "text", text: "Earlier summary" }],
+        },
+      };
+      const final = {
+        type: "message",
+        message: {
+          role: "assistant",
+          content: [{ type: "toolCall", toolName: "subagent_done", toolCallId: "tc-done", arguments: {} }],
+        },
+      };
+      assert.equal(findLastAssistantMessage([earlier, final] as any[]), "Earlier summary");
+    });
+
+    it("L-162 phase2: whitespace-only report is treated as empty and falls back to earlier text", () => {
+      const earlier = {
+        type: "message",
+        message: {
+          role: "assistant",
+          content: [{ type: "text", text: "Earlier valid" }],
+        },
+      };
+      const final = {
+        type: "message",
+        message: {
+          role: "assistant",
+          content: [{ type: "toolCall", toolName: "subagent_done", toolCallId: "tc-done", arguments: { report: "   " } }],
+        },
+      };
+      assert.equal(findLastAssistantMessage([earlier, final] as any[]), "Earlier valid");
+    });
+
+    it("L-162 phase2: no report + no earlier text → null (fallback wording)", () => {
+      const final = {
+        type: "message",
+        message: {
+          role: "assistant",
+          content: [{ type: "toolCall", toolName: "subagent_done", toolCallId: "tc-done", arguments: {} }],
+        },
+      };
+      const extracted = findLastAssistantMessage([final] as any[]);
+      assert.equal(extracted, null);
+      const fallback = extracted ?? "Sub-agent exited without output";
+      assert.equal(fallback, "Sub-agent exited without output");
+    });
+
+    it("L-162 phase2: final error still beats stale earlier text (priority 3 > 4)", () => {
+      const earlierGood = {
+        type: "message",
+        message: {
+          role: "assistant",
+          content: [{ type: "text", text: "Stale earlier text" }],
+        },
+      };
+      const errorFinal = {
+        type: "message",
+        message: {
+          role: "assistant",
+          content: [],
+          stopReason: "error",
+          errorMessage: "provider failed",
+        },
+      };
+      assert.equal(findLastAssistantMessage([earlierGood, errorFinal] as any[]), "Subagent error: provider failed");
+    });
+
+    it("L-162 phase2: final report beats final error (priority 2 > 3)", () => {
+      const final = {
+        type: "message",
+        message: {
+          role: "assistant",
+          content: [{ type: "toolCall", toolName: "subagent_done", toolCallId: "tc-done", arguments: { report: "Report wins over error" } }],
+          stopReason: "error",
+          errorMessage: "should be ignored",
+        },
+      };
+      assert.equal(findLastAssistantMessage([final] as any[]), "Report wins over error");
+    });
   });
 
   describe("findObservedSessionRuntime", () => {

--- a/test/test.ts
+++ b/test/test.ts
@@ -1494,6 +1494,11 @@ describe("subagent-done.ts", () => {
       assert.equal(shouldAutoExitOnAgentEnd(false, messages), false);
     });
 
+    it("stays open after a tool-use turn", () => {
+      const messages = [{ role: "assistant", stopReason: "toolUse" }];
+      assert.equal(shouldAutoExitOnAgentEnd(false, messages), false);
+    });
+
     it("still exits when the latest turn ended with stopReason=error", () => {
       // Auto-exit subagents must shut down on retry-exhaustion errors so the
       // parent is woken. The error sidecar (written separately) carries the

--- a/test/test.ts
+++ b/test/test.ts
@@ -1542,7 +1542,7 @@ describe("subagent-done.ts", () => {
         const { api, eventHandlers } = createMockExtensionApi();
         subagentDoneExtension(api);
         let shutdowns = 0;
-        const ctx = { shutdown: () => { shutdowns += 1; } };
+        const ctx = { shutdown: () => { shutdowns += 1; }, ui: { notify() {} } };
         eventHandlers.get("agent_end")![0]({
           messages: [{ role: "assistant", stopReason: "aborted" }],
         }, ctx);

--- a/test/test.ts
+++ b/test/test.ts
@@ -56,6 +56,7 @@ import subagentDoneExtension, {
 } from "../pi-extension/subagents/subagent-done.ts";
 import { interpretExitSidecar, waitForCompletion } from "../pi-extension/subagents/completion.ts";
 import {
+  MISSING_PANE_DEBOUNCE_MS,
   createLifecycle,
   lifecycleTransition,
   markCompleted,
@@ -1741,6 +1742,58 @@ describe("lifecycle.ts", () => {
     assert.equal(lifecycle.process.kind, "running");
   });
 
+  it("fails a pane that remains missing after the debounce", () => {
+    let lifecycle = createLifecycle(1_000);
+    lifecycle = observePaneInspection(lifecycle, { kind: "present", observedAt: 2_000, agentStatus: "working" }, 2_000);
+    const firstMissingAt = 3_000;
+    lifecycle = observePaneInspection(
+      lifecycle,
+      { kind: "missing", error: "pane_not_found" },
+      firstMissingAt,
+    );
+    assert.equal(lifecycle.process.kind, "running", "one missing observation is a race, not failure");
+    assert.notEqual(
+      projectLifecycle(lifecycle, firstMissingAt + MISSING_PANE_DEBOUNCE_MS).kind,
+      "failed",
+      "one missing observation must not project failure",
+    );
+
+    lifecycle = observePaneInspection(
+      lifecycle,
+      { kind: "missing", error: "pane_not_found" },
+      firstMissingAt + MISSING_PANE_DEBOUNCE_MS,
+    );
+    assert.equal(lifecycle.process.kind, "failed");
+    assert.match(lifecycle.process.error, /pane disappeared before completion evidence/i);
+    assert.equal(projectLifecycle(lifecycle, firstMissingAt + MISSING_PANE_DEBOUNCE_MS).kind, "failed");
+  });
+
+  it("persists a terminal missing projection for result delivery", () => {
+    const testApi = (subagentsModule as any).__test__;
+    let lifecycle = createLifecycle(1_000);
+    lifecycle = observePaneInspection(lifecycle, { kind: "present", observedAt: 2_000, agentStatus: "working" }, 2_000);
+    lifecycle = observePaneInspection(lifecycle, { kind: "missing", error: "pane_not_found" }, 3_000);
+    lifecycle = observePaneInspection(lifecycle, { kind: "missing", error: "pane_not_found" }, 3_001);
+    const running = {
+      id: "missing-child",
+      name: "Worker",
+      task: "task",
+      surface: "pane-1",
+      startTime: 1_000,
+      sessionFile: "worker.jsonl",
+      interactive: false,
+      lifecycle,
+    };
+
+    const projection = testApi.reconcileProjectedFailure(
+      running,
+      projectLifecycle(lifecycle, 3_000 + MISSING_PANE_DEBOUNCE_MS),
+    );
+    assert.equal(projection.kind, "failed");
+    assert.equal(running.lifecycle.process.kind, "failed");
+    assert.match(running.lifecycle.process.error, /pane disappeared before completion evidence/i);
+  });
+
   it("preserves local interrupt over stale herdr statuses", () => {
     for (const agentStatus of ["working", "blocked", "idle", "done"] as const) {
       let lifecycle = createLifecycle(1_000);
@@ -1923,6 +1976,26 @@ describe("completion.ts", () => {
       exitCode: 1,
       errorMessage: "Subagent pane disappeared before completion evidence was recorded.",
     });
+  });
+
+  it("does not reap a single transient missing-pane observation", async () => {
+    let inspections = 0;
+    let reads = 0;
+    const result = await waitForCompletion(new AbortController().signal, {
+      intervalMs: 1,
+      readTerminalTail: async () => {
+        reads += 1;
+        return reads >= 3 ? "__SUBAGENT_DONE_0__" : "";
+      },
+      inspectPane: async () => {
+        inspections += 1;
+        return inspections === 1
+          ? { kind: "missing", error: "pane_not_found" }
+          : { kind: "present", observedAt: Date.now(), agentStatus: "working" };
+      },
+    });
+    assert.deepEqual(result, { reason: "sentinel", exitCode: 0 });
+    assert.ok(inspections >= 2, "a transient miss must be followed by another inspection");
   });
 
   it("lets a sidecar win the pane-disappearance race", async () => {
@@ -2263,6 +2336,17 @@ describe("subagent parent lifecycle", () => {
 
     assert.equal(selectCompletionApi(previous, current), current);
     assert.equal(selectCompletionApi(previous, undefined), previous);
+  });
+
+  it("does not let pane cleanup throw after a missing-pane result", () => {
+    const testApi = (subagentsModule as any).__test__;
+    let closeAttempts = 0;
+
+    assert.doesNotThrow(() => testApi.closePaneQuietly("pane-1", () => {
+      closeAttempts += 1;
+      throw new Error("pane_not_found");
+    }));
+    assert.equal(closeAttempts, 1);
   });
 });
 

--- a/test/test.ts
+++ b/test/test.ts
@@ -2193,6 +2193,49 @@ describe("completion.ts", () => {
   });
 });
 
+describe("resume completion sidecar", () => {
+  const testApi = (subagentsModule as any).__test__;
+
+  it("clears stale done or ping sidecars before the watcher can consume actual resumed output", async () => {
+    for (const [index, payload] of [
+      { type: "done" },
+      { type: "ping", name: "Worker", message: "needs help" },
+    ].entries()) {
+      const dir = createTestDir();
+      const sessionFile = createSessionFile(dir, [
+        { type: "session", id: `session-${index}`, cwd: dir },
+      ]);
+      const entryCountBefore = getNewEntries(sessionFile, 0).length;
+      const exitFile = `${sessionFile}.exit`;
+      writeFileSync(exitFile, JSON.stringify(payload));
+
+      assert.equal(typeof testApi.clearResumeExitSidecar, "function");
+      testApi.clearResumeExitSidecar(sessionFile);
+      assert.equal(existsSync(exitFile), false, "resume must remove stale completion evidence");
+
+      writeFileSync(
+        sessionFile,
+        JSON.stringify({
+          type: "message",
+          id: `message-${index}`,
+          message: { role: "assistant", content: [{ type: "text", text: "actual resumed child output" }] },
+        }) + "\n",
+        { flag: "a" },
+      );
+      const completion = await waitForCompletion(new AbortController().signal, {
+        intervalMs: 1,
+        sessionFile,
+        readTerminalTail: async () => "__SUBAGENT_DONE_0__",
+      });
+      assert.deepEqual(completion, { reason: "sentinel", exitCode: 0 });
+      assert.equal(
+        findLastAssistantMessage(getNewEntries(sessionFile, entryCountBefore)),
+        "actual resumed child output",
+      );
+    }
+  });
+});
+
 describe("child launch hardening", () => {
   const testApi = (subagentsModule as any).__test__;
 

--- a/test/time-limits.test.ts
+++ b/test/time-limits.test.ts
@@ -1,0 +1,435 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import * as subagentsModule from "../pi-extension/subagents/index.ts";
+import subagentDoneExtension from "../pi-extension/subagents/subagent-done.ts";
+import { interpretExitSidecar } from "../pi-extension/subagents/completion.ts";
+import {
+  REPORT_ONLY_WRAPUP_DIRECTIVE,
+  consumeWrapupDirective,
+  evalTimeLimit,
+  writeWrapupDirective,
+} from "../pi-extension/subagents/time-limits.ts";
+import { createLifecycle } from "../pi-extension/subagents/lifecycle.ts";
+
+function withTempDir(run: (dir: string) => void) {
+  const dir = mkdtempSync(join(tmpdir(), "subagent-time-limits-"));
+  try {
+    run(dir);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+function makeRunning(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "child-1",
+    name: "Worker",
+    task: "Implement the feature",
+    surface: "pane-1",
+    startTime: 0,
+    sessionFile: "/tmp/worker.jsonl",
+    interactive: false,
+    lifecycle: createLifecycle(0),
+    timeLimit: { timeLimitSeconds: 100, timeoutWarnThreshold: 0.8 },
+    ...overrides,
+  };
+}
+
+function createMockExtensionApi() {
+  const eventHandlers = new Map<string, Array<Function>>();
+  const sentUserMessages: string[] = [];
+  return {
+    eventHandlers,
+    sentUserMessages,
+    api: {
+      on(event: string, handler: Function) {
+        const handlers = eventHandlers.get(event) ?? [];
+        handlers.push(handler);
+        eventHandlers.set(event, handlers);
+      },
+      registerShortcut() {},
+      registerTool() {},
+      registerCommand() {},
+      registerMessageRenderer(name: string, renderer: Function) {
+        this.renderers.push({ name, renderer });
+      },
+      renderers: [] as Array<{ name: string; renderer: Function }>,
+      getAllTools() {
+        return [];
+      },
+      sendUserMessage(message: string) {
+        sentUserMessages.push(message);
+      },
+    } as any,
+  };
+}
+
+function createTheme(calls: string[]) {
+  return {
+    fg(color: string, text: string) {
+      calls.push(`fg:${color}`);
+      return text;
+    },
+    bg(color: string, text: string) {
+      calls.push(`bg:${color}`);
+      return text;
+    },
+    bold(text: string) {
+      return text;
+    },
+  };
+}
+
+describe("time-limit frontmatter", () => {
+  it("parses valid values and ignores invalid or absent values", () => {
+    const parse = (subagentsModule as any).__test__.parseAgentDefinition;
+    const parseFields = (frontmatter: string) =>
+      parse(`---\nname: worker\n${frontmatter}\n---\nWorker body`, "fallback");
+
+    assert.deepEqual(
+      {
+        timeLimitSeconds: parseFields("time-limit: 120\nidle-timeout: 15\ntimeout-warn-threshold: 0.8").timeLimitSeconds,
+        idleTimeoutSeconds: parseFields("time-limit: 120\nidle-timeout: 15\ntimeout-warn-threshold: 0.8").idleTimeoutSeconds,
+        timeoutWarnThreshold: parseFields("time-limit: 120\nidle-timeout: 15\ntimeout-warn-threshold: 0.8").timeoutWarnThreshold,
+      },
+      { timeLimitSeconds: 120, idleTimeoutSeconds: 15, timeoutWarnThreshold: 0.8 },
+    );
+
+    for (const frontmatter of [
+      "time-limit: 0",
+      "time-limit: -1",
+      "time-limit: 1.5",
+      "time-limit: 1e3",
+      "idle-timeout: nope",
+      "idle-timeout: 0",
+      "timeout-warn-threshold: 0",
+      "timeout-warn-threshold: 1",
+      "timeout-warn-threshold: 1.1",
+      "timeout-warn-threshold: nope",
+      "",
+    ]) {
+      const parsed = parseFields(frontmatter);
+      assert.equal(parsed.timeLimitSeconds, undefined, frontmatter);
+      assert.equal(parsed.idleTimeoutSeconds, undefined, frontmatter);
+      assert.equal(parsed.timeoutWarnThreshold, undefined, frontmatter);
+    }
+  });
+});
+
+describe("evalTimeLimit", () => {
+  it("uses an injected clock for no-limit, warn-only, hard-only, both, and idle cases", () => {
+    const cases: Array<[
+      string,
+      number,
+      number | undefined,
+      { timeLimitSeconds?: number; idleTimeoutSeconds?: number; timeoutWarnThreshold?: number },
+      boolean | undefined,
+      "none" | "warn" | "hard-stop",
+    ]> = [
+      ["no limit", 999_999, undefined, {}, undefined, "none"],
+      ["before whole-run warning", 79_999, undefined, { timeLimitSeconds: 100, timeoutWarnThreshold: 0.8 }, false, "none"],
+      ["whole-run warning", 80_000, undefined, { timeLimitSeconds: 100, timeoutWarnThreshold: 0.8 }, false, "warn"],
+      ["warning fires once", 81_000, undefined, { timeLimitSeconds: 100, timeoutWarnThreshold: 0.8 }, true, "none"],
+      ["whole-run hard stop", 100_000, undefined, { timeLimitSeconds: 100, timeoutWarnThreshold: 0.8 }, true, "hard-stop"],
+      ["hard-only before deadline", 99_999, undefined, { timeLimitSeconds: 100 }, false, "none"],
+      ["hard-only at deadline", 100_000, undefined, { timeLimitSeconds: 100 }, false, "hard-stop"],
+      ["idle warning uses activity timestamp", 57_999, 50_000, { idleTimeoutSeconds: 10, timeoutWarnThreshold: 0.8 }, false, "none"],
+      ["idle warning at fraction", 58_000, 50_000, { idleTimeoutSeconds: 10, timeoutWarnThreshold: 0.8 }, false, "warn"],
+      ["idle hard stop", 60_000, 50_000, { idleTimeoutSeconds: 10, timeoutWarnThreshold: 0.8 }, true, "hard-stop"],
+      ["idle does not use wall clock without an activity snapshot", 100_000, undefined, { idleTimeoutSeconds: 10, timeoutWarnThreshold: 0.8 }, false, "none"],
+      ["the earliest configured deadline wins", 60_000, 55_000, { timeLimitSeconds: 100, idleTimeoutSeconds: 5, timeoutWarnThreshold: 0.8 }, true, "hard-stop"],
+    ];
+
+    for (const [label, now, lastActivityAt, config, warned, expected] of cases) {
+      assert.equal(evalTimeLimit(now, 0, lastActivityAt, config, warned), expected, label);
+    }
+  });
+});
+
+describe("parent time-limit actions", () => {
+  it("writes one directive then only sends Escape for a warned wrap-up", () => {
+    const testApi = (subagentsModule as any).__test__;
+    const running = makeRunning();
+    const calls: string[] = [];
+    let typed = 0;
+    const operations = {
+      interruptPane(surface: string) {
+        calls.push(`escape:${surface}`);
+      },
+      closePane() {
+        calls.push("close");
+      },
+      abortWatcher() {
+        calls.push("abort");
+      },
+      writeWrapup(sessionFile: string) {
+        calls.push(`write:${sessionFile}.wrapup`);
+      },
+      removeWrapup(sessionFile: string) {
+        calls.push(`remove:${sessionFile}.wrapup`);
+      },
+    };
+
+    assert.equal(testApi.advanceRunningTimeLimit(running, 80_000, operations).action, "warn");
+    assert.equal(running.wrapupPending, true);
+    assert.equal(running.timeLimitWarned, true);
+    assert.deepEqual(calls, ["write:/tmp/worker.jsonl.wrapup", "escape:pane-1"]);
+
+    assert.equal(testApi.advanceRunningTimeLimit(running, 81_000, operations).action, null);
+    assert.deepEqual(calls, ["write:/tmp/worker.jsonl.wrapup", "escape:pane-1"]);
+    assert.equal(typed, 0, "the warning path must not type free text into the child pane");
+  });
+
+  it("pins the warned idle deadline, tears down once at hard stop, and reports a timed-out session tail", () => {
+    withTempDir((dir) => {
+      const testApi = (subagentsModule as any).__test__;
+      const sessionFile = join(dir, "worker.jsonl");
+      writeFileSync(sessionFile, `${JSON.stringify({
+        type: "message",
+        message: { role: "assistant", content: [{ type: "text", text: "Halfway through the migration." }] },
+      })}\n`);
+      const running = makeRunning({
+        sessionFile,
+        activity: { updatedAt: 50_000 },
+        timeLimit: { idleTimeoutSeconds: 10, timeoutWarnThreshold: 0.8 },
+      });
+      let closes = 0;
+      let aborts = 0;
+      let removes = 0;
+      const operations = {
+        interruptPane() {},
+        closePane() {
+          closes += 1;
+        },
+        abortWatcher() {
+          aborts += 1;
+        },
+        writeWrapup() {},
+        removeWrapup() {
+          removes += 1;
+        },
+      };
+
+      assert.equal(testApi.advanceRunningTimeLimit(running, 58_000, operations).action, "warn");
+      running.activity = { updatedAt: 59_999 };
+      assert.equal(
+        testApi.advanceRunningTimeLimit(running, 60_000, operations).action,
+        "hard-stop",
+        "the original idle deadline must stay pinned after the warning",
+      );
+      assert.equal(closes, 1);
+      assert.equal(aborts, 1);
+      assert.equal(removes, 1);
+      assert.equal(running.wrapupPending, false);
+      assert.equal(running.lifecycle.process.kind, "failed");
+
+      const result = testApi.buildTimeLimitStoppedResult(running, 60_001);
+      assert.deepEqual(
+        { exitCode: result.exitCode, timeout: result.timeout, partial: result.partial },
+        { exitCode: 1, timeout: "hard-stop", partial: undefined },
+      );
+      assert.match(result.summary, /timed out after 60s/i);
+      assert.match(result.summary, /Halfway through the migration/);
+      assert.match(testApi.resolveResultPresentation(result, running.name), /failed/);
+      assert.doesNotMatch(testApi.resolveResultPresentation(result, running.name), /completed/);
+
+      assert.equal(testApi.advanceRunningTimeLimit(running, 61_000, operations).action, null);
+      assert.equal(closes, 1, "terminal hard-stop must not close twice");
+      assert.equal(aborts, 1, "terminal hard-stop must not abort twice");
+    });
+  });
+
+  it("keeps recovery, interactive, and resumed runs out of time-limit actions", () => {
+    const testApi = (subagentsModule as any).__test__;
+    const noPaneCalls = {
+      interruptPane() { throw new Error("must not interrupt"); },
+      closePane() { throw new Error("must not close"); },
+      abortWatcher() { throw new Error("must not abort"); },
+      writeWrapup() { throw new Error("must not write"); },
+      removeWrapup() { throw new Error("must not remove"); },
+    };
+
+    assert.equal(
+      testApi.advanceRunningTimeLimit(makeRunning({ interactive: true }), 100_000, noPaneCalls).action,
+      null,
+    );
+    assert.equal(
+      testApi.advanceRunningTimeLimit(makeRunning({ recoveryKilled: { errorMessage: "recovery-kill", killedAt: 1 } }), 100_000, noPaneCalls).action,
+      null,
+    );
+    assert.equal(
+      testApi.advanceRunningTimeLimit(makeRunning({ timeLimit: undefined }), 100_000, noPaneCalls).action,
+      null,
+      "a resume registration without re-specified frontmatter has no deadline",
+    );
+
+    assert.equal(
+      testApi.resolveTimeLimitConfig(
+        { timeLimitSeconds: 100, timeoutWarnThreshold: 0.8 },
+        false,
+        false,
+      ).timeoutWarnThreshold,
+      undefined,
+      "non-Pi children retain a hard deadline but cannot promise a file-based report continuation",
+    );
+
+    const hardStopped = makeRunning({ timeLimitStopped: { errorMessage: "timed out", stoppedAt: 1 } });
+    const recovery = testApi.advanceRunningRecovery(
+      hardStopped,
+      { kind: "stalled" },
+      100_000,
+      [1, 1, 1],
+      noPaneCalls,
+    );
+    assert.equal(recovery.action, null);
+    assert.equal(hardStopped.recovery, undefined);
+  });
+});
+
+describe("completion classification", () => {
+  it("keeps partial, timed-out, recovery-kill, and clean outcomes mutually exclusive", () => {
+    const testApi = (subagentsModule as any).__test__;
+    const partial = {
+      name: "Worker",
+      task: "Task",
+      summary: "Partial report",
+      exitCode: 0,
+      elapsed: 80,
+      partial: true,
+      timeout: "warned-wrapup" as const,
+    };
+    const timedOut = testApi.buildTimeLimitStoppedResult(
+      makeRunning({ timeLimitStopped: { errorMessage: "Subagent timed out after 100s.", stoppedAt: 100_000 } }),
+      100_000,
+    );
+    const recovery = testApi.buildRecoveryKilledResult(
+      makeRunning({ recoveryKilled: { errorMessage: "Subagent recovery-kill after 100s.", killedAt: 100_000 } }),
+      100_000,
+    );
+    const clean = {
+      name: "Worker",
+      task: "Task",
+      summary: "Completed",
+      exitCode: 0,
+      elapsed: 10,
+    };
+
+    const classify = (result: any) =>
+      result.partial ? "partial" : result.timeout === "hard-stop" ? "timed-out" : result.errorMessage ? "recovery-kill" : "clean";
+    assert.deepEqual(
+      [partial, timedOut, recovery, clean].map(classify),
+      ["partial", "timed-out", "recovery-kill", "clean"],
+    );
+    assert.match(testApi.resolveResultPresentation(partial, partial.name), /partial report/i);
+    assert.match(testApi.resolveResultPresentation(timedOut, timedOut.name), /failed/i);
+    assert.match(testApi.resolveResultPresentation(recovery, recovery.name), /failed/i);
+    assert.match(testApi.resolveResultPresentation(clean, clean.name), /completed/i);
+  });
+});
+
+describe("wrap-up directive and completion delivery", () => {
+  it("is consumed once, starts a report-only continuation, and publishes a normal partial completion", () => {
+    withTempDir((dir) => {
+      const artifactDir = join(dir, "artifacts");
+      mkdirSync(artifactDir);
+      const sessionFile = join(artifactDir, "worker.jsonl");
+      writeFileSync(sessionFile, "");
+      writeWrapupDirective(sessionFile);
+      assert.equal(readFileSync(`${sessionFile}.wrapup`, "utf8"), REPORT_ONLY_WRAPUP_DIRECTIVE);
+      assert.equal(consumeWrapupDirective(sessionFile), REPORT_ONLY_WRAPUP_DIRECTIVE);
+      assert.equal(consumeWrapupDirective(sessionFile), null, "a directive is consumed once");
+      assert.equal(existsSync(`${sessionFile}.wrapup`), false);
+
+      writeWrapupDirective(sessionFile);
+      const previousAutoExit = process.env.PI_SUBAGENT_AUTO_EXIT;
+      const previousSession = process.env.PI_SUBAGENT_SESSION;
+      process.env.PI_SUBAGENT_AUTO_EXIT = "1";
+      process.env.PI_SUBAGENT_SESSION = sessionFile;
+      try {
+        const { api, eventHandlers, sentUserMessages } = createMockExtensionApi();
+        subagentDoneExtension(api);
+        let shutdowns = 0;
+        const ctx = { shutdown() { shutdowns += 1; } };
+        const agentEnd = eventHandlers.get("agent_end")![0];
+        const agentSettled = eventHandlers.get("agent_settled")![0];
+
+        agentEnd({ messages: [{ role: "assistant", stopReason: "aborted" }] }, ctx);
+        agentSettled({}, ctx);
+        assert.deepEqual(sentUserMessages, [REPORT_ONLY_WRAPUP_DIRECTIVE]);
+        assert.equal(shutdowns, 0);
+        assert.equal(existsSync(`${sessionFile}.wrapup`), false);
+
+        agentEnd({ messages: [{ role: "assistant", stopReason: "stop" }] }, ctx);
+        agentSettled({}, ctx);
+        assert.equal(shutdowns, 1);
+        assert.deepEqual(JSON.parse(readFileSync(`${sessionFile}.exit`, "utf8")), {
+          type: "done",
+          wrapup: true,
+        });
+        assert.deepEqual(interpretExitSidecar({ type: "done", wrapup: true }), {
+          reason: "done",
+          exitCode: 0,
+          wrapup: true,
+        });
+        assert.equal(existsSync(sessionFile), true, "the partial-report session remains resumable");
+        assert.deepEqual(
+          readdirSync(artifactDir).filter((file) => file.endsWith(".wrapup")),
+          [],
+          "cleanup leaves no stray wrap-up directives in the artifact directory",
+        );
+      } finally {
+        if (previousAutoExit == null) delete process.env.PI_SUBAGENT_AUTO_EXIT;
+        else process.env.PI_SUBAGENT_AUTO_EXIT = previousAutoExit;
+        if (previousSession == null) delete process.env.PI_SUBAGENT_SESSION;
+        else process.env.PI_SUBAGENT_SESSION = previousSession;
+      }
+    });
+  });
+
+  it("marks warned reports in details, presentation, and warning-styled rendering", () => {
+    const testApi = (subagentsModule as any).__test__;
+    const result = {
+      name: "Worker",
+      task: "Implement the feature",
+      summary: "Implemented the parser; remaining tests need review.",
+      sessionFile: "/tmp/worker.jsonl",
+      exitCode: 0,
+      elapsed: 80,
+      partial: true,
+      timeout: "warned-wrapup" as const,
+    };
+    assert.deepEqual(testApi.buildResultTimeoutDetails(result), {
+      partial: true,
+      timeout: "warned-wrapup",
+    });
+
+    const presentation = testApi.resolveResultPresentation(result, result.name);
+    assert.match(presentation, /partial report under .*time limit/i);
+    assert.doesNotMatch(presentation, /failed/);
+
+    const { api } = createMockExtensionApi();
+    (subagentsModule as any).default(api);
+    const renderer = api.renderers.find((entry: any) => entry.name === "subagent_result")!.renderer;
+    const calls: string[] = [];
+    const rendered = renderer(
+      {
+        customType: "subagent_result",
+        content: presentation,
+        details: {
+          name: result.name,
+          exitCode: 0,
+          elapsed: result.elapsed,
+          partial: true,
+          timeout: "warned-wrapup",
+        },
+      },
+      { expanded: true },
+      createTheme(calls),
+    );
+    assert.match(rendered.render(100).join("\n"), /partial report \(time limit\)/i);
+    assert.ok(calls.includes("fg:warning"), "partial completion uses warning styling");
+  });
+});


### PR DESCRIPTION
## Root cause

Same-turn, same-identity spawns collide on second-resolution filenames. Two `buildCommand` calls within one wall-clock second produce identical `context/<name>-<ts>.md` paths, and the second `writeFileSync` silently destroys the first subagent's task brief. The user sees two sessions spawn but only one brief; the other agent reads a truncated/overwritten artifact.

## Fix

Append the per-spawn `params.id` to the three second-resolution filename sites so every spawn writes distinct artifacts:

1. task context artifact (`context/<name>-<ts>.md` -> includes spawn id)
2. system prompt file
3. resume message file

## Regression evidence

- New harness tests fail on the pre-fix commit `a7db2cc` (red) and pass on `2ceb138` (green).
- Full harness suite: 29 tests green; consumer guards: 9 green; oxlint clean.

## Reference

Sula board task F-113 (investigate subagent double-spawn losing the first task brief).
