### PR TITLE
Respect scoped subagent models

### DIFF
--- a/pi-extension/subagents/index.ts
+++ b/pi-extension/subagents/index.ts
@@ -1435,7 +1435,11 @@ export default function subagentsExtension(pi: ExtensionAPI) {
   // subagents whose watchers survived a reload.
   pi.on("session_start", (_event, ctx) => {
     runtime.latestCtx = ctx;
-    runtime.modelCatalog = buildAuthenticatedModelCatalog(wrapPiModelRegistry(ctx.modelRegistry));
+    runtime.modelCatalog = buildAuthenticatedModelCatalog(
+      wrapPiModelRegistry(ctx.modelRegistry),
+      24,
+      ctx.scopedModels.map(({ model }) => model),
+    );
     runtime.agentCatalog = buildAvailableAgentCatalog(
       discoverAgentDefinitions().filter((agent) => !agent.disableModelInvocation),
     );

--- a/pi-extension/subagents/runtime-routing.ts
+++ b/pi-extension/subagents/runtime-routing.ts
@@ -291,8 +291,10 @@ function formatTokenCount(value: number | undefined): string | undefined {
 export function buildAuthenticatedModelCatalog(
   registry: ModelRegistryAdapter,
   limit = 24,
+  scopedModels?: RoutingModel[],
 ): string {
-  const models = registry.available().sort((a, b) =>
+  const source = scopedModels?.length ? scopedModels : registry.available();
+  const models = [...source].sort((a, b) =>
     `${a.provider}/${a.id}`.localeCompare(`${b.provider}/${b.id}`),
   );
   const visibleModels = models.slice(0, limit);

--- a/test/runtime-routing.test.ts
+++ b/test/runtime-routing.test.ts
@@ -240,6 +240,13 @@ describe("authenticated model catalog", () => {
     );
   });
 
+  it("uses scoped models when provided", () => {
+    const available = [model("fake", "parent"), model("other", "fast")];
+    const catalog = buildAuthenticatedModelCatalog(registry(available), 24, [available[1]]);
+    assert.doesNotMatch(catalog, /fake\/parent/);
+    assert.match(catalog, /other\/fast/);
+  });
+
   it("caps large catalogs and reports omitted models", () => {
     const available = Array.from({ length: 30 }, (_, index) => model("fake", `model-${index}`));
     const catalog = buildAuthenticatedModelCatalog(registry(available), 5);


### PR DESCRIPTION
In the pi settings.json you can set enabledModels to configure which models from your configured providers will actually be available in the agent for selection. This also adds support for this setting to the subagent model selection, which both reduces context bloat, as well as only lets the subagents use models that are actually enabled for use